### PR TITLE
make more model information available in runtime 

### DIFF
--- a/runtime/native/include/treelite/c_api_runtime.h
+++ b/runtime/native/include/treelite/c_api_runtime.h
@@ -184,6 +184,34 @@ TREELITE_DLL int TreelitePredictorQueryNumOutputGroup(PredictorHandle handle,
  */
 TREELITE_DLL int TreelitePredictorQueryNumFeature(PredictorHandle handle,
                                                   size_t* out);
+
+/*!
+ * \brief Get name of post prediction transformation used to train
+ *        the loaded model
+ * \param handle predictor
+ * \param out name of post prediction transformation
+ * \return 0 for success, -1 for failure
+ */
+TREELITE_DLL int TreelitePredictorQueryPredTransform(PredictorHandle handle,
+                                                     char** out);
+/*!
+ * \brief Get alpha value of sigmoid transformation used to train
+ *        the loaded model
+ * \param handle predictor
+ * \param out alpha value of sigmoid transformation
+ * \return 0 for success, -1 for failure
+ */
+TREELITE_DLL int TreelitePredictorQuerySigmoidAlpha(PredictorHandle handle,
+                                                    float* out);
+
+/*!
+ * \brief Get global bias which adjusting predicted margin scores
+ * \param handle predictor
+ * \param out global bias value
+ * \return 0 for success, -1 for failure
+ */
+TREELITE_DLL int TreelitePredictorQueryGlobalBias(PredictorHandle handle,
+                                                  float* out);
 /*!
  * \brief delete predictor from memory
  * \param handle predictor to remove

--- a/runtime/native/include/treelite/predictor.h
+++ b/runtime/native/include/treelite/predictor.h
@@ -177,14 +177,44 @@ class Predictor {
     return num_feature_;
   }
 
+  /*!
+   * \brief Get name of post prediction transformation used to train the loaded model
+   * \return name of prediction transformation
+   */
+  inline std::string QueryPredTransform() const {
+    return pred_transform_;
+  }
+
+  /*!
+   * \brief Get alpha value in sigmoid transformation used to train the loaded model
+   * \return alpha value in sigmoid transformation
+   */
+  inline float QuerySigmoidAlpha() const {
+    return sigmoid_alpha_;
+  }
+
+  /*!
+   * \brief Get global bias which adjusting predicted margin scores
+   * \return global bias
+   */
+  inline float QueryGlobalBias() const {
+    return global_bias_;
+  }
+
  private:
   LibraryHandle lib_handle_;
   QueryFuncHandle num_output_group_query_func_handle_;
   QueryFuncHandle num_feature_query_func_handle_;
+  QueryFuncHandle pred_transform_query_func_handle_;
+  QueryFuncHandle sigmoid_alpha_query_func_handle_;
+  QueryFuncHandle global_bias_query_func_handle_;
   PredFuncHandle pred_func_handle_;
   ThreadPoolHandle thread_pool_handle_;
   size_t num_output_group_;
   size_t num_feature_;
+  std::string pred_transform_;
+  float sigmoid_alpha_;
+  float global_bias_;
   int num_worker_thread_;
 
   bool using_remote_lib_;  // load lib from remote location?

--- a/runtime/native/python/treelite_runtime/predictor.py
+++ b/runtime/native/python/treelite_runtime/predictor.py
@@ -278,6 +278,24 @@ class Predictor(object):
         self.handle,
         ctypes.byref(num_output_group)))
     self.num_output_group_ = num_output_group.value
+    # save # of pred transform
+    pred_transform = ctypes.c_char_p()
+    _check_call(_LIB.TreelitePredictorQueryPredTransform(
+        self.handle,
+        ctypes.byref(pred_transform)))
+    self.pred_transform_ = bytes.decode(pred_transform.value)
+    # save # of sigmoid alpha
+    sigmoid_alpha = ctypes.c_float()
+    _check_call(_LIB.TreelitePredictorQuerySigmoidAlpha(
+        self.handle,
+        ctypes.byref(sigmoid_alpha)))
+    self.sigmoid_alpha_ = sigmoid_alpha.value
+    # save # of global bias
+    global_bias = ctypes.c_float()
+    _check_call(_LIB.TreelitePredictorQueryGlobalBias(
+        self.handle,
+        ctypes.byref(global_bias)))
+    self.global_bias_ = global_bias.value
 
     if verbose:
       log_info(__file__, lineno(),
@@ -415,5 +433,20 @@ class Predictor(object):
   def num_output_group(self):
     """Query number of output groups of the model"""
     return self.num_output_group_
+
+  @property
+  def pred_transform(self):
+    """Query pred transform of the model"""
+    return self.pred_transform_
+
+  @property
+  def global_bias(self):
+    """Query global bias of the model"""
+    return self.global_bias_
+
+  @property
+  def sigmoid_alpha(self):
+    """Query sigmoid alpha of the model"""
+    return self.sigmoid_alpha_
 
 __all__ = ['Predictor', 'Batch', '__version__']

--- a/runtime/native/src/c_api/c_api_runtime.cc
+++ b/runtime/native/src/c_api/c_api_runtime.cc
@@ -8,6 +8,7 @@
 #include <treelite/predictor.h>
 #include <treelite/c_api_runtime.h>
 #include <string>
+#include <cstring>
 #include "./c_api_error.h"
 
 using namespace treelite;
@@ -154,6 +155,29 @@ int TreelitePredictorQueryNumFeature(PredictorHandle handle, size_t* out) {
   API_BEGIN();
   const Predictor* predictor_ = static_cast<Predictor*>(handle);
   *out = predictor_->QueryNumFeature();
+  API_END();
+}
+
+int TreelitePredictorQueryPredTransform(PredictorHandle handle, char** out) {
+  API_BEGIN()
+  const Predictor* predictor_ = static_cast<Predictor*>(handle);
+  auto predTransform = predictor_->QueryPredTransform();
+  *out = new char[predTransform.length() + 1];
+  strcpy(*out, predTransform.c_str());
+  API_END();
+}
+
+int TreelitePredictorQuerySigmoidAlpha(PredictorHandle handle, float* out) {
+  API_BEGIN()
+  const Predictor* predictor_ = static_cast<Predictor*>(handle);
+  *out = predictor_->QuerySigmoidAlpha();
+  API_END();
+}
+
+int TreelitePredictorQueryGlobalBias(PredictorHandle handle, float* out) {
+  API_BEGIN()
+  const Predictor* predictor_ = static_cast<Predictor*>(handle);
+  *out = predictor_->QueryGlobalBias();
   API_END();
 }
 

--- a/src/compiler/ast_native.cc
+++ b/src/compiler/ast_native.cc
@@ -228,6 +228,12 @@ class ASTNativeCompiler : public Compiler {
           = get_num_output_group_function_signature,
         "get_num_feature_function_signature"_a
           = get_num_feature_function_signature,
+        "get_pred_transform_function_signature"_a
+          = get_pred_transform_function_signature,
+        "get_sigmoid_alpha_function_signature"_a
+          = get_sigmoid_alpha_function_signature,
+        "get_global_bias_function_signature"_a
+          = get_global_bias_function_signature,
         "predict_function_signature"_a = predict_function_signature,
         "threshold_type"_a = (param.quantize > 0 ? "int" : "double")),
       indent);

--- a/src/compiler/ast_native.cc
+++ b/src/compiler/ast_native.cc
@@ -55,6 +55,9 @@ class ASTNativeCompiler : public Compiler {
 
     num_feature_ = model.num_feature;
     num_output_group_ = model.num_output_group;
+    pred_transform_ = model.param.pred_transform;
+    sigmoid_alpha_ = model.param.sigmoid_alpha;
+    global_bias_ = model.param.global_bias;
     pred_tranform_func_ = PredTransformFunction("native", model);
     files_.clear();
 
@@ -122,6 +125,9 @@ class ASTNativeCompiler : public Compiler {
   CompilerParam param;
   int num_feature_;
   int num_output_group_;
+  std::string pred_transform_;
+  float sigmoid_alpha_;
+  float global_bias_;
   std::string pred_tranform_func_;
   std::string array_is_categorical_;
   std::unordered_map<std::string, CompiledModel::FileEntry> files_;
@@ -176,6 +182,12 @@ class ASTNativeCompiler : public Compiler {
       = "size_t get_num_output_group(void)";
     const char* get_num_feature_function_signature
       = "size_t get_num_feature(void)";
+    const char* get_pred_transform_function_signature
+      = "const char* get_pred_transform(void)";
+    const char* get_sigmoid_alpha_function_signature
+      = "float get_sigmoid_alpha(void)";
+    const char* get_global_bias_function_signature
+      = "float get_global_bias(void)";
     const char* predict_function_signature
       = (num_output_group_ > 1) ?
           "size_t predict_multiclass(union Entry* data, int pred_margin, "
@@ -195,10 +207,19 @@ class ASTNativeCompiler : public Compiler {
           = get_num_output_group_function_signature,
         "get_num_feature_function_signature"_a
           = get_num_feature_function_signature,
+        "get_pred_transform_function_signature"_a
+          = get_pred_transform_function_signature,
+        "get_sigmoid_alpha_function_signature"_a
+          = get_sigmoid_alpha_function_signature,
+        "get_global_bias_function_signature"_a
+          = get_global_bias_function_signature,
         "pred_transform_function"_a = pred_tranform_func_,
         "predict_function_signature"_a = predict_function_signature,
         "num_output_group"_a = num_output_group_,
-        "num_feature"_a = node->num_feature),
+        "num_feature"_a = num_feature_,
+        "pred_transform"_a = pred_transform_,
+        "sigmoid_alpha"_a = sigmoid_alpha_,
+        "global_bias"_a = global_bias_),
       indent);
     AppendToBuffer("header.h",
       fmt::format(native::header_template,

--- a/src/compiler/native/header_template.h
+++ b/src/compiler/native/header_template.h
@@ -45,6 +45,9 @@ extern const unsigned char is_categorical[];
 
 {dllexport}{get_num_output_group_function_signature};
 {dllexport}{get_num_feature_function_signature};
+{dllexport}{get_pred_transform_function_signature};
+{dllexport}{get_sigmoid_alpha_function_signature};
+{dllexport}{get_global_bias_function_signature};
 {dllexport}{predict_function_signature};
 )TREELITETEMPLATE";
 

--- a/src/compiler/native/main_template.h
+++ b/src/compiler/native/main_template.h
@@ -26,6 +26,18 @@ R"TREELITETEMPLATE(
   return {num_feature};
 }}
 
+{get_pred_transform_function_signature} {{
+  return "{pred_transform}";
+}}
+
+{get_sigmoid_alpha_function_signature} {{
+  return {sigmoid_alpha};
+}}
+
+{get_global_bias_function_signature} {{
+  return {global_bias};
+}}
+
 {pred_transform_function}
 {predict_function_signature} {{
 )TREELITETEMPLATE";

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -104,6 +104,11 @@ class TestBasic(unittest.TestCase):
     subprocess.call(['make', '-C', 'mushroom'])
 
     predictor = treelite.runtime.Predictor(libpath='./mushroom', verbose=True)
+    assert predictor.num_feature == 127
+    assert predictor.num_output_group == 1
+    assert predictor.pred_transform == 'sigmoid'
+    assert predictor.global_bias == 0.0
+    assert predictor.sigmoid_alpha == 1.0
 
     X, _ = load_svmlight_file(dmat_path, zero_based=True)
     dmat = treelite.DMatrix(X)

--- a/tests/python/test_model_builder.py
+++ b/tests/python/test_model_builder.py
@@ -1421,6 +1421,11 @@ class TestModelBuilder(unittest.TestCase):
       model.export_lib(toolchain=toolchain, libpath=libpath,
                        params={'annotate_in': './annotation.json'}, verbose=True)
       predictor = treelite.runtime.Predictor(libpath=libpath, verbose=True)
+      assert predictor.num_feature == 4
+      assert predictor.num_output_group == 3
+      assert predictor.pred_transform == 'identity_multiclass'
+      assert predictor.global_bias == 0.0
+      assert predictor.sigmoid_alpha == 1.0
       batch = treelite.runtime.Batch.from_npy2d(X)
       out_prob = predictor.predict(batch)
       assert_almost_equal(out_prob, expected_prob)
@@ -1465,6 +1470,11 @@ class TestModelBuilder(unittest.TestCase):
     toolchain = 'msvc' if os_platform() == 'windows' else 'gcc'
     model.export_lib(toolchain=toolchain, libpath=libpath, verbose=True)
     predictor = treelite.runtime.Predictor(libpath=libpath)
+    assert predictor.num_feature == 3
+    assert predictor.num_output_group == 1
+    assert predictor.pred_transform == 'identity'
+    assert predictor.global_bias == 0.0
+    assert predictor.sigmoid_alpha == 1.0
     for f0 in [-0.5, 0.5, 1.5, np.nan]:
       for f1 in [0, 1, 2, 3, 4, np.nan]:
         for f2 in [-1.0, -0.5, 1.0, np.nan]:

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -40,6 +40,11 @@ class TestXGBoostIntegration(unittest.TestCase):
       predictor = treelite.runtime.Predictor(libpath=libpath, verbose=True)
       out_pred = predictor.predict(batch)
       assert_almost_equal(out_pred, expected_pred)
+      assert predictor.num_feature == 13
+      assert predictor.num_output_group == 1
+      assert predictor.pred_transform == 'identity'
+      assert predictor.global_bias == 0.5
+      assert predictor.sigmoid_alpha == 1.0
 
   def test_xgb_iris(self):
     X, y = load_iris(return_X_y=True)
@@ -64,3 +69,8 @@ class TestXGBoostIntegration(unittest.TestCase):
       predictor = treelite.runtime.Predictor(libpath=libpath, verbose=True)
       out_pred = predictor.predict(batch)
       assert_almost_equal(out_pred, expected_pred)
+      assert predictor.num_feature == 4
+      assert predictor.num_output_group == 3
+      assert predictor.pred_transform == 'max_index'
+      assert predictor.global_bias == 0.5
+      assert predictor.sigmoid_alpha == 1.0


### PR DESCRIPTION
While doing inference work with binary generated by TreeLite, one thing really annoying is lack of meta information like the task of model (Regression?BinaryClassification?).  So, the aim of this PR is making more meta information of model available in TreeLite runtime. In terms of me, the most useful information exposed in PR is the name of `pred_transform`.
Could you help to review this PR? @hcho3 