### PR TITLE
Speed up FailSafeCompiler further by directly saving arrays as ELF binary

### DIFF
--- a/include/treelite/common.h
+++ b/include/treelite/common.h
@@ -262,6 +262,17 @@ inline void WriteToFile(const std::string& filename,
 }
 
 /*!
+ * \brief write a sequence of bytes to a text file
+ * \param filename name of text file
+ * \param lines a sequence of strings to be written.
+ */
+inline void WriteToFile(const std::string& filename,
+                        const std::vector<char>& content) {
+  std::ofstream of(filename, std::ios::out | std::ios::binary);
+  of.write(content.data(), content.size());
+}
+
+/*!
  * \brief apply a given transformation to a sequence of strings and append them
  *        to another sequence.
  * \param p_dest pointer to the destination sequence

--- a/include/treelite/compiler.h
+++ b/include/treelite/compiler.h
@@ -13,6 +13,8 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <vector>
+#include <utility>
 
 namespace treelite {
 

--- a/include/treelite/compiler.h
+++ b/include/treelite/compiler.h
@@ -23,8 +23,27 @@ namespace compiler {
 struct CompilerParam;  // forward declaration
 
 struct CompiledModel {
+  struct FileEntry {
+    std::string content;
+    std::vector<char> content_binary;
+    bool is_binary;
+    FileEntry() : is_binary(false) {}
+    // Passing std::vector<char> indicates binary data
+    // Passing std::string indicates text data
+    // Use move constructor and assignment exclusively to save memory
+    explicit FileEntry(const std::string& content) = delete;
+    explicit FileEntry(std::string&& content)
+      : content(std::move(content)), is_binary(false) {}
+    explicit FileEntry(const std::vector<char>&) = delete;
+    explicit FileEntry(std::vector<char>&& content)
+      : content_binary(std::move(content)), is_binary(true) {}
+    FileEntry(const FileEntry& other) = delete;
+    FileEntry(FileEntry&& other) = default;
+    FileEntry& operator=(const FileEntry& other) = delete;
+    FileEntry& operator=(FileEntry&& other) = default;
+  };
   std::string backend;
-  std::unordered_map<std::string, std::string> files;
+  std::unordered_map<std::string, FileEntry> files;
   std::string file_prefix;
 };
 

--- a/python/treelite/contrib/__init__.py
+++ b/python/treelite/contrib/__init__.py
@@ -75,10 +75,10 @@ def generate_makefile(dirpath, platform, toolchain, options=None):
   obj_ext = _obj_ext()
 
   with open(os.path.join(dirpath, 'Makefile'), 'w') as f:
-    f.write('{}: {}\n'.format(recipe['target'] + lib_ext,
-                              ' '.join([x['name'] + obj_ext \
-                                        for x in recipe['sources']])))
-    f.write('\t{}\n'.format(_lib_cmd(sources=recipe['sources'],
+    objects = [x['name'] + obj_ext for x in recipe['sources']] \
+              + recipe.get('extra', [])
+    f.write('{}: {}\n'.format(recipe['target'] + lib_ext, ' '.join(objects)))
+    f.write('\t{}\n'.format(_lib_cmd(objects=objects,
                                      target=recipe['target'],
                                      lib_ext=lib_ext,
                                      toolchain=toolchain,

--- a/python/treelite/contrib/gcc.py
+++ b/python/treelite/contrib/gcc.py
@@ -17,13 +17,11 @@ def _obj_cmd(source, toolchain, options):
   return '{} -c -O3 -o {} {} -fPIC -std=c99 {}'\
          .format(toolchain, source + obj_ext, source + '.c', ' '.join(options))
 
-def _lib_cmd(sources, target, lib_ext, toolchain, options):
+def _lib_cmd(objects, target, lib_ext, toolchain, options):
   obj_ext = _obj_ext()
   return '{} -shared -O3 -o {} {} -std=c99 {}'\
-          .format(toolchain,
-                  target + lib_ext,
-                  ' '.join([x['name'] + obj_ext for x in sources]),
-                  ' '.join(options))
+          .format(toolchain, target + lib_ext,
+                  ' '.join(objects), ' '.join(options))
 
 def _create_shared(dirpath, toolchain, recipe, nthread, options, verbose):
   options += ['-lm']
@@ -33,8 +31,8 @@ def _create_shared(dirpath, toolchain, recipe, nthread, options, verbose):
   # pylint: disable=C0111
   def obj_cmd(source):
     return _obj_cmd(source, toolchain, options)
-  def lib_cmd(sources, target):
-    return _lib_cmd(sources, target, LIBEXT, toolchain, options)
+  def lib_cmd(objects, target):
+    return _lib_cmd(objects, target, LIBEXT, toolchain, options)
   recipe['create_object_cmd'] = obj_cmd
   recipe['create_library_cmd'] = lib_cmd
   recipe['initial_cmd'] = ''

--- a/python/treelite/contrib/gcc.py
+++ b/python/treelite/contrib/gcc.py
@@ -18,7 +18,6 @@ def _obj_cmd(source, toolchain, options):
          .format(toolchain, source + obj_ext, source + '.c', ' '.join(options))
 
 def _lib_cmd(objects, target, lib_ext, toolchain, options):
-  obj_ext = _obj_ext()
   return '{} -shared -O3 -o {} {} -std=c99 {}'\
           .format(toolchain, target + lib_ext,
                   ' '.join(objects), ' '.join(options))

--- a/python/treelite/contrib/msvc.py
+++ b/python/treelite/contrib/msvc.py
@@ -64,12 +64,10 @@ def _obj_cmd(source, toolchain, options):
           .format(source + '.c', ' '.join(options))
 
 # pylint: disable=W0613
-def _lib_cmd(sources, target, lib_ext, toolchain, options):
+def _lib_cmd(objects, target, lib_ext, toolchain, options):
   obj_ext = _obj_ext()
   return 'cl.exe /LD /Fe{} /openmp {} {}'\
-          .format(target,
-                  ' '.join([x['name'] + obj_ext for x in sources]),
-                  ' '.join(options))
+          .format(target, ' '.join(objects), ' '.join(options))
 
 # pylint: disable=R0913
 def _create_shared(dirpath, toolchain, recipe, nthread, options, verbose):
@@ -79,8 +77,8 @@ def _create_shared(dirpath, toolchain, recipe, nthread, options, verbose):
   # pylint: disable=C0111
   def obj_cmd(source):
     return _obj_cmd(source, toolchain, options)
-  def lib_cmd(sources, target):
-    return _lib_cmd(sources, target, LIBEXT, toolchain, options)
+  def lib_cmd(objects, target):
+    return _lib_cmd(objects, target, LIBEXT, toolchain, options)
   recipe['create_object_cmd'] = obj_cmd
   recipe['create_library_cmd'] = lib_cmd
   recipe['initial_cmd'] = '\"{}\" {}\n'\

--- a/python/treelite/contrib/msvc.py
+++ b/python/treelite/contrib/msvc.py
@@ -65,7 +65,6 @@ def _obj_cmd(source, toolchain, options):
 
 # pylint: disable=W0613
 def _lib_cmd(objects, target, lib_ext, toolchain, options):
-  obj_ext = _obj_ext()
   return 'cl.exe /LD /Fe{} /openmp {} {}'\
           .format(target, ' '.join(objects), ' '.join(options))
 

--- a/python/treelite/contrib/util.py
+++ b/python/treelite/contrib/util.py
@@ -128,9 +128,11 @@ def _create_shared_base(dirpath, recipe, nthread, verbose):
               .format(
                   os.path.join(dirpath,
                                recipe['target'] + recipe['library_ext'])))
+  objects = [x['name'] + recipe['object_ext'] for x in recipe['sources']] \
+            + recipe.get('extra', [])
   workqueue = {
       'tid': 0,
-      'queue': [lib_cmd(recipe['sources'], recipe['target'])],
+      'queue': [lib_cmd(objects, recipe['target'])],
       'dirpath': os.path.abspath(dirpath),
       'init_cmd': recipe['initial_cmd'],
       'create_log_cmd': create_log_cmd,

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -291,7 +291,11 @@ int TreeliteCompilerGenerateCode(CompilerHandle compiler,
       LOG(INFO) << "Writing file " << it.first << "...";
     }
     const std::string filename_full = dirpath_ + "/" + it.first;
-    common::WriteToFile(filename_full, it.second);
+    if (it.second.is_binary) {
+      common::WriteToFile(filename_full, it.second.content_binary);
+    } else {
+      common::WriteToFile(filename_full, it.second.content);
+    }
   }
 
   API_END();

--- a/src/compiler/ast_native.cc
+++ b/src/compiler/ast_native.cc
@@ -43,6 +43,10 @@ class ASTNativeCompiler : public Compiler {
     if (param.verbose > 0) {
       LOG(INFO) << "Using ASTNativeCompiler";
     }
+    if (param.dump_array_as_elf > 0) {
+      LOG(INFO) << "Warning: 'dump_array_as_elf' parameter is not applicable "
+                   "for ASTNativeCompiler";
+    }
   }
 
   CompiledModel Compile(const Model& model) override {

--- a/src/compiler/elf/elf_formatter.cc
+++ b/src/compiler/elf/elf_formatter.cc
@@ -5,7 +5,6 @@
  * \brief Generate a relocatable object file containing a constant, read-only array
  */
 #include <dmlc/registry.h>
-#include <elf.h>
 #include <fstream>
 #include <iterator>
 #include <stdexcept>
@@ -15,6 +14,8 @@
 #include "./elf_formatter.h"
 
 #ifdef __linux__
+
+#include <elf.h>
 
 namespace {
 

--- a/src/compiler/elf/elf_formatter.cc
+++ b/src/compiler/elf/elf_formatter.cc
@@ -139,6 +139,9 @@ void FormatArrayAsELF(std::vector<char>* elf_buffer) {
     { 1,   SHT_SYMTAB,                       0x0, 0x0, 0x0,   sizeof(symtab), 8, 8,  8, 24},
     { 9,   SHT_STRTAB,                       0x0, 0x0, 0x0,   sizeof(strtab), 0, 0,  1,  0},
     {17,   SHT_STRTAB,                       0x0, 0x0, 0x0, sizeof(shstrtab), 0, 0,  1,  0}
+    // Sections listed: (null)  .text     .data  .bss  .rodata  .comment  .note.GNU-stack  .symtab
+    //                  .strtab .shstrtab
+    // Note that some sections are not actually present in the object (thus has size zero).
   };
   // Compute offsets via cumulative sums
   section_header[1].sh_offset = 0x40;

--- a/src/compiler/elf/elf_formatter.cc
+++ b/src/compiler/elf/elf_formatter.cc
@@ -1,0 +1,191 @@
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file elf_formatter.cc
+ * \author Philip Cho
+ * \brief Generate a relocatable object file containing a constant, read-only array
+ */
+#include <dmlc/registry.h>
+#include <fstream>
+#include <iterator>
+#include <stdexcept>
+#include <vector>
+#include <cstdio>
+#include <cstring>
+#include <elf.h>
+#include "./elf_formatter.h"
+
+namespace {
+
+const char ident_str[EI_NIDENT] = {
+   ELFMAG0, ELFMAG1, ELFMAG2, ELFMAG3,             // magic string: 0x7F, "ELF"
+   ELFCLASS64, ELFDATA2LSB,                        // EI_CLASS, EI_DATA: 64-bit, little-endian
+   EV_CURRENT,                                     // EI_VERSION: ELF version 1
+   ELFOSABI_NONE,                                  // EI_OSABI: System V ABI or unspecified
+   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // EI_PAD: reserved
+};
+
+void AppendToBuffer(std::vector<char>* dest, const void* src, size_t count) {
+  const size_t beg = dest->size();
+  dest->resize(beg + count);
+  std::memcpy(dest->data() + beg, src, count);
+}
+
+}   // anonymous namespace
+
+namespace treelite {
+namespace compiler {
+
+DMLC_REGISTRY_FILE_TAG(elf_formatter);
+
+void AllocateELFHeader(std::vector<char>* elf_buffer) {
+  elf_buffer->resize(elf_buffer->size() + sizeof(Elf64_Ehdr));
+}
+
+void FormatArrayAsELF(std::vector<char>* elf_buffer) {
+  const size_t array_size = elf_buffer->size() - sizeof(Elf64_Ehdr);
+
+  /* Format compiler information string */
+  const char comment[] = "\0GCC: (Ubuntu 7.4.0-1ubuntu1~18.04.1) 7.4.0\0\0\0\0";
+    // padding added at the end so that the following section (.symtab) is 8-byte aligned.
+  const size_t comment_padding = 4;  // remember how many NUL letters we added for padding
+  static_assert(sizeof(comment) == 48, ".comment section has incorrect size");
+
+  /* Format symbol table */
+  const Elf64_Sym symtab[] = {
+    // Each symbol entry is of form {st_name, st_info, st_other, st_shndx, st_value, st_size}
+    // * st_name:  Symbol name. The symbol name is given by the null-terminated string that starts
+    //             at &strtab[st_name].
+    // * st_info:  Symbol's type and binding attributes
+    // * st_other: Symbol visibility (we'll use STV_DEFAULT for all entries)
+    // * st_shndx: Index of the section associated with the symbol
+    //             (SHN_UNDEF: no section associated. SHN_ABS: index of file entry, by convention)
+    // * st_value: Address associated with the symbol (we'll set this to 0 for all entries, since
+    //             the object file is relocatable.)
+    // * st_size:  Size (in bytes) of the symbol
+    { 0, ELF64_ST_INFO(STB_LOCAL,  STT_NOTYPE), STV_DEFAULT, SHN_UNDEF, 0,          0},
+    { 1, ELF64_ST_INFO(STB_LOCAL,    STT_FILE), STV_DEFAULT,   SHN_ABS, 0,          0},
+    { 0, ELF64_ST_INFO(STB_LOCAL, STT_SECTION), STV_DEFAULT,         1, 0,          0},
+    { 0, ELF64_ST_INFO(STB_LOCAL, STT_SECTION), STV_DEFAULT,         2, 0,          0},
+    { 0, ELF64_ST_INFO(STB_LOCAL, STT_SECTION), STV_DEFAULT,         3, 0,          0},
+    { 0, ELF64_ST_INFO(STB_LOCAL, STT_SECTION), STV_DEFAULT,         4, 0,          0},
+    { 0, ELF64_ST_INFO(STB_LOCAL, STT_SECTION), STV_DEFAULT,         6, 0,          0},
+    { 0, ELF64_ST_INFO(STB_LOCAL, STT_SECTION), STV_DEFAULT,         5, 0,          0},
+    {10, ELF64_ST_INFO(STB_GLOBAL, STT_OBJECT), STV_DEFAULT,         4, 0, array_size},
+  };
+  static_assert(sizeof(symtab) == 216, ".symtab has incorrect size");
+
+  /* Format symbol name table */
+  const char strtab[] = "\0arrays.c\0nodes";
+  static_assert(sizeof(strtab) == 16, ".strtab has incorrect size");
+
+  /* Format section name table */
+  const char shstrtab[] = "\0.symtab\0.strtab\0.shstrtab\0.text\0.data\0.bss\0.rodata\0.comment\0"
+                          ".note.GNU-stack\0\0\0";
+    // padding added at the end to ensure 4-byte alignment everywhere
+  const size_t shstrtab_padding = 3;  // remember how many NUL letters we added for padding
+  static_assert(sizeof(shstrtab) == 80, ".shstrtab has incorrect size");
+
+  /* Format ELF header */
+  Elf64_Ehdr elf_header;
+  // Compute e_shoff, section header table's offset.
+  const size_t e_shoff = sizeof(elf_header) + array_size + sizeof(comment)
+                         + sizeof(symtab) + sizeof(strtab) + sizeof(shstrtab);
+            
+  std::memcpy(elf_header.e_ident, ident_str, EI_NIDENT);
+  elf_header.e_type = ET_REL;        // A relocatable (object) file
+  elf_header.e_machine = EM_X86_64;  // AMD64 architecture target
+  elf_header.e_version = EV_CURRENT; // ELF version 1
+  elf_header.e_entry = 0;            // Set to zero because there's no entry point
+  elf_header.e_phoff = 0;            // Set to zero because there's no program header table
+  elf_header.e_shoff = e_shoff;      // Section header table's offset
+  elf_header.e_flags = 0;            // Reserved
+  elf_header.e_ehsize = 64;          // Size of ELF header (in bytes)
+  elf_header.e_phentsize = 0;        // Set to zero because there's no program header table
+  elf_header.e_phnum = 0;            // Set to zero because there's no program header table
+  elf_header.e_shentsize = 64;       // Size of each section header (in bytes)
+  elf_header.e_shnum = 10;           // Number of section headers
+  elf_header.e_shstrndx = 9;         // Index (in section header table) of the section storing 
+                                     // string representation of all section names
+                                     // In this case, the last section stores name of all sections
+
+  /* Format section header table */
+  Elf64_Shdr section_header[] = {
+    // Each section header is of form {sh_name, sh_type, sh_flags, sh_addr, sh_offset, sh_size,
+    //                                 sh_link, sh_info, sh_addralign, sh_entsize}
+    // * sh_name:      Section name. The section name is given by the null-terminated string that
+    //                 starts at &shstrtab[sh_name].
+    // * sh_type:      Type of section
+    // * sh_flags:     Miscellaneous attributes
+    // * sh_addr:      Address of the first byte of the section (we'll set this to 0 for all
+    //                 sections, since the object file is relocatable.)
+    // * sh_offset:    Byte offset from the beginning of the object file to the first byte in the
+    //                 section
+    // * sh_size:      Size of section in bytes
+    // * sh_link:      Interpretation of this field depends on the section type
+    //                 See https://www.sco.com/developers/gabi/1998-04-29/ch4.sheader.html#sh_link
+    // * sh_info:      Interpretation of this field depends on the section type
+    //                 See https://www.sco.com/developers/gabi/1998-04-29/ch4.sheader.html#sh_link
+    // * sh_addralign: Alignment constraint for the section. This must be a power of 2. A value of
+    //                 0 or 1 indicates the lack of alignment constraint.
+    // * sh_entsize:   Size of each entry in a table (in bytes). This is only applicable if the 
+    //                 section is a table of some kind (e.g. symbol table).
+    { 0,     SHT_NULL,                       0x0, 0x0, 0x0,                0, 0, 0,  0,  0},
+    {27, SHT_PROGBITS, SHF_ALLOC | SHF_EXECINSTR, 0x0, 0x0,                0, 0, 0,  1,  0}, 
+    {33, SHT_PROGBITS,     SHF_WRITE | SHF_ALLOC, 0x0, 0x0,                0, 0, 0,  1,  0},
+    {39,   SHT_NOBITS,     SHF_WRITE | SHF_ALLOC, 0x0, 0x0,                0, 0, 0,  1,  0},
+    {44, SHT_PROGBITS,                 SHF_ALLOC, 0x0, 0x0,       array_size, 0, 0, 32,  0},
+    {52, SHT_PROGBITS,   SHF_MERGE | SHF_STRINGS, 0x0, 0x0,  sizeof(comment), 0, 0,  1,  1},
+    {61, SHT_PROGBITS,                       0x0, 0x0, 0x0,                0, 0, 0,  1,  0},
+    { 1,   SHT_SYMTAB,                       0x0, 0x0, 0x0,   sizeof(symtab), 8, 8,  8, 24},
+    { 9,   SHT_STRTAB,                       0x0, 0x0, 0x0,   sizeof(strtab), 0, 0,  1,  0},
+    {17,   SHT_STRTAB,                       0x0, 0x0, 0x0, sizeof(shstrtab), 0, 0,  1,  0}
+  };
+  // Compute offsets via cumulative sums
+  section_header[1].sh_offset = 0x40;
+  for (size_t i = 2; i < sizeof(section_header) / sizeof(Elf64_Shdr); ++i) {
+    section_header[i].sh_offset = section_header[i - 1].sh_offset + section_header[i - 1].sh_size;
+  }
+  // Adjust size info so that padding is excluded
+  section_header[5].sh_size -= comment_padding;
+  section_header[6].sh_offset -= comment_padding;
+  section_header[9].sh_size -= shstrtab_padding;
+
+  /**
+   * Structure of ELF relocatable object file
+   *
+   * +---------------------------------+
+   * | ELF Header                      |
+   * +---------------------------------+
+   * | .rodata (read-only data)        |
+   * +---------------------------------+
+   * | .comment (compiler information) |
+   * +---------------------------------+
+   * | .symtab (symbol table)          |
+   * +---------------------------------+
+   * | .strtab (symbol name table)     |
+   * +---------------------------------+
+   * | .shstrtab (section name table)  |
+   * +---------------------------------+
+   * | Section headers                 |
+   * +---------------------------------+
+   *
+   **/
+
+  /* Write ELF header */
+  std::memcpy(elf_buffer->data(), &elf_header, sizeof(Elf64_Ehdr));
+    // elf_buffer already has a placeholder for the ELF header
+  /* .rodata (read-only data) segment is already part of elf_buffer */
+  /* Write .comment (compiler information) segment */
+  AppendToBuffer(elf_buffer, comment, sizeof(comment));
+  /* Write .symtab (symbol table) segment */
+  AppendToBuffer(elf_buffer, symtab, sizeof(symtab));
+  /* Write .strtab (symbol name table) segment */
+  AppendToBuffer(elf_buffer, strtab, sizeof(strtab));
+  /* Write .shstrtab (section name table) segment (referred by elf_header.e_shstrndx) */
+  AppendToBuffer(elf_buffer, shstrtab, sizeof(shstrtab));
+  /* Write section headers */
+  AppendToBuffer(elf_buffer, section_header, sizeof(section_header));
+}
+
+}  // namespace compiler
+}  // namespace treelite

--- a/src/compiler/elf/elf_formatter.cc
+++ b/src/compiler/elf/elf_formatter.cc
@@ -5,13 +5,13 @@
  * \brief Generate a relocatable object file containing a constant, read-only array
  */
 #include <dmlc/registry.h>
+#include <elf.h>
 #include <fstream>
 #include <iterator>
 #include <stdexcept>
 #include <vector>
 #include <cstdio>
 #include <cstring>
-#include <elf.h>
 #include "./elf_formatter.h"
 
 namespace {
@@ -19,11 +19,11 @@ namespace {
 const unsigned int SHF_X86_64_LARGE = 0x10000000;
 
 const char ident_str[EI_NIDENT] = {
-   ELFMAG0, ELFMAG1, ELFMAG2, ELFMAG3,             // magic string: 0x7F, "ELF"
-   ELFCLASS64, ELFDATA2LSB,                        // EI_CLASS, EI_DATA: 64-bit, little-endian
-   EV_CURRENT,                                     // EI_VERSION: ELF version 1
-   ELFOSABI_NONE,                                  // EI_OSABI: System V ABI or unspecified
-   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // EI_PAD: reserved
+  ELFMAG0, ELFMAG1, ELFMAG2, ELFMAG3,             // magic string: 0x7F, "ELF"
+  ELFCLASS64, ELFDATA2LSB,                        // EI_CLASS, EI_DATA: 64-bit, little-endian
+  EV_CURRENT,                                     // EI_VERSION: ELF version 1
+  ELFOSABI_NONE,                                  // EI_OSABI: System V ABI or unspecified
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // EI_PAD: reserved
 };
 
 void AppendToBuffer(std::vector<char>* dest, const void* src, size_t count) {
@@ -94,21 +94,21 @@ void FormatArrayAsELF(std::vector<char>* elf_buffer) {
                          + sizeof(symtab) + sizeof(strtab) + sizeof(shstrtab);
 
   std::memcpy(elf_header.e_ident, ident_str, EI_NIDENT);
-  elf_header.e_type = ET_REL;        // A relocatable (object) file
-  elf_header.e_machine = EM_X86_64;  // AMD64 architecture target
-  elf_header.e_version = EV_CURRENT; // ELF version 1
-  elf_header.e_entry = 0;            // Set to zero because there's no entry point
-  elf_header.e_phoff = 0;            // Set to zero because there's no program header table
-  elf_header.e_shoff = e_shoff;      // Section header table's offset
-  elf_header.e_flags = 0;            // Reserved
-  elf_header.e_ehsize = 64;          // Size of ELF header (in bytes)
-  elf_header.e_phentsize = 0;        // Set to zero because there's no program header table
-  elf_header.e_phnum = 0;            // Set to zero because there's no program header table
-  elf_header.e_shentsize = 64;       // Size of each section header (in bytes)
-  elf_header.e_shnum = 10;           // Number of section headers
-  elf_header.e_shstrndx = 9;         // Index (in section header table) of the section storing
-                                     // string representation of all section names
-                                     // In this case, the last section stores name of all sections
+  elf_header.e_type = ET_REL;         // A relocatable (object) file
+  elf_header.e_machine = EM_X86_64;   // AMD64 architecture target
+  elf_header.e_version = EV_CURRENT;  // ELF version 1
+  elf_header.e_entry = 0;             // Set to zero because there's no entry point
+  elf_header.e_phoff = 0;             // Set to zero because there's no program header table
+  elf_header.e_shoff = e_shoff;       // Section header table's offset
+  elf_header.e_flags = 0;             // Reserved
+  elf_header.e_ehsize = 64;           // Size of ELF header (in bytes)
+  elf_header.e_phentsize = 0;         // Set to zero because there's no program header table
+  elf_header.e_phnum = 0;             // Set to zero because there's no program header table
+  elf_header.e_shentsize = 64;        // Size of each section header (in bytes)
+  elf_header.e_shnum = 10;            // Number of section headers
+  elf_header.e_shstrndx = 9;          // Index (in section header table) of the section storing
+                                      // string representation of all section names
+                                      // In this case, the last section stores name of all sections
 
   /* Format section header table */
   Elf64_Shdr section_header[] = {

--- a/src/compiler/elf/elf_formatter.cc
+++ b/src/compiler/elf/elf_formatter.cc
@@ -14,6 +14,8 @@
 #include <cstring>
 #include "./elf_formatter.h"
 
+#ifdef __linux__
+
 namespace {
 
 const unsigned int SHF_X86_64_LARGE = 0x10000000;
@@ -197,3 +199,21 @@ void FormatArrayAsELF(std::vector<char>* elf_buffer) {
 
 }  // namespace compiler
 }  // namespace treelite
+
+#else  // __linux__
+
+namespace treelite {
+namespace compiler {
+
+void AllocateELFHeader(std::vector<char>* elf_buffer) {
+  LOG(FATAL) << "dump_array_as_elf is not supported in non-Linux OSes";
+}
+
+void FormatArrayAsELF(std::vector<char>* elf_buffer) {
+  LOG(FATAL) << "dump_array_as_elf is not supported in non-Linux OSes";
+}
+
+}  // namespace compiler
+}  // namespace treelite
+
+#endif  // __linux__

--- a/src/compiler/elf/elf_formatter.h
+++ b/src/compiler/elf/elf_formatter.h
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file elf_formatter.h
+ * \author Philip Cho
+ * \brief Generate a relocatable object file containing a constant, read-only array
+ */
+#ifndef TREELITE_COMPILER_ELF_ELF_FORMATTER_H_
+#define TREELITE_COMPILER_ELF_ELF_FORMATTER_H_
+
+#include <vector>
+
+namespace treelite {
+namespace compiler {
+
+/*!
+ * \brief Pre-allocate space in a buffer to fit an ELF header
+ * \param elf Buffer in which space will be allocated
+ */
+void AllocateELFHeader(std::vector<char>* elf);
+/*!
+ * \brief Format a relocatable ELF object file containing a constant, read-only array
+ * \param elf When the function is invoked, elf should contain 1) empty bytes that have been
+ *            allocated with a call to AllocateELFHeader(); followed by 2) bytes representing the
+ *            content of the array. The FormatArrayAsELF() function will then modify elf, so that
+ *            at the end, elf will contain a valid ELF relocatable object. Two modification will
+ *            take place: 1) The preceding empty bytes in elf will be overwritten with a validc ELF
+ *            header; and 2) symbol table, section headers, and other various sections will be
+ *            appended after the array bytes.
+ */
+void FormatArrayAsELF(std::vector<char>* elf);
+
+}  // namespace compiler
+}  // namespace treelite
+
+#endif  // TREELITE_COMPILER_ELF_ELF_FORMATTER_H_

--- a/src/compiler/failsafe.cc
+++ b/src/compiler/failsafe.cc
@@ -174,7 +174,7 @@ inline std::pair<std::string, std::string> FormatNodesArray(const treelite::Mode
 // Variant of FormatNodesArray(), where nodes[] array is dumped as an ELF binary
 inline std::pair<std::vector<char>, std::string> FormatNodesArrayELF(const treelite::Model& model) {
   std::vector<char> nodes_elf;
-  treelite::compiler::AllocateELFHeader(&nodes_elf); 
+  treelite::compiler::AllocateELFHeader(&nodes_elf);
 
   treelite::common::ArrayFormatter nodes_row_ptr(100, 2);
   NodeStructValue val;

--- a/src/compiler/failsafe.cc
+++ b/src/compiler/failsafe.cc
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017 by Contributors
+ * Copyright (c) 2019 by Contributors
  * \file failsafe.cc
  * \author Philip Cho
  * \brief C code generator (fail-safe). The generated code will mimic prediction

--- a/src/compiler/param.h
+++ b/src/compiler/param.h
@@ -42,6 +42,11 @@ struct CompilerParam : public dmlc::Parameter<CompilerParam> {
              folded. To diable folding, set to +inf. If hessian sums are
              available, they will be used as proxies of data counts. */
   double code_folding_req;
+  /*! \brief Only applicable when compiler is set to ``failsafe``. If set to a positive value,
+             the fail-safe compiler will not emit large constant arrays to the C code. Instead,
+             the arrays will be emitted as an ELF binary (Linux only). For large arrays, it is
+             much faster to directly dump ELF binaries than to pass them to a C compiler. */
+  int dump_array_as_elf;
   /*! \} */
 
   // declare parameters
@@ -60,6 +65,7 @@ struct CompilerParam : public dmlc::Parameter<CompilerParam> {
     DMLC_DECLARE_FIELD(code_folding_req)
        .set_default(std::numeric_limits<double>::infinity())
        .set_lower_bound(0);
+    DMLC_DECLARE_FIELD(dump_array_as_elf).set_lower_bound(0).set_default(0);
   }
 };
 

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -2,6 +2,7 @@
 """Suite of basic tests"""
 from __future__ import print_function
 import unittest
+import sys
 import os
 import subprocess
 from zipfile import ZipFile
@@ -22,6 +23,9 @@ class TestBasic(unittest.TestCase):
     Test a basic workflow: load a model, compile and export as shared lib,
     and make predictions
     """
+
+    is_linux = sys.platform.startswith('linux')
+
     for model_path, dtrain_path, dtest_path, libname_fmt, \
         expected_prob_path, expected_margin_path, multiclass in \
         [('mushroom/mushroom.model', 'mushroom/agaricus.train',
@@ -46,13 +50,23 @@ class TestBasic(unittest.TestCase):
                               multiclass=multiclass, use_annotation=use_annotation,
                               use_quantize=use_quantize,
                               use_parallel_comp=use_parallel_comp)
-      for use_elf in [True, False]:
+      for use_elf in [True, False] if is_linux else [False]:
         run_pipeline_test(model=model, dtest_path=dtest_path,
                           libname_fmt=libname_fmt,
                           expected_prob_path=expected_prob_path,
                           expected_margin_path=expected_margin_path,
                           multiclass=multiclass, use_elf=use_elf,
                           use_compiler='failsafe')
+      if not is_linux:
+        # Expect to see an exception when using ELF in non-Linux OS
+        with pytest.raises(treelite.TreeliteError):
+          run_pipeline_test(model=model, dtest_path=dtest_path,
+                            libname_fmt=libname_fmt,
+                            expected_prob_path=expected_prob_path,
+                            expected_margin_path=expected_margin_path,
+                            multiclass=multiclass, use_elf=True,
+                            use_compiler='failsafe')
+
     # LETOR
     model_path = os.path.join(dpath, 'letor/mq2008.model')
     model = treelite.Model.load(model_path, model_format='xgboost')
@@ -69,7 +83,8 @@ class TestBasic(unittest.TestCase):
                       libname_fmt='./mq2008{}',
                       expected_prob_path=None,
                       expected_margin_path='letor/mq2008.test.pred',
-                      multiclass=False, use_compiler='failsafe')
+                      multiclass=False, use_elf=is_linux,
+                      use_compiler='failsafe')
 
   def test_srcpkg(self):
     """Test feature to export a source tarball"""

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -46,11 +46,13 @@ class TestBasic(unittest.TestCase):
                               multiclass=multiclass, use_annotation=use_annotation,
                               use_quantize=use_quantize,
                               use_parallel_comp=use_parallel_comp)
-      run_pipeline_test(model=model, dtest_path=dtest_path,
-                        libname_fmt=libname_fmt,
-                        expected_prob_path=expected_prob_path,
-                        expected_margin_path=expected_margin_path,
-                        multiclass=multiclass, use_compiler='failsafe')
+      for use_elf in [True, False]:
+        run_pipeline_test(model=model, dtest_path=dtest_path,
+                          libname_fmt=libname_fmt,
+                          expected_prob_path=expected_prob_path,
+                          expected_margin_path=expected_margin_path,
+                          multiclass=multiclass, use_elf=use_elf,
+                          use_compiler='failsafe')
     # LETOR
     model_path = os.path.join(dpath, 'letor/mq2008.model')
     model = treelite.Model.load(model_path, model_format='xgboost')

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -59,7 +59,7 @@ class TestBasic(unittest.TestCase):
                           use_compiler='failsafe')
       if not is_linux:
         # Expect to see an exception when using ELF in non-Linux OS
-        with pytest.raises(treelite.TreeliteError):
+        with pytest.raises(treelite.common.util.TreeliteError):
           run_pipeline_test(model=model, dtest_path=dtest_path,
                             libname_fmt=libname_fmt,
                             expected_prob_path=expected_prob_path,

--- a/tests/python/util.py
+++ b/tests/python/util.py
@@ -89,7 +89,7 @@ def run_pipeline_test(model, dtest_path, libname_fmt,
                       expected_prob_path, expected_margin_path,
                       multiclass, use_annotation=None, use_quantize=None,
                       use_parallel_comp=None, use_code_folding=None,
-                      use_toolchains=None, use_elf=None, use_compiler=None):
+                      use_toolchains=None, use_elf=False, use_compiler=None):
   dpath = os.path.abspath(os.path.join(os.getcwd(), 'tests/examples/'))
   dtest_path = os.path.join(dpath, dtest_path)
   libpath = libname(libname_fmt)
@@ -115,7 +115,7 @@ def run_pipeline_test(model, dtest_path, libname_fmt,
     params['parallel_comp'] = use_parallel_comp
   if use_code_folding is not None:
     params['code_folding_req'] = use_code_folding
-  if use_elf is not None:
+  if use_elf:
     params['dump_array_as_elf'] = 1
   if use_compiler is None:
     import inspect

--- a/tests/python/util.py
+++ b/tests/python/util.py
@@ -89,7 +89,7 @@ def run_pipeline_test(model, dtest_path, libname_fmt,
                       expected_prob_path, expected_margin_path,
                       multiclass, use_annotation=None, use_quantize=None,
                       use_parallel_comp=None, use_code_folding=None,
-                      use_toolchains=None, use_compiler=None):
+                      use_toolchains=None, use_elf=None, use_compiler=None):
   dpath = os.path.abspath(os.path.join(os.getcwd(), 'tests/examples/'))
   dtest_path = os.path.join(dpath, dtest_path)
   libpath = libname(libname_fmt)
@@ -115,6 +115,8 @@ def run_pipeline_test(model, dtest_path, libname_fmt,
     params['parallel_comp'] = use_parallel_comp
   if use_code_folding is not None:
     params['code_folding_req'] = use_code_folding
+  if use_elf is not None:
+    params['dump_array_as_elf'] = 1
   if use_compiler is None:
     import inspect
     use_compiler \


### PR DESCRIPTION
**Rationale**

As pointed out in #114, it takes a long time for GCC to parse and compile a large array definition, particularly when the array exceeds 1 GB. The reason is that GCC needs to parse the text representation of the array elements. This is wasteful, since we are performing a full round-trip from float values to text, and to float values again:
```
                     FailSafeCompiler                    GCC
float values (in memory) =========> text (in arrays.c) ======> float values (in arrays.o)
```

Great savings are to be had if we eliminate the round trip to text and have the codegen produce an ELF binary directly.
```
                     FailSafeCompiler  
float values (in memory) =========> float values (in arrays.o)
```

**Usage**: Just set `dump_array_as_elf=1`.

```python
import treelite
model = treelite.Model.load(model_file, 'xgboost')
model.export_lib('gcc', 'predictor.so', compiler='failsafe',
                 params={'dump_array_as_elf': 1})
```

Compilation time for a 20k-tree example (339MB in disk)
* Fail-safe codegen : 129.71 s
* Fail-safe codegen with `dump_array_as_elf=1`: **1.85 s**