### PR TITLE
Simplify predictor interface

### DIFF
--- a/runtime/java/treelite4j/src/main/java/ml/dmlc/treelite4j/Predictor.java
+++ b/runtime/java/treelite4j/src/main/java/ml/dmlc/treelite4j/Predictor.java
@@ -28,18 +28,14 @@ public class Predictor {
    * @param nthread Number of workers threads to spawn. Set to -1 to use default,
    *                i.e., to launch as many threads as CPU cores available on
    *                the system. You are not allowed to launch more threads than
-   *                CPU cores.
+   *                CPU cores. Setting ``nthread=1`` indicates that the main
+   *                thread should be exclusively used.
    * @param verbose Whether to print extra diagnostic messages
-   * @param include_master_thread Whether the master thread (the thread calling
-   *                              the :java:ref:`predict()` method) should
-   *                              itself be assigned work. This option is
-   *                              applicable only to batch prediction.
    * @return Created Predictor
    * @throws TreeliteError
    */
   public Predictor(
-    String libpath, int nthread, boolean verbose, boolean include_master_thread)
-      throws TreeliteError {
+    String libpath, int nthread, boolean verbose) throws TreeliteError {
     File f = new File(libpath);
     String path = "";
     if (f.isDirectory()) {  // libpath is a diectory
@@ -74,7 +70,7 @@ public class Predictor {
 
     long[] out = new long[1];
     TreeliteJNI.checkCall(TreeliteJNI.TreelitePredictorLoad(
-      path, nthread, include_master_thread, out));
+      path, nthread, out));
     handle = out[0];
 
     // Save # of output groups and # of features

--- a/runtime/java/treelite4j/src/main/java/ml/dmlc/treelite4j/TreeliteJNI.java
+++ b/runtime/java/treelite4j/src/main/java/ml/dmlc/treelite4j/TreeliteJNI.java
@@ -48,8 +48,7 @@ class TreeliteJNI {
     long handle, boolean batch_sparse, long[] out_num_row, long[] out_num_col);
 
   public final static native int TreelitePredictorLoad(
-    String library_path, int num_worker_thread, boolean include_master_thread,
-    long[] out);
+    String library_path, int num_worker_thread, long[] out);
 
   public final static native int TreelitePredictorPredictBatch(
     long handle, long batch, boolean batch_sparse, boolean verbose,

--- a/runtime/java/treelite4j/src/native/treelite4j.cpp
+++ b/runtime/java/treelite4j/src/native/treelite4j.cpp
@@ -143,17 +143,17 @@ Java_ml_dmlc_treelite4j_TreeliteJNI_TreeliteBatchGetDimension(
 /*
  * Class:     ml_dmlc_treelite4j_TreeliteJNI
  * Method:    TreelitePredictorLoad
- * Signature: (Ljava/lang/String;IZ[J)I
+ * Signature: (Ljava/lang/String;I[J)I
  */
 JNIEXPORT jint JNICALL
 Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorLoad(
   JNIEnv* jenv, jclass jcls, jstring jlibrary_path, jint jnum_worker_thread,
-  jboolean jinclude_master_thread, jlongArray jout) {
+  jlongArray jout) {
 
   const char* library_path = jenv->GetStringUTFChars(jlibrary_path, 0);
   PredictorHandle out;
   const jint ret = (jint)TreelitePredictorLoad(library_path,
-    (int)jnum_worker_thread, (jinclude_master_thread == JNI_TRUE ? 1 : 0), &out);
+    (int)jnum_worker_thread, &out);
   setHandle(jenv, jout, out);
 
   return ret;

--- a/runtime/java/treelite4j/src/native/treelite4j.h
+++ b/runtime/java/treelite4j/src/native/treelite4j.h
@@ -63,11 +63,11 @@ Java_ml_dmlc_treelite4j_TreeliteJNI_TreeliteBatchGetDimension(
 /*
  * Class:     ml_dmlc_treelite4j_TreeliteJNI
  * Method:    TreelitePredictorLoad
- * Signature: (Ljava/lang/String;IZ[J)I
+ * Signature: (Ljava/lang/String;I[J)I
  */
 JNIEXPORT jint JNICALL
 Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorLoad(
-  JNIEnv*, jclass, jstring, jint, jboolean, jlongArray);
+  JNIEnv*, jclass, jstring, jint, jlongArray);
 
 /*
  * Class:     ml_dmlc_treelite4j_TreeliteJNI

--- a/runtime/java/treelite4j/src/test/java/ml/dmlc/treelite4j/PredictorTest.java
+++ b/runtime/java/treelite4j/src/test/java/ml/dmlc/treelite4j/PredictorTest.java
@@ -36,14 +36,14 @@ public class PredictorTest {
 
   @Test
   public void testPredictorBasic() throws TreeliteError {
-    Predictor predictor = new Predictor(mushroomLibLocation, -1, true, true);
+    Predictor predictor = new Predictor(mushroomLibLocation, -1, true);
     TestCase.assertEquals(1, predictor.GetNumOutputGroup());
     TestCase.assertEquals(127, predictor.GetNumFeature());
   }
 
   @Test
   public void testPredict() throws TreeliteError, IOException {
-    Predictor predictor = new Predictor(mushroomLibLocation, -1, true, true);
+    Predictor predictor = new Predictor(mushroomLibLocation, -1, true);
     List<DataPoint> dmat
       = BatchBuilder.LoadDatasetFromLibSVM(mushroomTestDataLocation);
     SparseBatch sparse_batch = BatchBuilder.CreateSparseBatch(dmat);
@@ -68,7 +68,7 @@ public class PredictorTest {
 
   @Test
   public void testPredictMargin() throws TreeliteError, IOException {
-    Predictor predictor = new Predictor(mushroomLibLocation, -1, true, true);
+    Predictor predictor = new Predictor(mushroomLibLocation, -1, true);
     List<DataPoint> dmat
       = BatchBuilder.LoadDatasetFromLibSVM(mushroomTestDataLocation);
     SparseBatch sparse_batch = BatchBuilder.CreateSparseBatch(dmat);
@@ -93,7 +93,7 @@ public class PredictorTest {
 
   @Test
   public void testPredictInst() throws TreeliteError, IOException {
-    Predictor predictor = new Predictor(mushroomLibLocation, -1, true, true);
+    Predictor predictor = new Predictor(mushroomLibLocation, -1, true);
     Entry[] inst_arr = new Entry[predictor.GetNumFeature()];
     for (int i = 0; i < inst_arr.length; ++i) {
       inst_arr[i] = new Entry();

--- a/runtime/native/include/treelite/c_api_runtime.h
+++ b/runtime/native/include/treelite/c_api_runtime.h
@@ -93,15 +93,11 @@ TREELITE_DLL int TreeliteBatchGetDimension(void* handle,
  * a dynamic shared library object (.so/.dll/.dylib).
  * \param library_path path to library object file containing prediction code
  * \param num_worker_thread number of worker threads (-1 to use max number)
- * \param include_master_thread whether to assign workload to the master
- *                              thread. If not, only workers threads will be
- *                              assigned work.
  * \param out handle to predictor
  * \return 0 for success, -1 for failure
  */
 TREELITE_DLL int TreelitePredictorLoad(const char* library_path,
                                        int num_worker_thread,
-                                       int include_master_thread,
                                        PredictorHandle* out);
 /*!
  * \brief Make predictions on a batch of data rows (synchronously). This

--- a/runtime/native/include/treelite/predictor.h
+++ b/runtime/native/include/treelite/predictor.h
@@ -54,8 +54,7 @@ class Predictor {
   typedef void* LibraryHandle;
   typedef void* ThreadPoolHandle;
 
-  Predictor(int num_worker_thread = -1,
-            bool include_master_thread = false);
+  Predictor(int num_worker_thread = -1);
   ~Predictor();
   /*!
    * \brief load the prediction function from dynamic shared library.
@@ -187,7 +186,6 @@ class Predictor {
   size_t num_output_group_;
   size_t num_feature_;
   int num_worker_thread_;
-  bool include_master_thread_;  // run task on master thread?
 
   bool using_remote_lib_;  // load lib from remote location?
   // information for temporary file to cache remote lib

--- a/runtime/native/python/treelite_runtime/predictor.py
+++ b/runtime/native/python/treelite_runtime/predictor.py
@@ -233,13 +233,10 @@ class Predictor(object):
       hardware threads
   verbose : :py:class:`bool <python:bool>`, optional
       Whether to print extra messages during construction
-  include_master_thread : :py:class:`bool <python:bool>`, optional
-      Whether to assign work to the master thread
   """
   # pylint: disable=R0903
 
-  def __init__(self, libpath, nthread=None, verbose=False,
-               include_master_thread=True):
+  def __init__(self, libpath, nthread=None, verbose=False):
     if os.path.isdir(libpath):  # libpath is a directory
       # directory is given; locate shared library inside it
       basename = os.path.basename(libpath.rstrip('/\\'))
@@ -268,7 +265,6 @@ class Predictor(object):
     _check_call(_LIB.TreelitePredictorLoad(
         c_str(path),
         ctypes.c_int(nthread if nthread is not None else -1),
-        ctypes.c_int(1 if include_master_thread else 0),
         ctypes.byref(self.handle)))
     # save # of features
     num_feature = ctypes.c_size_t()

--- a/runtime/native/src/c_api/c_api_runtime.cc
+++ b/runtime/native/src/c_api/c_api_runtime.cc
@@ -71,11 +71,9 @@ int TreeliteBatchGetDimension(void* handle,
 
 int TreelitePredictorLoad(const char* library_path,
                           int num_worker_thread,
-                          int include_master_thread,
                           PredictorHandle* out) {
   API_BEGIN();
-  Predictor* predictor = new Predictor(num_worker_thread,
-                                       static_cast<bool>(include_master_thread));
+  Predictor* predictor = new Predictor(num_worker_thread);
   predictor->Load(library_path);
   *out = static_cast<PredictorHandle>(predictor);
   API_END();

--- a/runtime/native/src/thread_pool/thread_pool.h
+++ b/runtime/native/src/thread_pool/thread_pool.h
@@ -27,9 +27,9 @@ class ThreadPool {
 
   ThreadPool(int num_worker, const TaskContext* context, TaskFunc task)
     : num_worker_(num_worker), context_(context), task_(task) {
-    CHECK(num_worker_ > 0 && num_worker_ <= std::thread::hardware_concurrency())
-    << "Number of worker threads must be between 1 and "
-    << std::thread::hardware_concurrency();
+    CHECK(num_worker_ >= 0 && num_worker_ < std::thread::hardware_concurrency())
+    << "Number of worker threads must be between 0 and "
+    << (std::thread::hardware_concurrency() - 1);
     for (int i = 0; i < num_worker_; ++i) {
       incoming_queue_.emplace_back(common::make_unique<SpscQueue<InputToken>>());
       outgoing_queue_.emplace_back(common::make_unique<SpscQueue<OutputToken>>());


### PR DESCRIPTION
* Always assign work to the main thread
* `nthread` always means the number of workers, including the main thread
  (so `nthread=1` means running on the main thread)