### PR TITLE
Added ast java compiler parameters java_package and java_file_prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ treelite
 # Project files
 *.pyproj
 .vscode/
+.idea/
 
 # Mac system file
 .DS_Store

--- a/src/compiler/ast_java.cc
+++ b/src/compiler/ast_java.cc
@@ -60,7 +60,7 @@ class ASTJavaCompiler : public Compiler {
   std::string pred_tranform_func_;
   std::unordered_map<std::string, std::string> files_;
   std::string main_tail_;
-  const std::string file_prefix_ = "src/main/java/treelite/predictor/";
+  const std::string file_prefix_ = param.java_file_prefix;
 
   void WalkAST(const ASTNode* node,
                const std::string& dest,
@@ -103,7 +103,7 @@ class ASTJavaCompiler : public Compiler {
                                                 "float[] result)"
         : "public static float predict(Entry[] data, boolean pred_margin)";
     CommitToFile(dest,
-                 "package treelite.predictor;\n\n"
+                 "package " + param.java_package + ";\n\n"
                  "import java.lang.Math;\n"
                  "import javolution.context.LogContext;\n"
                  "import javolution.context.LogContext.Level;\n\n"
@@ -285,7 +285,7 @@ class ASTJavaCompiler : public Compiler {
       prototype << "public static float " << func_name.str()
                 << "(Entry[] data)";
     }
-    callee_buf << "package treelite.predictor;\n\n"
+    callee_buf << "package " << param.java_package << ";\n\n"
                << "public class " << class_name.str() << " {\n"
                << "  " << prototype.str() << " {\n";
     CommitToFile(dest, caller_buf.str());

--- a/src/compiler/java/entry_type.h
+++ b/src/compiler/java/entry_type.h
@@ -1,10 +1,12 @@
-const char* entry_type =
-"package treelite.predictor;\n"
-"\n"
-"import javolution.io.Union;\n"
-"\n"
-"public class Entry extends Union {\n"
-"  public Signed32 missing = new Signed32();\n"
-"  public Float32  fvalue  = new Float32();\n"
-"  public Signed32 qvalue  = new Signed32();\n"
+std::string entry_type =
+"package " +
+param.java_package +
+";\n" +
+"\n" +
+"import javolution.io.Union;\n" +
+"\n" +
+"public class Entry extends Union {\n" +
+"  public Signed32 missing = new Signed32();\n" +
+"  public Float32  fvalue  = new Float32();\n" +
+"  public Signed32 qvalue  = new Signed32();\n" +
 "}\n";

--- a/src/compiler/param.h
+++ b/src/compiler/param.h
@@ -34,6 +34,10 @@ struct CompilerParam : public dmlc::Parameter<CompilerParam> {
   int verbose;
   /*! \} */
   int max_unit_size;
+  /*! \brief java package name */
+  std::string java_package;
+  /*! \brief java file path prefix */
+  std::string java_file_prefix;
 
   // declare parameters
   DMLC_DECLARE_PARAMETER(CompilerParam) {
@@ -48,6 +52,8 @@ struct CompilerParam : public dmlc::Parameter<CompilerParam> {
     DMLC_DECLARE_FIELD(verbose).set_default(0)
       .describe("if >0, produce extra messages");
     DMLC_DECLARE_FIELD(max_unit_size).set_default(100).set_lower_bound(5);
+    DMLC_DECLARE_FIELD(java_package).set_default("treelite.predictor");
+    DMLC_DECLARE_FIELD(java_file_prefix).set_default("src/main/java/treelite/predictor/");
   }
 };
 


### PR DESCRIPTION
Define java package through parameters so that we can have multiple models

E.g.
params={'quantize':1, 'max_unit_size':1000, 'verbose':1, 'java_package':'model123.predictor', 'java_file_prefix':'src/main/java/model123/predictor/'}
model.compile(dirpath='./model', compiler='ast_java', params=params)