### PR TITLE
Enable cross-compilation

### DIFF
--- a/python/treelite/contrib/__init__.py
+++ b/python/treelite/contrib/__init__.py
@@ -12,13 +12,6 @@ from ..common.util import TreeliteError, lineno, log_info
 from ..libpath import find_lib_path
 from .util import _libext, _toolchain_exist_check
 
-def _check_ext(toolchain, dllpath):
-  if toolchain == 'msvc':
-    from .msvc import _check_ext
-  else:
-    from .gcc import _check_ext
-  _check_ext(dllpath)
-
 def generate_makefile(dirpath, platform, toolchain, options=None):
   """
   Generate a Makefile for a given directory of headers and sources. The
@@ -78,9 +71,7 @@ def generate_makefile(dirpath, platform, toolchain, options=None):
                        'set platform=\'windows\'')
     from .msvc import _obj_ext, _obj_cmd, _lib_cmd
   else:
-    from .gcc import _obj_ext, _obj_cmd, _lib_cmd, _openmp_supported
-    if _openmp_supported(toolchain):
-      options += ['-fopenmp']
+    from .gcc import _obj_ext, _obj_cmd, _lib_cmd
   obj_ext = _obj_ext()
 
   with open(os.path.join(dirpath, 'Makefile'), 'w') as f:
@@ -204,7 +195,7 @@ def create_shared(toolchain, dirpath, nthread=None, verbose=False, options=None)
   if toolchain == 'msvc':
     from .msvc import _create_shared
   else:
-    from .gcc import _create_shared, _openmp_supported
+    from .gcc import _create_shared
   libpath = \
     _create_shared(dirpath, toolchain, recipe, nthread, options, verbose)
   if verbose:

--- a/python/treelite/contrib/gcc.py
+++ b/python/treelite/contrib/gcc.py
@@ -4,11 +4,7 @@ Tools to interact with toolchains GCC, Clang, and other UNIX compilers
 """
 
 from __future__ import absolute_import as _abs
-import os
-import subprocess
 
-from ..common.compat import DEVNULL
-from ..common.util import TemporaryDirectory
 from .util import _create_shared_base, _libext
 
 LIBEXT = _libext()

--- a/python/treelite/contrib/gcc.py
+++ b/python/treelite/contrib/gcc.py
@@ -13,19 +13,6 @@ from .util import _create_shared_base, _libext
 
 LIBEXT = _libext()
 
-def _openmp_supported(toolchain):
-  # make temporary folder
-  with TemporaryDirectory() as temp_dir:
-    sfile = os.path.join(temp_dir, 'test.c')
-    output = os.path.join(temp_dir, 'test')
-    with open(sfile, 'w') as f:
-      f.write('int main() { return 0; }\n')
-    retcode = subprocess.call('{} -o {} {} -fopenmp'\
-                              .format(toolchain, output, sfile),
-                              shell=True,
-                              stdin=DEVNULL, stdout=DEVNULL, stderr=DEVNULL)
-  return retcode == 0
-
 def _obj_ext():
   return '.o'
 
@@ -43,9 +30,7 @@ def _lib_cmd(sources, target, lib_ext, toolchain, options):
                   ' '.join(options))
 
 def _create_shared(dirpath, toolchain, recipe, nthread, options, verbose):
-  if _openmp_supported(toolchain):
-    options += ['-fopenmp']
-
+  options += ['-lm']
   # Specify command to compile an object file
   recipe['object_ext'] = _obj_ext()
   recipe['library_ext'] = LIBEXT
@@ -58,10 +43,5 @@ def _create_shared(dirpath, toolchain, recipe, nthread, options, verbose):
   recipe['create_library_cmd'] = lib_cmd
   recipe['initial_cmd'] = ''
   return _create_shared_base(dirpath, recipe, nthread, verbose)
-
-def _check_ext(dllpath):
-  fileext = os.path.splitext(dllpath)[1]
-  if fileext != LIBEXT:
-    raise ValueError('Library file should have {} extension'.format(LIBEXT))
 
 __all__ = []

--- a/python/treelite/contrib/msvc.py
+++ b/python/treelite/contrib/msvc.py
@@ -89,9 +89,4 @@ def _create_shared(dirpath, toolchain, recipe, nthread, options, verbose):
                                   'amd64' if _is_64bit_windows() else 'x86')
   return _create_shared_base(dirpath, recipe, nthread, verbose)
 
-def _check_ext(dllpath):
-  fileext = os.path.splitext(dllpath)[1]
-  if fileext != '.dll':
-    raise ValueError('Library file should have .dll extension')
-
 __all__ = []

--- a/python/treelite/frontend.py
+++ b/python/treelite/frontend.py
@@ -8,8 +8,7 @@ import os
 from .common.compat import STRING_TYPES
 from .common.util import c_str, TreeliteError, TemporaryDirectory
 from .core import _LIB, c_array, _check_call
-from .contrib import create_shared, generate_makefile, _check_ext, \
-                     _toolchain_exist_check
+from .contrib import create_shared, generate_makefile, _toolchain_exist_check
 
 def _isascii(string):
   """Tests if a given string is pure ASCII; works for both Python 2 and 3"""
@@ -91,7 +90,6 @@ class Model(object):
        # move the library out of the temporary directory
        shutil.move('/temporary/directory/mymodel.dll', './mymodel.dll')
     """
-    _check_ext(toolchain, libpath)  # check for file extension
     _toolchain_exist_check(toolchain)
     with TemporaryDirectory() as temp_dir:
       self.compile(temp_dir, params, compiler, verbose)
@@ -163,7 +161,6 @@ class Model(object):
     if fileext != '.zip':
       raise ValueError('Source package file should have .zip extension')
     libname = os.path.basename(libname)
-    _check_ext(toolchain, libname)
     _toolchain_exist_check(toolchain)
 
     with TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Example: Cross compile to Raspberry PI

```python
model.export_lib(toolchain='clang', libpath='./test.so', verbose=True,
                 options=['-target armv7l-none-linux-gnueabihf',
                          '-fuse-ld=lld', '-static'])
```