### PR TITLE
Fix Java test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ matrix:
 addons:
   apt:
     packages:
-      - cmake-data
-      - cmake
+      - cmake3-data
+      - cmake3
       - gcc-4.8
       - g++-4.8
       - clang-3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,8 @@ matrix:
 # dependent apt packages
 addons:
   apt:
-    sources:
-      - george-edison55-precise-backports
     packages:
+      - cmake-data
       - cmake
       - gcc-4.8
       - g++-4.8

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -56,7 +56,7 @@ fi
 
 if [ ${TASK} == "java_test" ]; then
   cd runtime/java/treelite4j
-  mvn test -DJNI.args=cpp-coverage
+  mvn test -DJNI.args=cpp-coverage || exit -1
   # capture coverage info
   lcov --directory . --capture --output-file coverage.info
   # filter system and 3rd-party headers


### PR DESCRIPTION
Java test is failing to build because of CMake version (https://travis-ci.org/dmlc/treelite/jobs/485780067#L1200) but the CI didn't catch the failure. Add a check against build failure.