### PR TITLE
Add utility functions to Treelite4J for creating input batches

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,6 +87,8 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.imgmath']
 
+imgmath_dvipng_args = ['-gamma', '1.5', '-D', '180', '-bg', 'Transparent']
+
 graphviz_output_format = 'png'
 plot_formats = [('svg', 300), ('png', 100), ('hires.png', 300)]
 plot_html_show_source_link = False

--- a/docs/tutorials/deploy_java.rst
+++ b/docs/tutorials/deploy_java.rst
@@ -113,3 +113,10 @@ Now invoke the batch prediction function using the SparseBatch object:
   float[][] result = predictor.predict(batch, true, false);
 
 The returned array is a two-dimensional array where the array ``result[i]`` represents the prediction for the ``i``-th data point. For most applications, each ``result[i]`` has length 1. Multi-class classification task is specical, in that for that task ``result[i]`` contains class probabilities, so the array is as long as the number of target classes.
+
+For your convenience, we also provide a convenience method to load a data text file in the LIBSVM format:
+
+.. code-block:: java
+
+  List<DataPoint> dmat = BatchBuilder.LoadDatasetFromLibSVM("path/to/my.data.libsvm");
+  SparseBatch batch = BatchBuilder.CreateSparseBatch(dmat);

--- a/docs/tutorials/deploy_java.rst
+++ b/docs/tutorials/deploy_java.rst
@@ -62,4 +62,54 @@ and invoke the prediction function.
 
 Predict with a batch of inputs
 ------------------------------
-[Under construction]
+For predicting with a batch of inputs, we create a list of DataPoint objects. Each DataPoint object consists of feature values and corresponding feature indices.
+
+Let us look at an example. Consider the following 4-by-6 data matrix
+
+.. math::
+
+  \left[
+    \begin{array}{cccccc}
+      10 & 20 & \cdot & \cdot & \cdot & \cdot\\
+      \cdot & 30 & \cdot & 40 & \cdot & \cdot\\
+      \cdot & \cdot & 50 & 60 & 70 & \cdot\\
+      \cdot & \cdot & \cdot & \cdot & \cdot & 80
+    \end{array}
+  \right]
+
+where the dot (.) indicates the missing value. The matrix consists of 4 data points (instances), each with 6 feature values.
+Since not all feature values are present, we need to store feature indices as well as feature values:
+
+.. code-block:: java
+
+  import ml.dmlc.treelite4j.DataPoint;
+
+  // Create a list consisting of 4 data points
+  List<DataPoint> dmat = new ArrayList<DataPoint>() {
+    {
+      //                feature indices     feature values
+      add(new DataPoint(new int[]{0, 1},    new float[]{10f, 20f}));
+      add(new DataPoint(new int[]{1, 3},    new float[]{30f, 40f}));
+      add(new DataPoint(new int[]{2, 3, 4}, new float[]{50f, 60f, 70f}));
+      add(new DataPoint(new int[]{5},       new float[]{80f}));
+    }
+  };
+
+Once the list is created, we then convert it into a SparseBatch object. We use SparseBatch rather than DenseBatch because significant portion of the data matrix
+consists of missing values.
+
+.. code-block:: java
+
+  import ml.dmlc.treelite4j.BatchBuilder;
+
+  // Convert data point list into SparseBatch object
+  SparseBatch batch = BatchBuilder.CreateSparseBatch(dmat);
+
+Now invoke the batch prediction function using the SparseBatch object:
+
+.. code-block:: java
+
+  // verbose=true, pred_margin=false
+  float[][] result = predictor.predict(batch, true, false);
+
+The returned array is a two-dimensional array where the array ``result[i]`` represents the prediction for the ``i``-th data point. For most applications, each ``result[i]`` has length 1. Multi-class classification task is specical, in that for that task ``result[i]`` contains class probabilities, so the array is as long as the number of target classes.

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -12,5 +12,6 @@ This page lists tutorials about treelite.
  import
  optimize
  deploy
+ deploy_java
  builder
  protobuf

--- a/runtime/java/treelite4j/pom.xml
+++ b/runtime/java/treelite4j/pom.xml
@@ -10,8 +10,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <scala.version>2.11.12</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
     <JNI.args></JNI.args>
   </properties>
   <dependencies>
@@ -40,6 +42,21 @@
       <groupId>org.javolution</groupId>
       <artifactId>javolution-core-java</artifactId>
       <version>6.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-compiler</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-reflect</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
     </dependency>
   </dependencies>
 
@@ -93,6 +110,41 @@
               </arguments>
               <workingDirectory>${project.basedir}</workingDirectory>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>3.2.2</version>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <phase>compile</phase>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <phase>test-compile</phase>
+          </execution>
+          <execution>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>scala-compile-first</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>compile</goal>
+              <goal>add-source</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/runtime/java/treelite4j/src/main/java/ml/dmlc/treelite4j/BatchBuilder.java
+++ b/runtime/java/treelite4j/src/main/java/ml/dmlc/treelite4j/BatchBuilder.java
@@ -1,0 +1,121 @@
+package ml.dmlc.treelite4j;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.LineIterator;
+import org.apache.commons.lang.ArrayUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class BatchBuilder {
+  public static SparseBatch CreateSparseBatch(List<DataPoint> dmat)
+      throws TreeliteError, IOException {
+    ArrayList<Float> data = new ArrayList<Float>();
+    ArrayList<Integer> col_ind = new ArrayList<Integer>();
+    ArrayList<Long> row_ptr = new ArrayList<Long>();
+    int num_row = dmat.size();
+    int num_col = 0;
+    row_ptr.add(0L);
+    for (DataPoint inst : dmat) {
+      int nnz = 0; // count number of nonzero feature values for current row
+      for (float e : inst.values()) {
+        data.add(e);
+        ++nnz;
+      }
+      if (inst.indices() != null) {
+        for (int e : inst.indices()) {
+          col_ind.add(e);
+          num_col = Math.max(num_col, e + 1);
+        }
+      } else {
+        // when indices are missing, assume feature indices 0, 1, 2, ...
+        int num_values = inst.values().length;
+        for (int i = 0; i < num_values; ++i) {
+          col_ind.add(i);
+        }
+        num_col = Math.max(num_col, num_values);
+      }
+      row_ptr.add(row_ptr.get(row_ptr.size() - 1) + (long)nnz);
+    }
+    float[] data_arr
+      = ArrayUtils.toPrimitive(data.toArray(new Float[0]));
+    int[] col_ind_arr
+      = ArrayUtils.toPrimitive(col_ind.toArray(new Integer[0]));
+    long[] row_ptr_arr
+      = ArrayUtils.toPrimitive(row_ptr.toArray(new Long[0]));
+    return new SparseBatch(data_arr, col_ind_arr, row_ptr_arr, num_row, num_col);
+  }
+
+  public static DenseBatch CreateDenseBatch(List<DataPoint> dmat)
+      throws TreeliteError, IOException {
+    int num_row = dmat.size();
+    int num_col = 0;
+    // compute num_col
+    for (DataPoint inst : dmat) {
+      if (inst.indices() != null) {
+        for (int e : inst.indices()) {
+          num_col = Math.max(num_col, e + 1);
+        }
+      } else {
+        // when indices are missing, assume feature indices 0, 1, 2, ...
+        num_col = Math.max(num_col, inst.values().length);
+      }
+    }
+    float[] data = new float[num_row * num_col];
+    Arrays.fill(data, Float.NaN);
+
+    /* write nonzero entries */
+    int row_id = 0;
+    for (DataPoint inst : dmat) {
+      if (inst.indices() != null) {
+        int[] indices = inst.indices();
+        float[] values = inst.values();
+        for (int i = 0; i < indices.length; ++i) {
+          data[row_id * num_col + indices[i]] = values[i];
+        }
+      } else {
+        // when indices are missing, assume feature indices 0, 1, 2, ...
+        float[] values = inst.values();
+        int num_values = values.length;
+        for (int i = 0; i < num_values; ++i) {
+          data[row_id * num_col + i] = values[i];
+        }
+      }
+      ++row_id;
+    }
+    assert row_id == num_row;
+
+    return new DenseBatch(data, Float.NaN, num_row, num_col);
+  }
+
+  public static List<DataPoint> LoadDatasetFromLibSVM(String filename)
+      throws TreeliteError, IOException {
+    File file = new File(filename);
+    LineIterator it = FileUtils.lineIterator(file, "UTF-8");
+    ArrayList<DataPoint> dmat = new ArrayList<DataPoint>();
+    try {
+      while (it.hasNext()) {
+        String line = it.nextLine();
+        String[] tokens = line.split(" ");
+        /* feature indices and values for the data point */
+        ArrayList<Integer> indices = new ArrayList<Integer>();
+        ArrayList<Float> values = new ArrayList<Float>();
+        // ignore label; just read feature values
+        for (int i = 1; i < tokens.length; ++i) {
+          String[] subtokens = tokens[i].split(":");
+          indices.add(Integer.parseInt(subtokens[0]));
+          values.add(Float.parseFloat(subtokens[1]));
+        }
+        dmat.add(new DataPoint(
+            ArrayUtils.toPrimitive(indices.toArray(new Integer[0])),
+            ArrayUtils.toPrimitive(values.toArray(new Float[0]))));
+      }
+    } finally {
+      it.close();
+    }
+    return dmat;
+  }
+}

--- a/runtime/java/treelite4j/src/main/java/ml/dmlc/treelite4j/BatchBuilder.java
+++ b/runtime/java/treelite4j/src/main/java/ml/dmlc/treelite4j/BatchBuilder.java
@@ -10,7 +10,18 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Collection of utility functions to create batch objects
+ * @author Philip Cho
+ */
 public class BatchBuilder {
+  /**
+   * Assemble a sparse batch from a list of data points
+   * @param dmat List of data points
+   * @return Created sparse batch
+   * @throws TreeliteError Treelite error
+   * @throws IOException IO error
+   */
   public static SparseBatch CreateSparseBatch(List<DataPoint> dmat)
       throws TreeliteError, IOException {
     ArrayList<Float> data = new ArrayList<Float>();
@@ -49,6 +60,13 @@ public class BatchBuilder {
     return new SparseBatch(data_arr, col_ind_arr, row_ptr_arr, num_row, num_col);
   }
 
+  /**
+   * Assemble a dense batch from a list of data points
+   * @param dmat List of data points
+   * @return Created dense batch
+   * @throws TreeliteError Treelite error
+   * @throws IOException IO error
+   */
   public static DenseBatch CreateDenseBatch(List<DataPoint> dmat)
       throws TreeliteError, IOException {
     int num_row = dmat.size();
@@ -91,6 +109,13 @@ public class BatchBuilder {
     return new DenseBatch(data, Float.NaN, num_row, num_col);
   }
 
+  /**
+   * Load a LIBSVM data file and construct a list of data points
+   * @param filename path to LIBSVM file
+   * @return Created list of data points
+   * @throws TreeliteError Treelite error
+   * @throws IOException IO error
+   */
   public static List<DataPoint> LoadDatasetFromLibSVM(String filename)
       throws TreeliteError, IOException {
     File file = new File(filename);

--- a/runtime/java/treelite4j/src/main/scala/ml/dmlc/treelite4j/DataPoint.scala
+++ b/runtime/java/treelite4j/src/main/scala/ml/dmlc/treelite4j/DataPoint.scala
@@ -1,0 +1,27 @@
+/*!
+ * Copyright (c) 2019 by Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ml.dmlc.treelite4j
+
+/**
+  * A data point (instance)
+  *
+  * @param indices Feature indices of this point or `null` if the data is dense
+  * @param values Feature values of this point
+  */
+case class DataPoint(
+    indices: Array[Int],
+    values: Array[Float]) extends Serializable {
+  require(indices == null || indices.length == values.length, "indices and values must have the same number of elements")
+}

--- a/runtime/java/treelite4j/src/test/java/ml/dmlc/treelite4j/SparseBatchTest.java
+++ b/runtime/java/treelite4j/src/test/java/ml/dmlc/treelite4j/SparseBatchTest.java
@@ -3,8 +3,11 @@ package ml.dmlc.treelite4j;
 import org.apache.commons.lang.ArrayUtils;
 import org.junit.Test;
 import junit.framework.TestCase;
+
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -35,7 +38,7 @@ public class SparseBatchTest {
         }
       }
       long[] row_ptr_arr
-        = ArrayUtils.toPrimitive(row_ptr.toArray(new Long[row_ptr.size()]));
+        = ArrayUtils.toPrimitive(row_ptr.toArray(new Long[0]));
       SparseBatch batch
         = new SparseBatch(data, col_ind, row_ptr_arr, num_row, num_col);
       long[] out_num_row = new long[1];
@@ -45,5 +48,26 @@ public class SparseBatchTest {
       TestCase.assertEquals(num_row, out_num_row[0]);
       TestCase.assertEquals(num_col, out_num_col[0]);
     }
+  }
+
+  @Test
+  public void testSparseBatchBuilder() throws TreeliteError, IOException {
+    List<DataPoint> dmat = new ArrayList<DataPoint>() {
+      {
+        add(new DataPoint(new int[]{0, 1},    new float[]{10f, 20f}));
+        add(new DataPoint(new int[]{1, 3},    new float[]{30f, 40f}));
+        add(new DataPoint(new int[]{2, 3, 4}, new float[]{50f, 60f, 70f}));
+        add(new DataPoint(new int[]{5},       new float[]{80f}));
+      }
+    };
+    SparseBatch batch = BatchBuilder.CreateSparseBatch(dmat);
+
+    // should get 4-by-6 matrix
+    long[] out_num_row = new long[1];
+    long[] out_num_col = new long[1];
+    TreeliteJNI.checkCall(TreeliteJNI.TreeliteBatchGetDimension(
+      batch.getHandle(), true, out_num_row, out_num_col));
+    TestCase.assertEquals(4, out_num_row[0]);
+    TestCase.assertEquals(6, out_num_col[0]);
   }
 }


### PR DESCRIPTION
Now it is much easier to create batches for batched prediction.

Example:
```java
import ml.dmlc.treelite4j.DataPoint;
import ml.dmlc.treelite4j.BatchBuilder;

// Create a list consisting of 4 data points
List<DataPoint> dmat = new ArrayList<DataPoint>() {
  {
    //                feature indices     feature values
    add(new DataPoint(new int[]{0, 1},    new float[]{10f, 20f}));
    add(new DataPoint(new int[]{1, 3},    new float[]{30f, 40f}));
    add(new DataPoint(new int[]{2, 3, 4}, new float[]{50f, 60f, 70f}));
    add(new DataPoint(new int[]{5},       new float[]{80f}));
  }
};

// Convert data point list into SparseBatch object
SparseBatch batch = BatchBuilder.CreateSparseBatch(dmat);

// Run prediction
float[][] result = predictor.predict(batch, true, false);
```