### PR TITLE
add #include <string> to make it compilable in Mac OS with clang++

### DIFF
--- a/include/treelite/base.h
+++ b/include/treelite/base.h
@@ -7,6 +7,7 @@
 #ifndef TREELITE_BASE_H_
 #define TREELITE_BASE_H_
 
+#include <string>
 #include <unordered_map>
 #include <cstdint>
 


### PR DESCRIPTION
Without this change it does not compile with Mac+clang++

looks like the compiler cannot find a `std::hash specialization` for string unless we explicitly include it

```
In file included from /Users/nanzhu/code/tree-lite/src/c_api/optable.cc:8:
In file included from /Users/nanzhu/code/tree-lite/include/treelite/base.h:10:
In file included from /Users/nanzhu/code/clang+llvm-3.9.0-x86_64-apple-darwin/bin/../include/c++/v1/unordered_map:369:
In file included from /Users/nanzhu/code/clang+llvm-3.9.0-x86_64-apple-darwin/bin/../include/c++/v1/__hash_table:16:
In file included from /Users/nanzhu/code/clang+llvm-3.9.0-x86_64-apple-darwin/bin/../include/c++/v1/memory:600:
/Users/nanzhu/code/clang+llvm-3.9.0-x86_64-apple-darwin/bin/../include/c++/v1/type_traits:1464:38: error: implicit
      instantiation of undefined template 'std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>,
      std::__1::allocator<char> > >'
    : public integral_constant<bool, __is_empty(_Tp)> {};
                                     ^
/Users/nanzhu/code/clang+llvm-3.9.0-x86_64-apple-darwin/bin/../include/c++/v1/unordered_map:383:18: note: in instantiation of
      template class 'std::__1::is_empty<std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>,
      std::__1::allocator<char> > > >' requested here
          bool = is_empty<_Hash>::value && !__libcpp_is_final<_Hash>::value
                 ^
/Users/nanzhu/code/clang+llvm-3.9.0-x86_64-apple-darwin/bin/../include/c++/v1/unordered_map:765:13: note: in instantiation of
      default argument for '__unordered_map_hasher<std::__1::basic_string<char, std::__1::char_traits<char>,
      std::__1::allocator<char> >, std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>,
      std::__1::allocator<char> >, treelite::Operator>, std::__1::hash<std::__1::basic_string<char,
      std::__1::char_traits<char>, std::__1::allocator<char> > > >' required here
    typedef __unordered_map_hasher<key_type, __value_type, hasher>   __hasher;
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/nanzhu/code/tree-lite/src/c_api/optable.cc:12:49: note: in instantiation of template class
      'std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >,
      treelite::Operator, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >
      >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >,
      std::__1::allocator<std::__1::pair<const std::__1::basic_string<char, std::__1::char_traits<char>,
      std::__1::allocator<char> >, treelite::Operator> > >' requested here
const std::unordered_map<std::string, Operator> optable{
                                                ^
/Users/nanzhu/code/clang+llvm-3.9.0-x86_64-apple-darwin/bin/../include/c++/v1/type_traits:397:51: note: template is declared
      here
template <class _Tp> struct _LIBCPP_TYPE_VIS_ONLY hash;
                                                  ^
1 error generated.

```