### PR TITLE
Install fmtlib headers in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,3 +149,5 @@ endif()
 
 install(DIRECTORY include/treelite DESTINATION include
         FILES_MATCHING PATTERN "*.h")
+install(DIRECTORY 3rdparty/fmt/fmt DESTINATION include/fmt
+        FILES_MATCHING PATTERN "*.h")


### PR DESCRIPTION
Closes #126.

@teju85 @canonizer @dantegd Please review.