### PR TITLE
Add feature to export as Protobuf; add round trip test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,10 +95,9 @@ if (ENABLE_PROTOBUF)
   include_directories(${PROTOBUF_INCLUDE_DIRS})
   include_directories(${CMAKE_CURRENT_BINARY_DIR})
   PROTOBUF_GENERATE_CPP(TREE_PROTO_SRCS TREE_PROTO_HDRS src/tree.proto)
-  PROTOBUF_GENERATE_CPP(AST_PROTO_SRCS AST_PROTO_HDRS src/compiler/ast/ast.proto)
   PROTOBUF_GENERATE_JAVA(tree_proto_java src/tree.proto)
-  PROTOBUF_GENERATE_JAVA(ast_proto_java src/compiler/ast/ast.proto)
-  list(INSERT SOURCES 0 ${TREE_PROTO_SRCS} ${TREE_PROTO_HDRS} ${AST_PROTO_SRCS} ${AST_PROTO_HDRS})
+  PROTOBUF_GENERATE_PYTHON(tree_proto_python src/tree.proto)
+  list(INSERT SOURCES 0 ${TREE_PROTO_SRCS} ${TREE_PROTO_HDRS})
 endif()
 
 # dmlc-core

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ option(TEST_COVERAGE "C++ test coverage" OFF)
 # enable custom logging facility in dmlc-core
 add_definitions(-DDMLC_LOG_CUSTOMIZE)
 
+# use fPIC globally
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # Protobuf
 if (ENABLE_PROTOBUF)
   set(protobuf_BUILD_TESTS OFF CACHE BOOL "enable tests for protobuf" FORCE)
@@ -61,7 +64,6 @@ if(OPENMP_FOUND)
 else(OPENMP_FOUND)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif(OPENMP_FOUND)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 if(MSVC)
   # Multithreaded compilation
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ doxygen:
 	cd docs; doxygen
 
 cpp-coverage:
-	rm -rf build; mkdir build; cd build; cmake .. -DTEST_COVERAGE=ON && make -j$(NPROC)
+	rm -rf build; mkdir build; cd build; cmake .. -DTEST_COVERAGE=ON -DENABLE_PROTOBUF=ON && make -j$(NPROC)
 
 all:
-	rm -rf build; mkdir build; cd build; cmake .. && make -j$(NPROC)
+	rm -rf build; mkdir build; cd build; cmake .. -DENABLE_PROTOBUF=ON && make -j$(NPROC)

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -158,3 +158,32 @@ function(PROTOBUF_GENERATE_JAVA TARGET_NAME PROTO_FILE)
     VERBATIM
   )
 endfunction()
+
+function(PROTOBUF_GENERATE_PYTHON TARGET_NAME PROTO_FILE)
+  get_filename_component(ABS_FIL ${PROTO_FILE} ABSOLUTE)
+  get_filename_component(ABS_PATH ${ABS_FIL} PATH)
+  get_filename_component(FIL_WE ${PROTO_FILE} NAME_WE)
+  list(FIND _protobuf_include_path ${ABS_PATH} _contains_already)
+  if(${_contains_already} EQUAL -1)
+    list(APPEND _protobuf_include_path -I ${ABS_PATH})
+  endif()
+
+  if(DEFINED PROTOBUF_IMPORT_DIRS)
+    foreach(DIR ${PROTOBUF_IMPORT_DIRS})
+      get_filename_component(ABS_PATH ${DIR} ABSOLUTE)
+      list(FIND _protobuf_include_path ${ABS_PATH} _contains_already)
+      if(${_contains_already} EQUAL -1)
+        list(APPEND _protobuf_include_path -I ${ABS_PATH})
+      endif()
+    endforeach()
+  endif()
+
+  set(PROTOC_DEPENDENCY ${PROTOBUF_PROTOC_EXECUTABLE})
+
+  add_custom_target(${TARGET_NAME} ALL
+    ${PROTOBUF_PROTOC_EXECUTABLE} --python_out ${CMAKE_CURRENT_BINARY_DIR} ${_protobuf_include_path} ${ABS_FIL}
+    DEPENDS ${ABS_FIL} ${PROTOC_DEPENDENCY}
+    COMMENT "Running Python protocol buffer compiler on ${PROTO_FILE}"
+    VERBATIM
+  )
+endfunction()

--- a/include/treelite/base.h
+++ b/include/treelite/base.h
@@ -30,6 +30,22 @@ enum class Operator : int8_t {
 /*! \brief conversion table from string to operator, defined in optable.cc */
 extern const std::unordered_map<std::string, Operator> optable;
 
+/*!
+ * \brief get string representation of comparsion operator
+ * \param op comparison operator
+ * \return string representation
+ */
+inline std::string OpName(Operator op) {
+  switch (op) {
+    case Operator::kEQ: return "==";
+    case Operator::kLT: return "<";
+    case Operator::kLE: return "<=";
+    case Operator::kGT: return ">";
+    case Operator::kGE: return ">=";
+    default: return "";
+  }
+}
+
 }  // namespace treelite
 
 #endif  // TREELITE_BASE_H_

--- a/include/treelite/c_api.h
+++ b/include/treelite/c_api.h
@@ -261,6 +261,16 @@ TREELITE_DLL int TreeliteLoadXGBoostModelFromMemoryBuffer(const void* buf,
 TREELITE_DLL int TreeliteLoadProtobufModel(const char* filename,
                                            ModelHandle* out);
 /*!
+ * \brief export a model in Protocol Buffers format. Protocol Buffers
+ *        (google/protobuf) is a language- and platform-neutral mechanism for
+ *        serializing structured data. See src/tree.proto for format spec.
+ * \param filename name of model file
+ * \param model model to export
+ * \return 0 for success, -1 for failure
+ */
+TREELITE_DLL int TreeliteExportProtobufModel(const char* filename,
+                                             ModelHandle model);
+/*!
  * \brief delete model from memory
  * \param handle model to remove
  * \return 0 for success, -1 for failure

--- a/include/treelite/frontend.h
+++ b/include/treelite/frontend.h
@@ -50,6 +50,14 @@ Model LoadXGBoostModel(const void* buf, size_t len);
  * \return loaded model
  */
 Model LoadProtobufModel(const char* filename);
+/*!
+ * \brief export a model in Protocol Buffers format. Protocol Buffers
+ *        (google/protobuf) is a language- and platform-neutral mechanism for
+ *        serializing structured data. See src/tree.proto for format spec.
+ * \param filename name of model file
+ * \param model model to export
+ */
+void ExportProtobufModel(const char* filename, const Model& model);
 
 //--------------------------------------------------------------------------
 // model builder interface: build trees incrementally

--- a/python/treelite/frontend.py
+++ b/python/treelite/frontend.py
@@ -226,6 +226,25 @@ class Model(object):
         c_str(dirpath)))
     _check_call(_LIB.TreeliteCompilerFree(compiler_handle))
 
+  def export_protobuf(self, filename):
+    """
+    Export a tree ensemble model as a Protocol Buffers format. Protocol Buffers
+    (google/protobuf) is a language- and platform-neutral mechanism for
+    serializing structured data. See src/tree.proto for format spec.
+
+    Parameters
+    ----------
+    filename : :py:class:`str <python:str>`
+        path to save Protocol Buffers output
+
+    Example
+    -------
+    .. code-block:: python
+
+       model.export_protobuf('./my.buffer')
+    """
+    _check_call(_LIB.TreeliteExportProtobufModel(c_str(filename), self.handle))
+
   @staticmethod
   def _set_compiler_param(compiler_handle, params, value=None):
     """

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -335,6 +335,14 @@ int TreeliteLoadProtobufModel(const char* filename,
   API_END();
 }
 
+int TreeliteExportProtobufModel(const char* filename,
+                                ModelHandle model) {
+  API_BEGIN();
+  Model* model_ = static_cast<Model*>(model);
+  frontend::ExportProtobufModel(filename, *model_);
+  API_END();
+}
+
 int TreeliteFreeModel(ModelHandle handle) {
   API_BEGIN();
   delete static_cast<Model*>(handle);

--- a/src/compiler/ast/ast.h
+++ b/src/compiler/ast/ast.h
@@ -20,22 +20,6 @@ class ASTNode;
 namespace treelite {
 namespace compiler {
 
-/*!
- * \brief get string representation of comparsion operator
- * \param op comparison operator
- * \return string representation
- */
-inline std::string OpName(Operator op) {
-  switch (op) {
-    case Operator::kEQ: return "==";
-    case Operator::kLT: return "<";
-    case Operator::kLE: return "<=";
-    case Operator::kGT: return ">";
-    case Operator::kGE: return ">=";
-    default: return "";
-  }
-}
-
 class ASTNode {
  public:
   ASTNode* parent;

--- a/src/frontend/builder.cc
+++ b/src/frontend/builder.cc
@@ -5,9 +5,9 @@
  * \author Philip Cho
  */
 
+#include <dmlc/registry.h>
 #include <treelite/frontend.h>
 #include <treelite/tree.h>
-#include <dmlc/registry.h>
 #include <memory>
 #include <queue>
 #include "../c_api/c_api_error.h"

--- a/src/frontend/lightgbm.cc
+++ b/src/frontend/lightgbm.cc
@@ -6,6 +6,7 @@
  */
 
 #include <dmlc/data.h>
+#include <treelite/frontend.h>
 #include <treelite/tree.h>
 #include <unordered_map>
 #include <queue>

--- a/src/frontend/protobuf.cc
+++ b/src/frontend/protobuf.cc
@@ -220,12 +220,10 @@ void ExportProtobufModel(const char* filename, const Model& model) {
   treelite_protobuf::Model protomodel;
 
   protomodel.set_num_feature(
-    static_cast<google::protobuf::int32>(model.num_feature)
-  );
+    static_cast<google::protobuf::int32>(model.num_feature));
 
   protomodel.set_num_output_group(
-    static_cast<google::protobuf::int32>(model.num_output_group)
-  );
+    static_cast<google::protobuf::int32>(model.num_output_group));
 
   protomodel.set_random_forest_flag(model.random_forest_flag);
 
@@ -305,8 +303,7 @@ void ExportProtobufModel(const char* filename, const Model& model) {
       /* set node statistics */
       if (tree[nid].has_data_count()) {
         proto_node->set_data_count(
-          static_cast<google::protobuf::uint64>(tree[nid].data_count())
-        );
+          static_cast<google::protobuf::uint64>(tree[nid].data_count()));
       }
       if (tree[nid].has_sum_hess()) {
         proto_node->set_sum_hess(tree[nid].sum_hess());

--- a/src/frontend/xgboost.cc
+++ b/src/frontend/xgboost.cc
@@ -7,6 +7,7 @@
 
 #include <dmlc/data.h>
 #include <dmlc/memory_io.h>
+#include <treelite/frontend.h>
 #include <treelite/tree.h>
 #include <memory>
 #include <queue>

--- a/tests/python/test_lightgbm_integration.py
+++ b/tests/python/test_lightgbm_integration.py
@@ -68,15 +68,11 @@ class TestLightGBMIntegration(unittest.TestCase):
                          3      1
                          4      2
     """
-    try:
-      import lightgbm
-    except ImportError:
-      raise nose.SkipTest()  # skip this test if LightGBM is not installed
 
-    for model_path, dtrain_path, dtest_path, libname_fmt, \
+    for model_path, dtest_path, libname_fmt, \
         expected_prob_path, expected_margin_path, multiclass in \
         [('toy_categorical/toy_categorical_model.txt',
-          None, 'toy_categorical/toy_categorical.test', './toycat{}',
+          'toy_categorical/toy_categorical.test', './toycat{}',
           None, 'toy_categorical/toy_categorical.test.pred', False)]:
       model_path = os.path.join(dpath, model_path)
       model = treelite.Model.load(model_path, model_format='lightgbm')

--- a/tests/python/test_protobuf.py
+++ b/tests/python/test_protobuf.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""Tests for reading/writing Protocol Buffers"""
+from __future__ import print_function
+import unittest
+import os
+import numpy as np
+import treelite
+import treelite.runtime
+from util import run_pipeline_test
+
+dpath = os.path.abspath(os.path.join(os.getcwd(), 'tests/examples/'))
+
+class TestProtobuf(unittest.TestCase):
+  def test_round_trip(self):
+    for model_format, model_path, dtest_path, libname_fmt, \
+        expected_prob_path, expected_margin_path, multiclass in \
+        [('xgboost', 'mushroom/mushroom.model', 'mushroom/agaricus.test',
+          './agaricus{}', 'mushroom/agaricus.test.prob',
+          'mushroom/agaricus.test.margin', False),
+         ('xgboost', 'dermatology/dermatology.model',
+          'dermatology/dermatology.test', './dermatology{}',
+          'dermatology/dermatology.test.prob',
+          'dermatology/dermatology.test.margin', True),
+         ('xgboost', 'letor/mq2008.model', 'letor/mq2008.test', './mq2008{}',
+          None, 'letor/mq2008.test.pred', False),
+         ('lightgbm', 'toy_categorical/toy_categorical_model.txt',
+          'toy_categorical/toy_categorical.test', './toycat{}',
+          None, 'toy_categorical/toy_categorical.test.pred', False)]:
+      model_path = os.path.join(dpath, model_path)
+      model = treelite.Model.load(model_path, model_format=model_format)
+      model.export_protobuf('./my.buffer')
+      model2 = treelite.Model.load('./my.buffer', model_format='protobuf')
+      for use_quantize in [False, True]:
+        run_pipeline_test(model=model2, dtest_path=dtest_path,
+                          libname_fmt=libname_fmt,
+                          expected_prob_path=expected_prob_path,
+                          expected_margin_path=expected_margin_path,
+                          multiclass=multiclass, use_annotation=None,
+                          use_quantize=use_quantize, use_parallel_comp=None)


### PR DESCRIPTION
It is now possible to export Treelite model objects as Protobuf. We verify that nothing is lost if a model is exported as Protobuf and read back.