### PR TITLE
install runtime headers at a non-conflicting location (issue #120)

### DIFF
--- a/runtime/native/CMakeLists.txt
+++ b/runtime/native/CMakeLists.txt
@@ -96,5 +96,5 @@ else()
           LIBRARY DESTINATION lib)
 endif()
 
-install(DIRECTORY include/treelite DESTINATION include
+install(DIRECTORY include/treelite DESTINATION runtime/native/include
         FILES_MATCHING PATTERN "*.h")


### PR DESCRIPTION
This PR proposes a solution for the issue described in #120 .
Tagging @hcho3 and @canonizer for the review and further discussions.