### PR TITLE
Save libs relative to build folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ endif()
 # Shared library
 add_library(treelite $<TARGET_OBJECTS:objtreelite>)
 target_link_libraries(treelite ${LINK_LIBRARIES})
-set_output_directory(treelite ${PROJECT_SOURCE_DIR}/lib)
+set_output_directory(treelite ${CMAKE_BINARY_DIR}/lib)
 if(MINGW)
   # remove the 'lib' prefix to conform to windows convention for shared library names
   set_target_properties(treelite PROPERTIES PREFIX "")

--- a/docs/tutorials/deploy.rst
+++ b/docs/tutorials/deploy.rst
@@ -244,7 +244,7 @@ both archives ``mymodel.zip`` and ``treelite_runtime.zip``:
   [ 83%] Building CXX object CMakeFiles/objtreelite_runtime.dir/src/predictor.cc.o
   [ 83%] Built target objtreelite_runtime
   Scanning dependencies of target treelite_runtime
-  [100%] Linking CXX shared library ../lib/libtreelite_runtime.so
+  [100%] Linking CXX shared library ../../lib/libtreelite_runtime.so
   [100%] Built target treelite_runtime
   john.doe@target-machine:/home/john.doe/runtime/build/$ cd ../..
   john.doe@target-machine:/home/john.doe/$

--- a/python/treelite/libpath.py
+++ b/python/treelite/libpath.py
@@ -44,8 +44,10 @@ def find_lib_path(basename, libformat=True):
   # List possible locations for the library file
   dll_path = [curr_path,
               os.path.join(curr_path, '../../lib/'),
+              os.path.join(curr_path, '../../build/lib/'),
               os.path.join(curr_path, '../../runtime/native/lib/'),
               os.path.join(curr_path, './lib/'),
+              os.path.join(curr_path, './build/lib/'),
               os.path.join(sys.prefix, 'treelite'),
               os.path.join(site.USER_BASE, 'treelite')]
   # Windows hack: additional candidate locations

--- a/runtime/java/CMakeLists.txt
+++ b/runtime/java/CMakeLists.txt
@@ -69,9 +69,8 @@ endif()
 include_directories(${JNI_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/treelite4j/src/native ${PARENT_DIR}/native/include
                     ${GRANDPARENT_DIR}/dmlc-core/include)
 add_library(treelite4j SHARED $<TARGET_OBJECTS:objtreelite_runtime> treelite4j/src/native/treelite4j.cpp)
-set_output_directory(treelite4j ${PROJECT_SOURCE_DIR}/lib)
+set_output_directory(treelite4j ${CMAKE_BINARY_DIR}/lib)
 target_link_libraries(treelite4j ${LINK_LIBRARIES} ${JAVA_JVM_LIBRARY})
-set_output_directory(treelite4j ${PROJECT_SOURCE_DIR}/lib)
 if(MINGW)
   # remove the 'lib' prefix to conform to windows convention for shared library names
   set_target_properties(treelite4j PROPERTIES PREFIX "")

--- a/runtime/java/treelite4j/create_jni.py
+++ b/runtime/java/treelite4j/create_jni.py
@@ -82,7 +82,7 @@ if __name__ == "__main__":
     "linux": "libtreelite4j.so"
   }[sys.platform]
   maybe_makedirs("src/main/resources/lib")
-  cp("../lib/" + library_name, "src/main/resources/lib")
+  cp("../build/lib/" + library_name, "src/main/resources/lib")
 
   print("building mushroom example")
   with cd("src/test/resources/mushroom_example"):

--- a/runtime/native/CMakeLists.txt
+++ b/runtime/native/CMakeLists.txt
@@ -82,7 +82,7 @@ list(APPEND RUNTIME_LINK_LIBRARIES dmlc)
 # Shared library
 add_library(treelite_runtime SHARED $<TARGET_OBJECTS:objtreelite_runtime>)
 target_link_libraries(treelite_runtime ${RUNTIME_LINK_LIBRARIES})
-set_output_directory(treelite_runtime ${PROJECT_SOURCE_DIR}/lib)
+set_output_directory(treelite_runtime ${CMAKE_BINARY_DIR}/lib)
 if(MINGW)
   # remove the 'lib' prefix to conform to windows convention for shared library names
   set_target_properties(treelite_runtime PROPERTIES PREFIX "")

--- a/runtime/native/python/treelite_runtime/libpath.py
+++ b/runtime/native/python/treelite_runtime/libpath.py
@@ -45,8 +45,10 @@ def find_lib_path(basename, libformat=True):
   # List possible locations for the library file
   dll_path = [curr_path,
               os.path.join(curr_path, '../../lib/'),
+              os.path.join(curr_path, '../../build/lib/'),
               os.path.join(curr_path, '../../'),
               os.path.join(curr_path, './lib/'),
+              os.path.join(curr_path, './build/lib/'),
               os.path.join(sys.prefix, 'treelite'),
               os.path.join(site.USER_BASE, 'treelite')]
   # Windows hack: additional candidate locations


### PR DESCRIPTION
This is needed for cases when we simultaneously build project for different architectures. For Example when building the project using Android Gradle.

Libs location now:
```
./build/lib/libtreelite4j.so
./build/lib/libtreelite_runtime.so
./build/lib/libtreelite.so
```