### PR TITLE
Make function declaration in header a prototype

### DIFF
--- a/include/treelite/c_api_common.h
+++ b/include/treelite/c_api_common.h
@@ -34,7 +34,7 @@
  * Note. Each thread will get the last error occured in its own context.
  * \return error string
  */
-TREELITE_DLL const char* TreeliteGetLastError();
+TREELITE_DLL const char* TreeliteGetLastError(void);
 
 /*!
  * \brief register callback function for LOG(INFO) messages -- helpful messages


### PR DESCRIPTION
Without this, compiling with strict prototypes flags fails. e.g.:

```
/treelite/include/treelite/c_api_common.h:37:1: error: function declaration isn't a prototype [-Werror=strict-prototypes]
 TREELITE_DLL const char* TreeliteGetLastError();
```