### PR TITLE
Fix Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,8 +139,13 @@ endif()
 # Group sources
 auto_source_group("${SOURCES}")
 
-install(TARGETS treelite
-        LIBRARY DESTINATION lib)
+if(WIN32)
+  install(TARGETS treelite
+          RUNTIME DESTINATION lib)
+else()
+  install(TARGETS treelite
+          LIBRARY DESTINATION lib)
+endif()
 
 install(DIRECTORY include/treelite DESTINATION include
         FILES_MATCHING PATTERN "*.h")

--- a/runtime/native/CMakeLists.txt
+++ b/runtime/native/CMakeLists.txt
@@ -88,8 +88,13 @@ if(MINGW)
   set_target_properties(treelite_runtime PROPERTIES PREFIX "")
 endif()
 
-install(TARGETS treelite_runtime
-        LIBRARY DESTINATION lib)
+if(WIN32)
+  install(TARGETS treelite_runtime
+          RUNTIME DESTINATION lib)
+else()
+  install(TARGETS treelite_runtime
+          LIBRARY DESTINATION lib)
+endif()
 
 install(DIRECTORY include/treelite DESTINATION include
         FILES_MATCHING PATTERN "*.h")

--- a/src/common/filesystem.h
+++ b/src/common/filesystem.h
@@ -13,10 +13,13 @@
 #include <string>
 #include <regex>
 #include <cstdlib>
+#include <random>
 
 #ifdef _WIN32
 #define NOMINMAX
 #include <windows.h>
+#include <Shlwapi.h>
+#pragma comment(lib, "Shlwapi.lib")
 #else
 #include <unistd.h>
 #include <errno.h>

--- a/src/compiler/common/code_folding_util.h
+++ b/src/compiler/common/code_folding_util.h
@@ -119,9 +119,12 @@ RenderCodeFolderArrays(const CodeFolderNode* node,
           cat_bitmap.insert(cat_bitmap.end(), bitmap.begin(), bitmap.end());
           cat_begin.push_back(cat_bitmap.size());
         }
-        auto BoolWrapper =
-          use_boolean_literal ? [](bool x) { return x ? "true" : "false"; }
-                              : [](bool x) { return x ? "1" : "0"; };
+        const char* (*BoolWrapper)(bool);
+        if (use_boolean_literal) {
+          BoolWrapper = [](bool x) { return x ? "true" : "false"; };
+        } else {
+          BoolWrapper = [](bool x) { return x ? "1" : "0"; };
+        }
         formatter << fmt::format(node_entry_template,
                                   "default_left"_a = BoolWrapper(default_left),
                                   "split_index"_a = split_index,

--- a/src/compiler/native/header_template.h
+++ b/src/compiler/native/header_template.h
@@ -43,9 +43,9 @@ struct Node {{
 
 extern const unsigned char is_categorical[];
 
-{get_num_output_group_function_signature};
-{get_num_feature_function_signature};
-{predict_function_signature};
+{dllexport}{get_num_output_group_function_signature};
+{dllexport}{get_num_feature_function_signature};
+{dllexport}{predict_function_signature};
 )TREELITETEMPLATE";
 
 }  // namespace native

--- a/src/compiler/native/main_template.h
+++ b/src/compiler/native/main_template.h
@@ -16,9 +16,7 @@ const char* main_start_template =
 R"TREELITETEMPLATE(
 #include "header.h"
 
-const unsigned char is_categorical[] = {{
-{array_is_categorical}
-}};
+{array_is_categorical};
 
 {get_num_output_group_function_signature} {{
   return {num_output_group};


### PR DESCRIPTION
Ensure that Treelite is able to compile on Windows. In addition, the compiled model artifacts must have correct symbol exports (`__declspec(export)`) in order for prediction to work.