### PR TITLE
Use learner model parameter instead of gbtree.

### DIFF
--- a/src/frontend/xgboost.cc
+++ b/src/frontend/xgboost.cc
@@ -384,8 +384,8 @@ inline treelite::Model ParseStream(dmlc::Stream* fi) {
 
   /* 2. Export model */
   treelite::Model model;
-  model.num_feature = gbm_param_.num_feature;
-  model.num_output_group = gbm_param_.num_output_group;
+  model.num_feature = mparam_.num_feature;
+  model.num_output_group = std::max(mparam_.num_class, 1);
   model.random_forest_flag = false;
 
   // set global bias

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -61,6 +61,9 @@ class TestXGBoostIntegration(unittest.TestCase):
     expected_pred = bst.predict(dtest)
 
     model = treelite.Model.from_xgboost(bst)
+    assert model.num_output_group == 3
+    assert model.num_feature == dtrain.num_col()
+
     libpath = libname('./iris{}')
     batch = treelite.runtime.Batch.from_npy2d(X_test)
     for toolchain in os_compatible_toolchains():


### PR DESCRIPTION
Fixes #139 .

Note: `num_output_group` is 1, as binary classification uses 1 stack of trees with logistic loss.