### PR TITLE
Create template classes for model representations to support multiple data types (Part of #196)

### DIFF
--- a/include/treelite/base.h
+++ b/include/treelite/base.h
@@ -8,9 +8,11 @@
 #define TREELITE_BASE_H_
 
 #include <cstdint>
+#include <typeinfo>
 #include <string>
 #include <unordered_map>
 #include <stdexcept>
+#include "./typeinfo.h"
 
 namespace treelite {
 
@@ -33,7 +35,7 @@ enum class Operator : int8_t {
 extern const std::unordered_map<std::string, Operator> optable;
 
 /*!
- * \brief get string representation of comparsion operator
+ * \brief get string representation of comparison operator
  * \param op comparison operator
  * \return string representation
  */
@@ -56,7 +58,8 @@ inline std::string OpName(Operator op) {
  * \param rhs float on the right hand side
  * \return whether [lhs] [op] [rhs] is true or not
  */
-inline bool CompareWithOp(tl_float lhs, Operator op, tl_float rhs) {
+template <typename ElementType, typename ThresholdType>
+inline bool CompareWithOp(ElementType lhs, Operator op, ThresholdType rhs) {
   switch (op) {
     case Operator::kEQ: return lhs == rhs;
     case Operator::kLT: return lhs <  rhs;

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -145,9 +145,9 @@ class Tree {
                 || std::is_same<LeafOutputType, float>::value
                 || std::is_same<LeafOutputType, double>::value,
                 "LeafOutputType must be one of uint32_t, float32 or float64");
-  static_assert(!std::is_same<ThresholdType, float>::value
-                || !std::is_same<LeafOutputType, double>::value,
-                "LeafOutputType cannot be float64 when ThresholdType is float32");
+  static_assert(std::is_same<ThresholdType, LeafOutputType>::value
+                || std::is_same<LeafOutputType, uint32_t>::value,
+                "Unsupported combination of ThresholdType and LeafOutputType");
   static_assert((std::is_same<ThresholdType, float>::value && sizeof(Node) == 48)
                 || (std::is_same<ThresholdType, double>::value && sizeof(Node) == 56),
                 "Node size incorrect");
@@ -555,7 +555,7 @@ class ModelImpl : public Model {
   inline size_t GetNumTree() const override {
     return trees.size();
   }
-  inline void SetTreeLimit(size_t limit) override {
+  void SetTreeLimit(size_t limit) override {
     return trees.resize(limit);
   }
 

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -78,6 +78,7 @@ class ContiguousArray {
 };
 
 /*! \brief in-memory representation of a decision tree */
+template <typename ThresholdType, typename LeafOutputType>
 class Tree {
  public:
   /*! \brief tree node */
@@ -87,8 +88,8 @@ class Tree {
     inline void Init();
     /*! \brief store either leaf value or decision threshold */
     union Info {
-      tl_float leaf_value;  // for leaf nodes
-      tl_float threshold;   // for non-leaf nodes
+      LeafOutputType leaf_value;  // for leaf nodes
+      ThresholdType threshold;   // for non-leaf nodes
     };
     /*! \brief pointer to left and right children */
     int32_t cleft_, cright_;
@@ -137,7 +138,19 @@ class Tree {
   };
 
   static_assert(std::is_pod<Node>::value, "Node must be a POD type");
-  static_assert(sizeof(Node) == 48, "Node must be 48 bytes");
+  static_assert(std::is_same<ThresholdType, float>::value
+                || std::is_same<ThresholdType, double>::value,
+                "ThresholdType must be either float32 or float64");
+  static_assert(std::is_same<LeafOutputType, uint32_t>::value
+                || std::is_same<LeafOutputType, float>::value
+                || std::is_same<LeafOutputType, double>::value,
+                "LeafOutputType must be either uint32_t, float32 or float64");
+  static_assert(!std::is_same<ThresholdType, float>::value
+                || !std::is_same<LeafOutputType, double>::value,
+                "LeafOutputType cannot be float64 when ThresholdType is float32");
+  static_assert((std::is_same<ThresholdType, float>::value && sizeof(Node) == 48)
+                || (std::is_same<ThresholdType, double>::value && sizeof(Node) == 56),
+                "Node incorrect size");
 
   Tree() = default;
   ~Tree() = default;
@@ -146,6 +159,7 @@ class Tree {
   Tree(Tree&&) noexcept = default;
   Tree& operator=(Tree&&) noexcept = default;
 
+  inline const char* GetFormatStringForNode();
   inline void GetPyBuffer(std::vector<PyBufferFrame>* dest);
   inline void InitFromPyBuffer(std::vector<PyBufferFrame>::iterator begin,
                                std::vector<PyBufferFrame>::iterator end);
@@ -153,7 +167,7 @@ class Tree {
  private:
   // vector of nodes
   ContiguousArray<Node> nodes_;
-  ContiguousArray<tl_float> leaf_vector_;
+  ContiguousArray<LeafOutputType> leaf_vector_;
   ContiguousArray<size_t> leaf_vector_offset_;
   ContiguousArray<uint32_t> left_categories_;
   ContiguousArray<size_t> left_categories_offset_;
@@ -225,19 +239,19 @@ class Tree {
    * \brief get leaf value of the leaf node
    * \param nid ID of node being queried
    */
-  inline tl_float LeafValue(int nid) const {
+  inline LeafOutputType LeafValue(int nid) const {
     return (nodes_[nid].info_).leaf_value;
   }
   /*!
    * \brief get leaf vector of the leaf node; useful for multi-class random forest classifier
    * \param nid ID of node being queried
    */
-  inline std::vector<tl_float> LeafVector(int nid) const {
+  inline std::vector<LeafOutputType> LeafVector(int nid) const {
     if (nid > leaf_vector_offset_.Size()) {
       throw std::runtime_error("nid too large");
     }
-    return std::vector<tl_float>(&leaf_vector_[leaf_vector_offset_[nid]],
-                                 &leaf_vector_[leaf_vector_offset_[nid + 1]]);
+    return std::vector<LeafOutputType>(&leaf_vector_[leaf_vector_offset_[nid]],
+                                       &leaf_vector_[leaf_vector_offset_[nid + 1]]);
   }
   /*!
    * \brief tests whether the leaf node has a non-empty leaf vector
@@ -253,7 +267,7 @@ class Tree {
    * \brief get threshold of the node
    * \param nid ID of node being queried
    */
-  inline tl_float Threshold(int nid) const {
+  inline ThresholdType Threshold(int nid) const {
     return (nodes_[nid].info_).threshold;
   }
   /*!
@@ -346,7 +360,7 @@ class Tree {
    * \param cmp comparison operator to compare between feature value and
    *            threshold
    */
-  inline void SetNumericalSplit(int nid, unsigned split_index, tl_float threshold,
+  inline void SetNumericalSplit(int nid, unsigned split_index, ThresholdType threshold,
                                 bool default_left, Operator cmp);
   /*!
    * \brief create a categorical split
@@ -365,13 +379,13 @@ class Tree {
    * \param nid ID of node being updated
    * \param value leaf value
    */
-  inline void SetLeaf(int nid, tl_float value);
+  inline void SetLeaf(int nid, LeafOutputType value);
   /*!
    * \brief set the leaf vector of the node; useful for multi-class random forest classifier
    * \param nid ID of node being updated
    * \param leaf_vector leaf vector
    */
-  inline void SetLeafVector(int nid, const std::vector<tl_float>& leaf_vector);
+  inline void SetLeafVector(int nid, const std::vector<LeafOutputType>& leaf_vector);
   /*!
    * \brief set the hessian sum of the node
    * \param nid ID of node being updated
@@ -474,11 +488,24 @@ class Model {
   /*! \brief disable copy; use default move */
   Model() = default;
   virtual ~Model() = default;
-  inline static std::unique_ptr<Model> Create();
   Model(const Model&) = delete;
   Model& operator=(const Model&) = delete;
   Model(Model&&) = default;
   Model& operator=(Model&&) = default;
+
+  template <typename ThresholdType, typename LeafOutputType>
+  inline static std::unique_ptr<Model> Create();
+  inline static std::unique_ptr<Model> Create(TypeInfo threshold_type, TypeInfo leaf_output_type);
+  inline TypeInfo GetThresholdType() const {
+    return threshold_type_;
+  }
+  inline TypeInfo GetLeafOutputType() const {
+    return leaf_output_type_;
+  }
+  template <typename Func>
+  inline auto Dispatch(Func func);
+  template <typename Func>
+  inline auto Dispatch(Func func) const;
 
   virtual size_t GetNumTree() const = 0;
   virtual void SetTreeLimit(size_t limit) = 0;
@@ -502,16 +529,19 @@ class Model {
   ModelParam param;
 
  private:
+  TypeInfo threshold_type_;
+  TypeInfo leaf_output_type_;
   // Internal functions for serialization
   virtual void GetPyBuffer(std::vector<PyBufferFrame>* dest) = 0;
   virtual void InitFromPyBuffer(std::vector<PyBufferFrame>::iterator begin,
                                 std::vector<PyBufferFrame>::iterator end) = 0;
 };
 
+template <typename ThresholdType, typename LeafOutputType>
 class ModelImpl : public Model {
  public:
   /*! \brief member trees */
-  std::vector<Tree> trees;
+  std::vector<Tree<ThresholdType, LeafOutputType>> trees;
 
   /*! \brief disable copy; use default move */
   ModelImpl() = default;
@@ -525,7 +555,7 @@ class ModelImpl : public Model {
   inline size_t GetNumTree() const override {
     return trees.size();
   }
-  void SetTreeLimit(size_t limit) override {
+  inline void SetTreeLimit(size_t limit) override {
     return trees.resize(limit);
   }
 

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -144,7 +144,7 @@ class Tree {
   static_assert(std::is_same<LeafOutputType, uint32_t>::value
                 || std::is_same<LeafOutputType, float>::value
                 || std::is_same<LeafOutputType, double>::value,
-                "LeafOutputType must be either uint32_t, float32 or float64");
+                "LeafOutputType must be one of uint32_t, float32 or float64");
   static_assert(!std::is_same<ThresholdType, float>::value
                 || !std::is_same<LeafOutputType, double>::value,
                 "LeafOutputType cannot be float64 when ThresholdType is float32");

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -150,7 +150,7 @@ class Tree {
                 "LeafOutputType cannot be float64 when ThresholdType is float32");
   static_assert((std::is_same<ThresholdType, float>::value && sizeof(Node) == 48)
                 || (std::is_same<ThresholdType, double>::value && sizeof(Node) == 56),
-                "Node incorrect size");
+                "Node size incorrect");
 
   Tree() = default;
   ~Tree() = default;

--- a/include/treelite/tree_impl.h
+++ b/include/treelite/tree_impl.h
@@ -591,8 +591,8 @@ template <typename ThresholdType, typename LeafOutputType>
 inline std::unique_ptr<Model>
 Model::Create() {
   std::unique_ptr<Model> model = std::make_unique<ModelImpl<ThresholdType, LeafOutputType>>();
-  model->threshold_type_ = InferTypeInfoOf<ThresholdType>();
-  model->leaf_output_type_ = InferTypeInfoOf<LeafOutputType>();
+  model->threshold_type_ = TypeToInfo<ThresholdType>();
+  model->leaf_output_type_ = TypeToInfo<LeafOutputType>();
   return model;
 }
 

--- a/include/treelite/typeinfo.h
+++ b/include/treelite/typeinfo.h
@@ -58,7 +58,7 @@ inline std::string TypeInfoToString(treelite::TypeInfo type) {
  * \return TypeInfo corresponding to the template type arg
  */
 template <typename T>
-inline TypeInfo InferTypeInfoOf() {
+inline TypeInfo TypeToInfo() {
   if (std::is_same<T, uint32_t>::value) {
     return TypeInfo::kUInt32;
   } else if (std::is_same<T, float>::value) {


### PR DESCRIPTION
Extracted from #196 for easier reviewing.
(The CI tests in this PR won't pass due to missing parts. See #196 to look up the test results.)

* The `ModelImpl` class (created in #201) becomes the template class `ModelImpl<ThresholdType, LeafOutputType>`.
* Implement template classes `ModelImpl<ThresholdType, LeafOutputType>` and `TreeImpl<ThresholdType, LeafOutputType>` that contain the details of the tree ensemble model. The template classes are parameterized by the types of the thresholds and leaf outputs. Currently the following combinations are allowed:

| Threshold type | Leaf output type |
|----|----|
| float32 | float32 |
| float32 | uint32 |
| float64 | float64 |
| float64 | uint32 |

* Revise the zero-copy serialization protocol, to prepend the type information (threshold_type, leaf_output_type) to the serialized types so that the recipient will choose the correct `ModelImpl<ThresholdType, LeafOutputType>` to deserialize to.

* A run-time type dispatching system using the enum type `TypeInfo`. Users are able to dispatch a correct version of `ModelImpl<ThresholdType, LeafOutputType>`  by specifying a pair of `TypeInfo` values. We also implement a set of convenient functions, such as `InferTypeInfoOf<T>` that converts the template arg `T` into `TypeInfo` enum.

@canonizer @levsnv @jakirkham @wphicks Can you review this PR?