### PR TITLE
Expose common Data interface to Java callers

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -297,17 +297,11 @@ int TreeliteCompilerGenerateCode(CompilerHandle compiler,
   }
 
   if (!compiled_model.file_prefix.empty()) {
-    const std::vector<std::string> tokens
-      = common::Split(compiled_model.file_prefix, '/');
-    std::string accum = dirpath_ + "/" + tokens[0];
-    for (size_t i = 0; i < tokens.size(); ++i) {
-      common::filesystem::CreateDirectoryIfNotExist(accum.c_str());
-      if (i < tokens.size() - 1) {
-        accum += "/";
-        accum += tokens[i + 1];
-      }
-    }
+    common::filesystem::CreateDirectoryIfNotExistRecursive(
+      dirpath_ + "/" + compiled_model.file_prefix);
   }
+  common::filesystem::CreateDirectoryIfNotExistRecursive(
+    dirpath_ + "/src/main/java/ml/dmlc/treelite");
 
   for (const auto& it : compiled_model.files) {
     LOG(INFO) << "Writing file " << it.first << "...";

--- a/src/common/filesystem.h
+++ b/src/common/filesystem.h
@@ -118,6 +118,18 @@ inline void CreateDirectoryIfNotExist(const char* dirpath) {
 #endif
 }
 
+inline void CreateDirectoryIfNotExistRecursive(const std::string& dirpath) {
+  const std::vector<std::string> tokens = common::Split(dirpath, '/');
+  std::string accum = tokens[0];
+  for (size_t i = 0; i < tokens.size(); ++i) {
+    common::filesystem::CreateDirectoryIfNotExist(accum.c_str());
+    if (i < tokens.size() - 1 && !tokens[i + 1].empty()) {
+      accum += "/";
+      accum += tokens[i + 1];
+    }
+  }
+}
+
 }  // namespace filesystem
 }  // namespace common
 }  // namespace treelite

--- a/src/compiler/ast_java.cc
+++ b/src/compiler/ast_java.cc
@@ -72,6 +72,7 @@ class ASTJavaCompiler : public Compiler {
       builder.Serialize(param.ast_dump_path, param.ast_dump_binary > 0);
     }
     #include "./java/entry_type.h"
+    #include "./java/data_interface.h"
     #include "./java/node_type.h"
     #include "./java/pom_xml.h"
     files_[file_prefix_ + "Entry.java"]
@@ -81,6 +82,7 @@ class ASTJavaCompiler : public Compiler {
       = fmt::format(node_type_template,
           "java_package"_a = param.java_package,
           "threshold_type"_a = (param.quantize > 0 ? "int" : "float"));
+    files_["src/main/java/ml/dmlc/treelite/Data.java"] = data_interface;
     files_["pom.xml"]
       = fmt::format(pom_xml_template,
           "java_package"_a = param.java_package,
@@ -481,8 +483,8 @@ class ASTJavaCompiler : public Compiler {
             << "L >>> (tmp - " << (i * 64) << ") ) & 1) )";
       }
       result = oss.str();
-      return result;
     }
+    return result;
   }
 
   inline std::string

--- a/src/compiler/ast_native.cc
+++ b/src/compiler/ast_native.cc
@@ -468,8 +468,8 @@ class ASTNativeCompiler : public Compiler {
             << "U >> (tmp - " << (i * 64) << ") ) & 1) )";
       }
       result = oss.str();
-      return result;
     }
+    return result;
   }
 
   inline std::string

--- a/src/compiler/java/data_interface.h
+++ b/src/compiler/java/data_interface.h
@@ -1,0 +1,11 @@
+const char* data_interface =
+R"TREELITETEMPLATE(
+package ml.dmlc.treelite;
+
+public interface Data {
+  public void setFValue(float val);
+  public void setMissing();
+  public boolean isMissing();
+  public float getFValue();
+}
+)TREELITETEMPLATE";

--- a/src/compiler/java/entry_type.h
+++ b/src/compiler/java/entry_type.h
@@ -3,10 +3,24 @@ R"TREELITETEMPLATE(
 package {java_package};
 
 import javolution.io.Union;
+import ml.dmlc.treelite.Data;
 
-public class Entry extends Union {{
+public class Entry extends Union implements Data {{
   public Signed32 missing = new Signed32();
   public Float32  fvalue  = new Float32();
   public Signed32 qvalue  = new Signed32();
+
+  public void setFValue(float val) {{
+    this.fvalue.set(val);
+  }}
+  public void setMissing() {{
+    this.missing.set(-1);
+  }}
+  public boolean isMissing() {{
+    return this.missing.get() == -1;
+  }}
+  public float getFValue() {{
+    return this.fvalue.get();
+  }}
 }}
 )TREELITETEMPLATE";


### PR DESCRIPTION
Allow callers to use multiple model implementations by having them inherit from the common interface `ml.dmlc.treelite.Data`.