### PR TITLE
Allow user to turn off thread pinning via a flag

### DIFF
--- a/runtime/native/src/thread_pool/thread_pool.h
+++ b/runtime/native/src/thread_pool/thread_pool.h
@@ -9,6 +9,7 @@
 
 #include <treelite/common.h>
 #include <vector>
+#include <cstdlib>
 #ifdef _WIN32
 #define NOMINMAX
 #include <windows.h>
@@ -41,7 +42,10 @@ class ThreadPool {
                                       context_);
     }
     /* bind threads to cores */
-    SetAffinity();
+    const char* bind_flag = getenv("TREELITE_BIND_THREADS");
+    if (bind_flag == nullptr || std::atoi(bind_flag) == 1) {
+      SetAffinity();
+    }
   }
   ~ThreadPool() {
     for (int i = 0; i < num_worker_; ++i) {


### PR DESCRIPTION
Setting the environment variable `TREELITE_BIND_THREADS` to zero will disable thread pinning. This is useful when running multiple processes of Treelite runtime.

@ziyu-guo @yidawang 