### PR TITLE
Install libraries and headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,3 +138,9 @@ endif()
 
 # Group sources
 auto_source_group("${SOURCES}")
+
+install(TARGETS treelite
+        LIBRARY DESTINATION lib)
+
+install(DIRECTORY include/treelite DESTINATION include
+        FILES_MATCHING PATTERN "*.h")

--- a/runtime/native/CMakeLists.txt
+++ b/runtime/native/CMakeLists.txt
@@ -87,3 +87,9 @@ if(MINGW)
   # remove the 'lib' prefix to conform to windows convention for shared library names
   set_target_properties(treelite_runtime PROPERTIES PREFIX "")
 endif()
+
+install(TARGETS treelite_runtime
+        LIBRARY DESTINATION lib)
+
+install(DIRECTORY include/treelite DESTINATION include
+        FILES_MATCHING PATTERN "*.h")


### PR DESCRIPTION
When trying to install the library for a project of mine I saw no headers nor shared libs in the install directory. As a local fix I use this patch, but I am not sure whether this can be relevant or useful for the common use cases.

