### PR TITLE
[CI] Use `raise from` to comply with pylint check

### DIFF
--- a/python/treelite/contrib/__init__.py
+++ b/python/treelite/contrib/__init__.py
@@ -65,8 +65,8 @@ def generate_makefile(dirpath, platform, toolchain, options=None):  # pylint: di
     try:
         with open(os.path.join(dirpath, 'recipe.json')) as f:
             recipe = json.load(f)
-    except IOError:
-        raise TreeliteError('Failed to open recipe.json')
+    except IOError as e:
+        raise TreeliteError('Failed to open recipe.json') from e
 
     if 'sources' not in recipe or 'target' not in recipe:
         raise TreeliteError('Malformed recipe.json')
@@ -74,8 +74,8 @@ def generate_makefile(dirpath, platform, toolchain, options=None):  # pylint: di
         try:
             _ = iter(options)
             options = [str(x) for x in options]
-        except TypeError:
-            raise TreeliteError('options must be a list of string')
+        except TypeError as e:
+            raise TreeliteError('options must be a list of string') from e
     else:
         options = []
 
@@ -137,8 +137,8 @@ def generate_cmakelists(dirpath, options=None):
     try:
         with open(os.path.join(dirpath, 'recipe.json')) as f:
             recipe = json.load(f)
-    except IOError:
-        raise TreeliteError('Failed to open recipe.json')
+    except IOError as e:
+        raise TreeliteError('Failed to open recipe.json') from e
 
     if 'sources' not in recipe or 'target' not in recipe:
         raise TreeliteError('Malformed recipe.json')
@@ -146,8 +146,8 @@ def generate_cmakelists(dirpath, options=None):
         try:
             _ = iter(options)
             options = [str(x) for x in options]
-        except TypeError:
-            raise TreeliteError('options must be a list of string')
+        except TypeError as e:
+            raise TreeliteError('options must be a list of string') from e
     else:
         options = []
 
@@ -239,8 +239,8 @@ def create_shared(toolchain, dirpath, nthread=None, verbose=False, options=None)
     try:
         with open(os.path.join(dirpath, 'recipe.json')) as f:
             recipe = json.load(f)
-    except IOError:
-        raise TreeliteError('Failed to open recipe.json')
+    except IOError as e:
+        raise TreeliteError('Failed to open recipe.json') from e
 
     if 'sources' not in recipe or 'target' not in recipe:
         raise TreeliteError('Malformed recipe.json')
@@ -248,8 +248,8 @@ def create_shared(toolchain, dirpath, nthread=None, verbose=False, options=None)
         try:
             _ = iter(options)
             options = [str(x) for x in options]
-        except TypeError:
-            raise TreeliteError('options must be a list of string')
+        except TypeError as e:
+            raise TreeliteError('options must be a list of string') from e
     else:
         options = []
 

--- a/python/treelite/core.py
+++ b/python/treelite/core.py
@@ -144,9 +144,8 @@ class DMatrix():
             try:
                 csr = scipy.sparse.csr_matrix(data)
                 self._init_from_csr(csr)
-            except:
-                raise TypeError('Cannot initialize DMatrix from {}'
-                                .format(type(data).__name__))
+            except Exception as e:
+                raise TypeError(f'Cannot initialize DMatrix from {type(data).__name__}') from e
         self.feature_names = feature_names
         self.feature_types = feature_types
         self._get_internals()  # save handles for internal arrays

--- a/python/treelite/frontend.py
+++ b/python/treelite/frontend.py
@@ -336,9 +336,9 @@ class Model():
         # attempt to load xgboost
         try:
             import xgboost
-        except ImportError:
-            raise TreeliteError('xgboost module must be installed to read from ' + \
-                                '`xgboost.Booster` object')
+        except ImportError as e:
+            raise TreeliteError('xgboost module must be installed to read from ' +
+                                '`xgboost.Booster` object') from e
         if not isinstance(booster, xgboost.Booster):
             raise ValueError('booster must be of type `xgboost.Booster`')
         buffer = booster.save_raw()
@@ -431,9 +431,9 @@ class ModelBuilder():
                 _check_call(_LIB.TreeliteTreeBuilderSetRootNode(
                     self.tree.handle,
                     ctypes.c_int(self.node_key)))
-            except AttributeError:
-                raise TreeliteError('This node has never been inserted into a tree; ' \
-                                    + 'a node must be inserted before it can be a root')
+            except AttributeError as e:
+                raise TreeliteError('This node has never been inserted into a tree; ' +
+                                    'a node must be inserted before it can be a root') from e
 
         def set_leaf_node(self, leaf_value):
             """
@@ -471,9 +471,9 @@ class ModelBuilder():
                     leaf_value = [float(i) for i in leaf_value]
                 else:
                     leaf_value = float(leaf_value)
-            except TypeError:
-                raise TreeliteError('leaf_value parameter should be either a ' + \
-                                    'single float or a list of floats')
+            except TypeError as e:
+                raise TreeliteError('leaf_value parameter should be either a ' +
+                                    'single float or a list of floats') from e
 
             try:
                 if is_list:
@@ -488,9 +488,9 @@ class ModelBuilder():
                         ctypes.c_int(self.node_key),
                         ctypes.c_float(leaf_value)))
                 self.empty = False
-            except AttributeError:
-                raise TreeliteError('This node has never been inserted into a tree; ' \
-                                    + 'a node must be inserted before it can be a leaf node')
+            except AttributeError as e:
+                raise TreeliteError('This node has never been inserted into a tree; ' +
+                                    'a node must be inserted before it can be a leaf node') from e
 
         # pylint: disable=R0913
         def set_numerical_test_node(self, feature_id, opname, threshold,
@@ -541,9 +541,9 @@ class ModelBuilder():
                     ctypes.c_int(left_child_key),
                     ctypes.c_int(right_child_key)))
                 self.empty = False
-            except AttributeError:
-                raise TreeliteError('This node has never been inserted into a tree; ' \
-                                    + 'a node must be inserted before it can be a test node')
+            except AttributeError as e:
+                raise TreeliteError('This node has never been inserted into a tree; ' +
+                                    'a node must be inserted before it can be a test node') from e
 
         # pylint: disable=R0913
         def set_categorical_test_node(self, feature_id, left_categories,
@@ -596,9 +596,9 @@ class ModelBuilder():
                     ctypes.c_int(left_child_key),
                     ctypes.c_int(right_child_key)))
                 self.empty = False
-            except AttributeError:
-                raise TreeliteError('This node has never been inserted into a tree; ' \
-                                    + 'a node must be inserted before it can be a test node')
+            except AttributeError as e:
+                raise TreeliteError('This node has never been inserted into a tree; ' +
+                                    'a node must be inserted before it can be a test node') from e
 
     class Tree():
         """Handle to a decision tree in a tree ensemble Builder"""


### PR DESCRIPTION
Pylint now has an additional check: 

> raise-missing-from (W0707):
> Consider explicitly re-raising using the 'from' keyword Python 3's exception chaining means it shows the traceback of the current exception, but also the original exception. Not using raise from makes the traceback inaccurate, because the message implies there is a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

