### PR TITLE
Fix edge case where code_folding_req = 0 and parallel_comp > 1

### DIFF
--- a/src/compiler/ast/builder.h
+++ b/src/compiler/ast/builder.h
@@ -59,6 +59,10 @@ class ASTBuilder {
   void QuantizeThresholds();
   /* \brief Load data counts from annotation file */
   void LoadDataCounts(const std::vector<std::vector<size_t>>& counts);
+  /*
+   * \brief Get a text representation of AST
+   */
+  std::string GetDump() const;
 
   inline const ASTNode* GetRootNode() {
     return main_node;

--- a/src/compiler/ast/dump.cc
+++ b/src/compiler/ast/dump.cc
@@ -1,0 +1,34 @@
+/*!
+ * Copyright 2019 by Contributors
+ * \file dump.cc
+ * \brief Generate text representation of AST
+ */
+#include "./builder.h"
+
+namespace {
+
+void get_dump_from_node(std::ostringstream* oss,
+                        const treelite::compiler::ASTNode* node,
+                        int indent) {
+  (*oss) << std::string(indent, ' ') << node->GetDump() << "\n";
+  for (const treelite::compiler::ASTNode* child : node->children) {
+    CHECK(child);
+    get_dump_from_node(oss, child, indent + 2);
+  }
+}
+
+}  // namespace anonymous
+
+namespace treelite {
+namespace compiler {
+
+DMLC_REGISTRY_FILE_TAG(dump);
+
+std::string ASTBuilder::GetDump() const {
+  std::ostringstream oss;
+  get_dump_from_node(&oss, this->main_node, 0);
+  return oss.str();
+}
+
+}  // namespace compiler
+}  // namespace treelite

--- a/src/compiler/ast/dump.cc
+++ b/src/compiler/ast/dump.cc
@@ -17,7 +17,7 @@ void get_dump_from_node(std::ostringstream* oss,
   }
 }
 
-}  // namespace anonymous
+}  // anonymous namespace
 
 namespace treelite {
 namespace compiler {

--- a/src/compiler/ast/split.cc
+++ b/src/compiler/ast/split.cc
@@ -34,7 +34,8 @@ void ASTBuilder::Split(int parallel_comp) {
   /* tree_head[i] stores reference to head of tree i */
   std::vector<ASTNode*> tree_head;
   for (ASTNode* node : top_ac_node->children) {
-    CHECK(dynamic_cast<ConditionNode*>(node) || dynamic_cast<OutputNode*>(node));
+    CHECK(dynamic_cast<ConditionNode*>(node) || dynamic_cast<OutputNode*>(node)
+          || dynamic_cast<CodeFolderNode*>(node));
     tree_head.push_back(node);
   }
   /* dynamic_cast<> is used here to check node types. This is to ensure

--- a/src/compiler/ast_native.cc
+++ b/src/compiler/ast_native.cc
@@ -9,6 +9,7 @@
 #include <treelite/annotator.h>
 #include <fmt/format.h>
 #include <algorithm>
+#include <fstream>
 #include <unordered_map>
 #include <queue>
 #include <cmath>
@@ -76,6 +77,15 @@ class ASTNativeCompiler : public Compiler {
     if (param.quantize > 0) {
       builder.QuantizeThresholds();
     }
+
+    {
+      const char* destfile = getenv("TREELITE_DUMP_AST");
+      if (destfile) {
+        std::ofstream os(destfile);
+        os << builder.GetDump() << std::endl;
+      }
+    }
+
     WalkAST(builder.GetRootNode(), "main.c", 0);
     if (files_.count("arrays.c") > 0) {
       PrependToBuffer("arrays.c", "#include \"header.h\"\n", 0);

--- a/tests/python/test_code_folding.py
+++ b/tests/python/test_code_folding.py
@@ -17,7 +17,7 @@ class TestCodeFolding(unittest.TestCase):
         use_parallel_comp in \
         [('xgboost', 'mushroom/mushroom.model', 'mushroom/agaricus.train',
           'mushroom/agaricus.test', './agaricus{}', 'mushroom/agaricus.test.prob',
-          'mushroom/agaricus.test.margin', False, None),
+          'mushroom/agaricus.test.margin', False, 2),
          ('xgboost', 'dermatology/dermatology.model',
           'dermatology/dermatology.train', 'dermatology/dermatology.test',
           './dermatology{}', 'dermatology/dermatology.test.prob',
@@ -31,7 +31,7 @@ class TestCodeFolding(unittest.TestCase):
       else:
         use_annotation = None
       for use_quantize in [False, True]:
-        for use_code_folding in [1.0, 2.0, 3.0]:
+        for use_code_folding in [0.0, 1.0, 2.0, 3.0]:
           run_pipeline_test(model=model, dtest_path=dtest_path,
                             libname_fmt=libname_fmt,
                             expected_prob_path=expected_prob_path,


### PR DESCRIPTION
Setting `code_folding_req=0` will cause Treelite to produce a small loop to represent each tree. Example:

```cpp
float sum = 0.0f;
  unsigned int tmp;
  int nid, cond, fid;  /* used for folded subtrees */

  nid = 0;
  while (nid >= 0) {  /* negative nid implies leaf */
    fid = node_tree0_node0[nid].split_index;
    if (data[fid].missing == -1) {
      cond = node_tree0_node0[nid].default_left;
    } else {
      cond = (data[fid].fvalue < node_tree0_node0[nid].threshold);
    }
    nid = cond ? node_tree0_node0[nid].left_child : node_tree0_node0[nid].right_child;
  }

  switch (nid) {
   case -1:
    sum += (float)-0.0058267717249691486;
    break;
   case -2:
    sum += (float)0.0018431372009217739;
    break;
  // ...
  }
```

This PR fixes an edge case where we couldn't set `code_folding_req=0` and `parallel_comp>1` simultaneously (doing so resulted in an error)