### PR TITLE
Handle categorical splits with empty left_categories

### DIFF
--- a/src/compiler/common/categorical_bitmap.h
+++ b/src/compiler/common/categorical_bitmap.h
@@ -16,6 +16,9 @@ namespace common_util {
 inline std::vector<uint64_t>
 GetCategoricalBitmap(const std::vector<uint32_t>& left_categories) {
   const size_t num_left_categories = left_categories.size();
+  if (num_left_categories == 0) {
+    return std::vector<uint64_t>{0};
+  }
   const uint32_t max_left_category = left_categories[num_left_categories - 1];
   std::vector<uint64_t> bitmap((max_left_category + 1 + 63) / 64, 0);
   for (size_t i = 0; i < left_categories.size(); ++i) {


### PR DESCRIPTION
A segmentation fault occurs when left_categories size is 0.