### PR TITLE
[treelite4j] enforce rich model info on jvm runtime

### DIFF
--- a/runtime/java/treelite4j/pom.xml
+++ b/runtime/java/treelite4j/pom.xml
@@ -5,16 +5,15 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ml.dmlc</groupId>
   <artifactId>treelite4j</artifactId>
-  <version>0.1-SNAPSHOT</version>
+  <version>0.9-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
-    <JNI.args></JNI.args>
   </properties>
   <dependencies>
     <dependency>
@@ -59,7 +58,82 @@
       <version>${scala.version}</version>
     </dependency>
   </dependencies>
-
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>3.0.2</version>
+            <executions>
+              <execution>
+                <id>empty-javadoc-jar</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <classifier>javadoc</classifier>
+                  <classesDirectory>${basedir}/javadoc</classesDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-release-plugin</artifactId>
+            <version>2.5.3</version>
+            <configuration>
+              <autoVersionSubmodules>true</autoVersionSubmodules>
+              <useReleaseProfile>false</useReleaseProfile>
+              <releaseProfiles>release</releaseProfiles>
+              <goals>deploy</goals>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>2.2.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.7</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
   <build>
     <plugins>
       <plugin>
@@ -106,7 +180,6 @@
               <executable>python</executable>
               <arguments>
                 <argument>create_jni.py</argument>
-                <argument>${JNI.args}</argument>
               </arguments>
               <workingDirectory>${project.basedir}</workingDirectory>
             </configuration>
@@ -169,4 +242,10 @@
       </plugin>
     </plugins>
   </build>
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
 </project>

--- a/runtime/java/treelite4j/src/main/java/ml/dmlc/treelite4j/Predictor.java
+++ b/runtime/java/treelite4j/src/main/java/ml/dmlc/treelite4j/Predictor.java
@@ -16,6 +16,9 @@ public class Predictor {
   private long handle = 0;
   private int num_output_group;
   private int num_feature;
+  private String pred_transform;
+  private float sigmoid_alpha;
+  private float global_bias;
 
   /**
    * Create a Predictor by loading a shared library (dll/so/dylib).
@@ -68,18 +71,29 @@ public class Predictor {
       }
     }
 
-    long[] out = new long[1];
+    long[] long_out = new long[1];
     TreeliteJNI.checkCall(TreeliteJNI.TreelitePredictorLoad(
-      path, nthread, out));
-    handle = out[0];
+      path, nthread, long_out));
+    handle = long_out[0];
 
-    // Save # of output groups and # of features
+    // Fetch meta information from model
     TreeliteJNI.checkCall(TreeliteJNI.TreelitePredictorQueryNumOutputGroup(
-      handle, out));
-    num_output_group = (int)out[0];
+      handle, long_out));
+    num_output_group = (int)long_out[0];
     TreeliteJNI.checkCall(TreeliteJNI.TreelitePredictorQueryNumFeature(
-      handle, out));
-    num_feature = (int)out[0];
+      handle, long_out));
+    num_feature = (int)long_out[0];
+    String[] str_out = new String[1];
+    TreeliteJNI.checkCall(TreeliteJNI.TreelitePredictorQueryPredTransform(
+      handle, str_out));
+    pred_transform = str_out[0];
+    float[] fp_out = new float[1];
+    TreeliteJNI.checkCall(TreeliteJNI.TreelitePredictorQuerySigmoidAlpha(
+      handle, fp_out));
+    sigmoid_alpha = fp_out[0];
+    TreeliteJNI.checkCall(TreeliteJNI.TreelitePredictorQueryGlobalBias(
+      handle, fp_out));
+    global_bias = fp_out[0];
 
     if (verbose) {
       logger.info(String.format(
@@ -105,6 +119,30 @@ public class Predictor {
    */
   public int GetNumFeature() {
     return this.num_feature;
+  }
+
+  /**
+   * Get name of post prediction transformation used to train the loaded model.
+   * @return Name of (post-)prediction transformation
+   */
+  public String GetPredTransform() {
+    return this.pred_transform;
+  }
+
+  /**
+   * Get alpha value in sigmoid transformation used to train the loaded model.
+   * @return Alpha value of sigmoid transformation
+   */
+  public float GetSigmoidAlpha() {
+    return this.sigmoid_alpha;
+  }
+
+  /**
+   * Get global bias which adjusting predicted margin scores.
+   * @return Value of global bias
+   */
+  public float GetGlobalBias() {
+    return this.global_bias;
   }
 
   /**

--- a/runtime/java/treelite4j/src/main/java/ml/dmlc/treelite4j/TreeliteJNI.java
+++ b/runtime/java/treelite4j/src/main/java/ml/dmlc/treelite4j/TreeliteJNI.java
@@ -70,6 +70,15 @@ class TreeliteJNI {
   public final static native int TreelitePredictorQueryNumFeature(
     long handle, long[] out);
 
+  public final static native int TreelitePredictorQueryPredTransform(
+    long handle, String[] out);
+
+  public final static native int TreelitePredictorQuerySigmoidAlpha(
+    long handle, float[] out);
+
+  public final static native int TreelitePredictorQueryGlobalBias(
+    long handle, float[] out);
+
   public final static native int TreelitePredictorFree(long handle);
 
 }

--- a/runtime/java/treelite4j/src/native/treelite4j.cpp
+++ b/runtime/java/treelite4j/src/native/treelite4j.cpp
@@ -309,6 +309,68 @@ Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorQueryNumFeature(
 
 /*
  * Class:     ml_dmlc_treelite4j_TreeliteJNI
+ * Method:    TreelitePredictorQueryPredTransform
+ * Signature: (J[Ljava/lang/String;)I
+ */
+JNIEXPORT jint JNICALL
+Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorQueryPredTransform(
+  JNIEnv* jenv, jclass jcls, jlong jhandle, jobjectArray jout) {
+
+  char* pred_transform;
+  const jint ret = (jint)TreelitePredictorQueryPredTransform(
+      (PredictorHandle)jhandle, &pred_transform);
+  // store data
+  jstring out = nullptr;
+  if (pred_transform != nullptr) {
+    out = jenv->NewStringUTF(pred_transform);
+  }
+  jenv->SetObjectArrayElement(jout, 0, out);
+
+  return ret;
+}
+
+/*
+ * Class:     ml_dmlc_treelite4j_TreeliteJNI
+ * Method:    TreelitePredictorQuerySigmoidAlpha
+ * Signature: (J[F)I
+ */
+JNIEXPORT jint JNICALL
+Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorQuerySigmoidAlpha(
+    JNIEnv* jenv, jclass jcls, jlong jhandle, jfloatArray jout) {
+
+  float alpha;
+  const jint ret = (jint)TreelitePredictorQuerySigmoidAlpha(
+      (PredictorHandle)jhandle, &alpha);
+  // store data
+  jfloat* out = jenv->GetFloatArrayElements(jout, 0);
+  out[0] = (jlong)alpha;
+  jenv->ReleaseFloatArrayElements(jout, out, 0);
+
+  return ret;
+}
+
+/*
+ * Class:     ml_dmlc_treelite4j_TreeliteJNI
+ * Method:    TreelitePredictorQueryGlobalBias
+ * Signature: (J[F)I
+ */
+JNIEXPORT jint JNICALL
+Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorQueryGlobalBias(
+    JNIEnv* jenv, jclass jcls, jlong jhandle, jfloatArray jout) {
+
+  float bias;
+  const jint ret = (jint)TreelitePredictorQueryGlobalBias(
+      (PredictorHandle)jhandle, &bias);
+  // store data
+  jfloat* out = jenv->GetFloatArrayElements(jout, 0);
+  out[0] = (jlong)bias;
+  jenv->ReleaseFloatArrayElements(jout, out, 0);
+
+  return ret;
+}
+
+/*
+ * Class:     ml_dmlc_treelite4j_TreeliteJNI
  * Method:    TreelitePredictorFree
  * Signature: (J)I
  */

--- a/runtime/java/treelite4j/src/native/treelite4j.h
+++ b/runtime/java/treelite4j/src/native/treelite4j.h
@@ -12,126 +12,136 @@ extern "C" {
  * Method:    TreeliteGetLastError
  * Signature: ()Ljava/lang/String;
  */
-JNIEXPORT jstring JNICALL
-Java_ml_dmlc_treelite4j_TreeliteJNI_TreeliteGetLastError(JNIEnv*, jclass);
+JNIEXPORT jstring JNICALL Java_ml_dmlc_treelite4j_TreeliteJNI_TreeliteGetLastError
+  (JNIEnv *, jclass);
 
 /*
  * Class:     ml_dmlc_treelite4j_TreeliteJNI
  * Method:    TreeliteAssembleSparseBatch
  * Signature: ([F[I[JJJ[J)I
  */
-JNIEXPORT jint JNICALL
-Java_ml_dmlc_treelite4j_TreeliteJNI_TreeliteAssembleSparseBatch(
-  JNIEnv*, jclass, jfloatArray, jintArray, jlongArray, jlong, jlong, jlongArray);
+JNIEXPORT jint JNICALL Java_ml_dmlc_treelite4j_TreeliteJNI_TreeliteAssembleSparseBatch
+  (JNIEnv *, jclass, jfloatArray, jintArray, jlongArray, jlong, jlong, jlongArray);
 
 /*
  * Class:     ml_dmlc_treelite4j_TreeliteJNI
  * Method:    TreeliteDeleteSparseBatch
  * Signature: (J[F[I[J)I
  */
-JNIEXPORT jint JNICALL
-Java_ml_dmlc_treelite4j_TreeliteJNI_TreeliteDeleteSparseBatch(
-  JNIEnv*, jclass, jlong, jfloatArray, jintArray, jlongArray);
+JNIEXPORT jint JNICALL Java_ml_dmlc_treelite4j_TreeliteJNI_TreeliteDeleteSparseBatch
+  (JNIEnv *, jclass, jlong, jfloatArray, jintArray, jlongArray);
 
 /*
  * Class:     ml_dmlc_treelite4j_TreeliteJNI
  * Method:    TreeliteAssembleDenseBatch
  * Signature: ([FFJJ[J)I
  */
-JNIEXPORT jint JNICALL
-Java_ml_dmlc_treelite4j_TreeliteJNI_TreeliteAssembleDenseBatch(
-  JNIEnv*, jclass, jfloatArray, jfloat, jlong, jlong, jlongArray);
+JNIEXPORT jint JNICALL Java_ml_dmlc_treelite4j_TreeliteJNI_TreeliteAssembleDenseBatch
+  (JNIEnv *, jclass, jfloatArray, jfloat, jlong, jlong, jlongArray);
 
 /*
  * Class:     ml_dmlc_treelite4j_TreeliteJNI
  * Method:    TreeliteDeleteDenseBatch
  * Signature: (J[F)I
  */
-JNIEXPORT jint JNICALL
-Java_ml_dmlc_treelite4j_TreeliteJNI_TreeliteDeleteDenseBatch(
-  JNIEnv*, jclass, jlong, jfloatArray);
+JNIEXPORT jint JNICALL Java_ml_dmlc_treelite4j_TreeliteJNI_TreeliteDeleteDenseBatch
+  (JNIEnv *, jclass, jlong, jfloatArray);
 
 /*
  * Class:     ml_dmlc_treelite4j_TreeliteJNI
  * Method:    TreeliteBatchGetDimension
  * Signature: (JZ[J[J)I
  */
-JNIEXPORT jint JNICALL
-Java_ml_dmlc_treelite4j_TreeliteJNI_TreeliteBatchGetDimension(
-  JNIEnv*, jclass, jlong, jboolean, jlongArray, jlongArray);
+JNIEXPORT jint JNICALL Java_ml_dmlc_treelite4j_TreeliteJNI_TreeliteBatchGetDimension
+  (JNIEnv *, jclass, jlong, jboolean, jlongArray, jlongArray);
 
 /*
  * Class:     ml_dmlc_treelite4j_TreeliteJNI
  * Method:    TreelitePredictorLoad
  * Signature: (Ljava/lang/String;I[J)I
  */
-JNIEXPORT jint JNICALL
-Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorLoad(
-  JNIEnv*, jclass, jstring, jint, jlongArray);
+JNIEXPORT jint JNICALL Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorLoad
+  (JNIEnv *, jclass, jstring, jint, jlongArray);
 
 /*
  * Class:     ml_dmlc_treelite4j_TreeliteJNI
  * Method:    TreelitePredictorPredictBatch
- * Signature: (JJZZZ[F)I
+ * Signature: (JJZZZ[F[J)I
  */
-JNIEXPORT jint JNICALL
-Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorPredictBatch(
-  JNIEnv*, jclass, jlong, jlong, jboolean, jboolean, jboolean,
-  jfloatArray, jlongArray);
+JNIEXPORT jint JNICALL Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorPredictBatch
+  (JNIEnv *, jclass, jlong, jlong, jboolean, jboolean, jboolean, jfloatArray, jlongArray);
 
 /*
  * Class:     ml_dmlc_treelite4j_TreeliteJNI
  * Method:    TreelitePredictorPredictInst
  * Signature: (J[BZ[F[J)I
  */
-JNIEXPORT jint JNICALL
-Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorPredictInst(
-  JNIEnv*, jclass, jlong, jbyteArray, jboolean, jfloatArray, jlongArray);
+JNIEXPORT jint JNICALL Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorPredictInst
+  (JNIEnv *, jclass, jlong, jbyteArray, jboolean, jfloatArray, jlongArray);
 
 /*
  * Class:     ml_dmlc_treelite4j_TreeliteJNI
  * Method:    TreelitePredictorQueryResultSize
  * Signature: (JJZ[J)I
  */
-JNIEXPORT jint JNICALL
-Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorQueryResultSize(
-  JNIEnv*, jclass, jlong, jlong, jboolean, jlongArray);
+JNIEXPORT jint JNICALL Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorQueryResultSize
+  (JNIEnv *, jclass, jlong, jlong, jboolean, jlongArray);
 
 /*
  * Class:     ml_dmlc_treelite4j_TreeliteJNI
  * Method:    TreelitePredictorQueryResultSizeSingleInst
  * Signature: (J[J)I
  */
-JNIEXPORT jint JNICALL
-Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorQueryResultSizeSingleInst(
-  JNIEnv*, jclass, jlong, jlongArray);
+JNIEXPORT jint JNICALL Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorQueryResultSizeSingleInst
+  (JNIEnv *, jclass, jlong, jlongArray);
 
 /*
  * Class:     ml_dmlc_treelite4j_TreeliteJNI
  * Method:    TreelitePredictorQueryNumOutputGroup
  * Signature: (J[J)I
  */
-JNIEXPORT jint JNICALL
-Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorQueryNumOutputGroup(
-  JNIEnv*, jclass, jlong, jlongArray);
+JNIEXPORT jint JNICALL Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorQueryNumOutputGroup
+  (JNIEnv *, jclass, jlong, jlongArray);
 
 /*
  * Class:     ml_dmlc_treelite4j_TreeliteJNI
  * Method:    TreelitePredictorQueryNumFeature
  * Signature: (J[J)I
  */
-JNIEXPORT jint JNICALL
-Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorQueryNumFeature(
-  JNIEnv*, jclass, jlong, jlongArray);
+JNIEXPORT jint JNICALL Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorQueryNumFeature
+  (JNIEnv *, jclass, jlong, jlongArray);
+
+/*
+ * Class:     ml_dmlc_treelite4j_TreeliteJNI
+ * Method:    TreelitePredictorQueryPredTransform
+ * Signature: (J[Ljava/lang/String;)I
+ */
+JNIEXPORT jint JNICALL Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorQueryPredTransform
+  (JNIEnv *, jclass, jlong, jobjectArray);
+
+/*
+ * Class:     ml_dmlc_treelite4j_TreeliteJNI
+ * Method:    TreelitePredictorQuerySigmoidAlpha
+ * Signature: (J[F)I
+ */
+JNIEXPORT jint JNICALL Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorQuerySigmoidAlpha
+  (JNIEnv *, jclass, jlong, jfloatArray);
+
+/*
+ * Class:     ml_dmlc_treelite4j_TreeliteJNI
+ * Method:    TreelitePredictorQueryGlobalBias
+ * Signature: (J[F)I
+ */
+JNIEXPORT jint JNICALL Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorQueryGlobalBias
+  (JNIEnv *, jclass, jlong, jfloatArray);
 
 /*
  * Class:     ml_dmlc_treelite4j_TreeliteJNI
  * Method:    TreelitePredictorFree
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL
-Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorFree(
-  JNIEnv*, jclass, jlong);
+JNIEXPORT jint JNICALL Java_ml_dmlc_treelite4j_TreeliteJNI_TreelitePredictorFree
+  (JNIEnv *, jclass, jlong);
 
 #ifdef __cplusplus
 }

--- a/runtime/java/treelite4j/src/test/java/ml/dmlc/treelite4j/PredictorTest.java
+++ b/runtime/java/treelite4j/src/test/java/ml/dmlc/treelite4j/PredictorTest.java
@@ -39,6 +39,9 @@ public class PredictorTest {
     Predictor predictor = new Predictor(mushroomLibLocation, -1, true);
     TestCase.assertEquals(1, predictor.GetNumOutputGroup());
     TestCase.assertEquals(127, predictor.GetNumFeature());
+    TestCase.assertEquals("sigmoid", predictor.GetPredTransform());
+    TestCase.assertEquals(1.0f, predictor.GetSigmoidAlpha());
+    TestCase.assertEquals(0.0f, predictor.GetGlobalBias());
   }
 
   @Test

--- a/runtime/java/treelite4j/src/test/resources/mushroom_example/mushroom.c
+++ b/runtime/java/treelite4j/src/test/resources/mushroom_example/mushroom.c
@@ -17,57 +17,70 @@ size_t get_num_feature(void) {
   return 127;
 }
 
+const char* get_pred_transform(void) {
+  return "sigmoid";
+}
+
+float get_sigmoid_alpha(void) {
+  return 1;
+}
+
+float get_global_bias(void) {
+  return -0;
+}
+
 static inline float pred_transform(float margin) {
   const float alpha = (float)1;
   return 1.0f / (1 + expf(-alpha * margin));
 }
-
 float predict(union Entry* data, int pred_margin) {
   float sum = 0.0f;
-  if (!(data[29].missing != -1) || (data[29].fvalue < -9.5367432e-07)) {
-    if (!(data[56].missing != -1) || (data[56].fvalue < -9.5367432e-07)) {
-      if (!(data[60].missing != -1) || (data[60].fvalue < -9.5367432e-07)) {
-        sum += (float)1.8989965;
+  unsigned int tmp;
+  int nid, cond, fid;  /* used for folded subtrees */
+  if (!(data[29].missing != -1) || (data[29].fvalue < -9.5367431640625e-07)) {
+    if (!(data[56].missing != -1) || (data[56].fvalue < -9.5367431640625e-07)) {
+      if (!(data[60].missing != -1) || (data[60].fvalue < -9.5367431640625e-07)) {
+        sum += (float)1.8989964723587036;
       } else {
-        sum += (float)-1.9473684;
+        sum += (float)-1.9473683834075928;
       }
     } else {
-      if (!(data[21].missing != -1) || (data[21].fvalue < -9.5367432e-07)) {
-        sum += (float)1.7837838;
+      if (!(data[21].missing != -1) || (data[21].fvalue < -9.5367431640625e-07)) {
+        sum += (float)1.7837837934494019;
       } else {
-        sum += (float)-1.981352;
+        sum += (float)-1.9813519716262817;
       }
     }
   } else {
-    if (!(data[109].missing != -1) || (data[109].fvalue < -9.5367432e-07)) {
-      if (!(data[67].missing != -1) || (data[67].fvalue < -9.5367432e-07)) {
-        sum += (float)-1.9854598;
+    if (!(data[109].missing != -1) || (data[109].fvalue < -9.5367431640625e-07)) {
+      if (!(data[67].missing != -1) || (data[67].fvalue < -9.5367431640625e-07)) {
+        sum += (float)-1.9854598045349121;
       } else {
-        sum += (float)0.93877554;
+        sum += (float)0.93877553939819336;
       }
     } else {
-      sum += (float)1.8709677;
+      sum += (float)1.8709677457809448;
     }
   }
-  if (!(data[29].missing != -1) || (data[29].fvalue < -9.5367432e-07)) {
-    if (!(data[21].missing != -1) || (data[21].fvalue < -9.5367432e-07)) {
-      sum += (float)1.1460791;
+  if (!(data[29].missing != -1) || (data[29].fvalue < -9.5367431640625e-07)) {
+    if (!(data[21].missing != -1) || (data[21].fvalue < -9.5367431640625e-07)) {
+      sum += (float)1.1460790634155273;
     } else {
-      if (!(data[36].missing != -1) || (data[36].fvalue < -9.5367432e-07)) {
-        sum += (float)-6.8799467;
+      if (!(data[36].missing != -1) || (data[36].fvalue < -9.5367431640625e-07)) {
+        sum += (float)-6.8799467086791992;
       } else {
-        sum += (float)-0.10659159;
+        sum += (float)-0.10659158974885941;
       }
     }
   } else {
-    if (!(data[109].missing != -1) || (data[109].fvalue < -9.5367432e-07)) {
-      if (!(data[39].missing != -1) || (data[39].fvalue < -9.5367432e-07)) {
-        sum += (float)-0.093065776;
+    if (!(data[109].missing != -1) || (data[109].fvalue < -9.5367431640625e-07)) {
+      if (!(data[39].missing != -1) || (data[39].fvalue < -9.5367431640625e-07)) {
+        sum += (float)-0.0930657759308815;
       } else {
-        sum += (float)-1.1526121;
+        sum += (float)-1.1526120901107788;
       }
     } else {
-      sum += (float)1.0042307;
+      sum += (float)1.0042307376861572;
     }
   }
 


### PR DESCRIPTION
This PR is to enable query of extra model information (which has been applied in #138 ) on Java predictor.