### PR TITLE
Add model query functions

### DIFF
--- a/include/treelite/c_api.h
+++ b/include/treelite/c_api.h
@@ -271,6 +271,27 @@ TREELITE_DLL int TreeliteLoadProtobufModel(const char* filename,
 TREELITE_DLL int TreeliteExportProtobufModel(const char* filename,
                                              ModelHandle model);
 /*!
+ * \brief Query the number of trees in the model
+ * \param handle model to query
+ * \param out number of trees
+ * \return 0 for success, -1 for failure
+ */
+TREELITE_DLL int TreeliteQueryNumTree(ModelHandle handle, size_t* out);
+/*!
+ * \brief Query the number of features used in the model
+ * \param handle model to query
+ * \param out number of features
+ * \return 0 for success, -1 for failure
+ */
+TREELITE_DLL int TreeliteQueryNumFeature(ModelHandle handle, size_t* out);
+/*!
+ * \brief Query the number of output groups of the model
+ * \param handle model to query
+ * \param out number of output groups
+ * \return 0 for success, -1 for failure
+ */
+TREELITE_DLL int TreeliteQueryNumOutputGroups(ModelHandle handle, size_t* out);
+/*!
  * \brief delete model from memory
  * \param handle model to remove
  * \return 0 for success, -1 for failure

--- a/python/treelite/frontend.py
+++ b/python/treelite/frontend.py
@@ -41,6 +41,33 @@ class Model(object):
       _check_call(_LIB.TreeliteFreeModel(self.handle))
       self.handle = None
 
+  @property
+  def num_tree(self):
+    """Number of decision trees in the model"""
+    if self.handle is None:
+      raise AttributeError('Model not loaded yet')
+    out = ctypes.c_size_t()
+    _check_call(_LIB.TreeliteQueryNumTree(self.handle, ctypes.byref(out)))
+    return out.value
+
+  @property
+  def num_feature(self):
+    """Number of features used in the model"""
+    if self.handle is None:
+      raise AttributeError('Model not loaded yet')
+    out = ctypes.c_size_t()
+    _check_call(_LIB.TreeliteQueryNumFeature(self.handle, ctypes.byref(out)))
+    return out.value
+
+  @property
+  def num_output_group(self):
+    """Number of output groups of the model"""
+    if self.handle is None:
+      raise AttributeError('Model not loaded yet')
+    out = ctypes.c_size_t()
+    _check_call(_LIB.TreeliteQueryNumOutputGroups(self.handle, ctypes.byref(out)))
+    return out.value
+
   # pylint: disable=R0913
   def export_lib(self, toolchain, libpath, params=None, compiler='ast_native',
                  verbose=False, nthread=None, options=None):

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -349,6 +349,27 @@ int TreeliteFreeModel(ModelHandle handle) {
   API_END();
 }
 
+int TreeliteQueryNumTree(ModelHandle handle, size_t* out) {
+  API_BEGIN();
+  const Model* model_ = static_cast<Model*>(handle);
+  *out = model_->trees.size();
+  API_END();
+}
+
+int TreeliteQueryNumFeature(ModelHandle handle, size_t* out) {
+  API_BEGIN();
+  const Model* model_ = static_cast<Model*>(handle);
+  *out = static_cast<size_t>(model_->num_feature);
+  API_END();
+}
+
+int TreeliteQueryNumOutputGroups(ModelHandle handle, size_t* out) {
+  API_BEGIN();
+  const Model* model_ = static_cast<Model*>(handle);
+  *out = static_cast<size_t>(model_->num_output_group);
+  API_END();
+}
+
 int TreeliteCreateTreeBuilder(TreeBuilderHandle* out) {
   API_BEGIN();
   auto builder = new frontend::TreeBuilder();


### PR DESCRIPTION
Add query functions for `Model` objects. This is useful when deciding `parallel_comp` parameter, which is a must for compiling large models in reasonable amount of time.