### PR TITLE
Support sklearn's extremely randomized trees

### DIFF
--- a/python/treelite/sklearn/__init__.py
+++ b/python/treelite/sklearn/__init__.py
@@ -50,9 +50,9 @@ def import_model(sklearn_model):
     if module_name != 'sklearn':
         raise Exception('Not a scikit-learn model')
 
-    if class_name == 'RandomForestRegressor' or class_name == 'ExtraTreesRegressor':
+    if class_name in ['RandomForestRegressor', 'ExtraTreesRegressor']:
         return SKLRFRegressorConverter.process_model(sklearn_model)
-    if class_name == 'RandomForestClassifier' or class_name == 'ExtraTreesClassifier':
+    if class_name in ['RandomForestClassifier', 'ExtraTreesClassifier']:
         if sklearn_model.n_classes_ == 2:
             return SKLRFClassifierConverter.process_model(sklearn_model)
         if sklearn_model.n_classes_ > 2:
@@ -66,8 +66,9 @@ def import_model(sklearn_model):
         if sklearn_model.n_classes_ > 2:
             return SKLGBMMultiClassifierConverter.process_model(sklearn_model)
         raise TreeliteError('n_classes_ must be at least 2')
-    raise TreeliteError('Unsupported model type: only '
-                        'random forests and gradient boosted trees are supported')
+    raise TreeliteError('Unsupported model type: currently ' +
+                        'random forests, extremely randomized trees, and gradient boosted trees ' +
+                        'are supported')
 
 
 class SKLGBMRegressorConverter(SKLGBMRegressorMixin, SKLConverterBase):  # pylint: disable=C0111

--- a/python/treelite/sklearn/__init__.py
+++ b/python/treelite/sklearn/__init__.py
@@ -50,9 +50,9 @@ def import_model(sklearn_model):
     if module_name != 'sklearn':
         raise Exception('Not a scikit-learn model')
 
-    if class_name == 'RandomForestRegressor':
+    if class_name == 'RandomForestRegressor' or class_name == 'ExtraTreesRegressor':
         return SKLRFRegressorConverter.process_model(sklearn_model)
-    if class_name == 'RandomForestClassifier':
+    if class_name == 'RandomForestClassifier' or class_name == 'ExtraTreesClassifier':
         if sklearn_model.n_classes_ == 2:
             return SKLRFClassifierConverter.process_model(sklearn_model)
         if sklearn_model.n_classes_ > 2:

--- a/tests/python/test_model_builder.py
+++ b/tests/python/test_model_builder.py
@@ -5,24 +5,10 @@ import os
 import pytest
 import numpy as np
 import treelite
-import treelite.sklearn
 import treelite_runtime
-from treelite.util import has_sklearn
 from treelite.contrib import _libext
 from .metadata import dataset_db
 from .util import os_compatible_toolchains, check_predictor
-
-if has_sklearn():
-    from sklearn.ensemble import RandomForestClassifier, GradientBoostingClassifier, \
-        RandomForestRegressor, GradientBoostingRegressor
-    from sklearn.datasets import load_iris, load_breast_cancer, load_boston
-else:
-    class RandomForestClassifier:  # pylint: disable=missing-class-docstring, R0903
-        pass
-
-
-    class GradientBoostingClassifier:  # pylint: disable=missing-class-docstring, R0903
-        pass
 
 
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())
@@ -111,122 +97,6 @@ def test_model_builder(tmpdir, use_annotation, quantize, toolchain):
     model.export_lib(toolchain=toolchain, libpath=libpath, params=params, verbose=True)
     predictor = treelite_runtime.Predictor(libpath=libpath, verbose=True)
     check_predictor(predictor, 'mushroom')
-
-
-@pytest.mark.skipif(not has_sklearn(), reason='Needs scikit-learn')
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-@pytest.mark.parametrize('clazz', [RandomForestClassifier, GradientBoostingClassifier])
-def test_skl_converter_multiclass_classifier(tmpdir, clazz, toolchain):
-    # pylint: disable=too-many-locals
-    """Convert scikit-learn multi-class classifier"""
-    X, y = load_iris(return_X_y=True)
-    kwargs = {}
-    if clazz == GradientBoostingClassifier:
-        kwargs['init'] = 'zero'
-    clf = clazz(max_depth=3, random_state=0, n_estimators=10, **kwargs)
-    clf.fit(X, y)
-    expected_prob = clf.predict_proba(X)
-
-    model = treelite.sklearn.import_model(clf)
-    assert model.num_feature == clf.n_features_
-    assert model.num_output_group == clf.n_classes_
-    assert (model.num_tree ==
-            clf.n_estimators * (clf.n_classes_ if clazz == GradientBoostingClassifier else 1))
-
-    dtrain = treelite_runtime.DMatrix(X, dtype='float64')
-    annotation_path = os.path.join(tmpdir, 'annotation.json')
-    annotator = treelite.Annotator()
-    annotator.annotate_branch(model=model, dmat=dtrain, verbose=True)
-    annotator.save(path=annotation_path)
-
-    libpath = os.path.join(tmpdir, 'skl' + _libext())
-    model.export_lib(toolchain=toolchain, libpath=libpath, params={'annotate_in': annotation_path},
-                     verbose=True)
-    predictor = treelite_runtime.Predictor(libpath=libpath)
-    assert predictor.num_feature == clf.n_features_
-    assert predictor.num_output_group == clf.n_classes_
-    assert (predictor.pred_transform ==
-            ('softmax' if clazz == GradientBoostingClassifier else 'identity_multiclass'))
-    assert predictor.global_bias == 0.0
-    assert predictor.sigmoid_alpha == 1.0
-    out_prob = predictor.predict(dtrain)
-    np.testing.assert_almost_equal(out_prob, expected_prob)
-
-
-@pytest.mark.skipif(not has_sklearn(), reason='Needs scikit-learn')
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-@pytest.mark.parametrize('clazz', [RandomForestClassifier, GradientBoostingClassifier])
-def test_skl_converter_binary_classifier(tmpdir, clazz, toolchain):
-    # pylint: disable=too-many-locals
-    """Convert scikit-learn binary classifier"""
-    X, y = load_breast_cancer(return_X_y=True)
-    kwargs = {}
-    if clazz == GradientBoostingClassifier:
-        kwargs['init'] = 'zero'
-    clf = clazz(max_depth=3, random_state=0, n_estimators=10, **kwargs)
-    clf.fit(X, y)
-    expected_prob = clf.predict_proba(X)[:, 1]
-
-    model = treelite.sklearn.import_model(clf)
-    assert model.num_feature == clf.n_features_
-    assert model.num_output_group == 1
-    assert model.num_tree == clf.n_estimators
-
-    dtrain = treelite_runtime.DMatrix(X, dtype='float64')
-    annotation_path = os.path.join(tmpdir, 'annotation.json')
-    annotator = treelite.Annotator()
-    annotator.annotate_branch(model=model, dmat=dtrain, verbose=True)
-    annotator.save(path=annotation_path)
-
-    libpath = os.path.join(tmpdir, 'skl' + _libext())
-    model.export_lib(toolchain=toolchain, libpath=libpath, params={'annotate_in': annotation_path},
-                     verbose=True)
-    predictor = treelite_runtime.Predictor(libpath=libpath)
-    assert predictor.num_feature == clf.n_features_
-    assert model.num_output_group == 1
-    assert (predictor.pred_transform
-            == ('sigmoid' if clazz == GradientBoostingClassifier else 'identity'))
-    assert predictor.global_bias == 0.0
-    assert predictor.sigmoid_alpha == 1.0
-    out_prob = predictor.predict(dtrain)
-    np.testing.assert_almost_equal(out_prob, expected_prob)
-
-
-@pytest.mark.skipif(not has_sklearn(), reason='Needs scikit-learn')
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-@pytest.mark.parametrize('clazz', [RandomForestRegressor, GradientBoostingRegressor])
-def test_skl_converter_regressor(tmpdir, clazz, toolchain):  # pylint: disable=too-many-locals
-    """Convert scikit-learn regressor"""
-    X, y = load_boston(return_X_y=True)
-    kwargs = {}
-    if clazz == GradientBoostingRegressor:
-        kwargs['init'] = 'zero'
-    clf = clazz(max_depth=3, random_state=0, n_estimators=10, **kwargs)
-    clf.fit(X, y)
-    expected_pred = clf.predict(X)
-
-    model = treelite.sklearn.import_model(clf)
-    assert model.num_feature == clf.n_features_
-    assert model.num_output_group == 1
-    assert model.num_tree == clf.n_estimators
-
-    dtrain = treelite_runtime.DMatrix(X, dtype='float32')
-    annotation_path = os.path.join(tmpdir, 'annotation.json')
-    annotator = treelite.Annotator()
-    annotator.annotate_branch(model=model, dmat=dtrain, verbose=True)
-    annotator.save(path=annotation_path)
-
-    libpath = os.path.join(tmpdir, 'skl' + _libext())
-    model.export_lib(toolchain=toolchain, libpath=libpath, params={'annotate_in': annotation_path},
-                     verbose=True)
-    predictor = treelite_runtime.Predictor(libpath=libpath)
-    assert predictor.num_feature == clf.n_features_
-    assert model.num_output_group == 1
-    assert predictor.pred_transform == 'identity'
-    assert predictor.global_bias == 0.0
-    assert predictor.sigmoid_alpha == 1.0
-    out_pred = predictor.predict(dtrain)
-    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())

--- a/tests/python/test_skl_importer.py
+++ b/tests/python/test_skl_importer.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+"""Tests for scikit-learn importer"""
+import os
+
+import pytest
+import numpy as np
+import treelite
+import treelite_runtime
+from treelite.contrib import _libext
+from treelite.util import has_sklearn
+from .util import os_compatible_toolchains, check_predictor
+
+
+if has_sklearn():
+    from sklearn.ensemble import RandomForestClassifier, GradientBoostingClassifier, \
+        RandomForestRegressor, GradientBoostingRegressor
+    from sklearn.datasets import load_iris, load_breast_cancer, load_boston
+else:
+    class RandomForestClassifier:  # pylint: disable=missing-class-docstring, R0903
+        pass
+
+
+    class GradientBoostingClassifier:  # pylint: disable=missing-class-docstring, R0903
+        pass
+
+
+@pytest.mark.skipif(not has_sklearn(), reason='Needs scikit-learn')
+@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
+@pytest.mark.parametrize('clazz', [RandomForestClassifier, GradientBoostingClassifier])
+def test_skl_converter_multiclass_classifier(tmpdir, clazz, toolchain):
+    # pylint: disable=too-many-locals
+    """Convert scikit-learn multi-class classifier"""
+    X, y = load_iris(return_X_y=True)
+    kwargs = {}
+    if clazz == GradientBoostingClassifier:
+        kwargs['init'] = 'zero'
+    clf = clazz(max_depth=3, random_state=0, n_estimators=10, **kwargs)
+    clf.fit(X, y)
+    expected_prob = clf.predict_proba(X)
+
+    model = treelite.sklearn.import_model(clf)
+    assert model.num_feature == clf.n_features_
+    assert model.num_output_group == clf.n_classes_
+    assert (model.num_tree ==
+            clf.n_estimators * (clf.n_classes_ if clazz == GradientBoostingClassifier else 1))
+
+    dtrain = treelite_runtime.DMatrix(X, dtype='float64')
+    annotation_path = os.path.join(tmpdir, 'annotation.json')
+    annotator = treelite.Annotator()
+    annotator.annotate_branch(model=model, dmat=dtrain, verbose=True)
+    annotator.save(path=annotation_path)
+
+    libpath = os.path.join(tmpdir, 'skl' + _libext())
+    model.export_lib(toolchain=toolchain, libpath=libpath, params={'annotate_in': annotation_path},
+                     verbose=True)
+    predictor = treelite_runtime.Predictor(libpath=libpath)
+    assert predictor.num_feature == clf.n_features_
+    assert predictor.num_output_group == clf.n_classes_
+    assert (predictor.pred_transform ==
+            ('softmax' if clazz == GradientBoostingClassifier else 'identity_multiclass'))
+    assert predictor.global_bias == 0.0
+    assert predictor.sigmoid_alpha == 1.0
+    out_prob = predictor.predict(dtrain)
+    np.testing.assert_almost_equal(out_prob, expected_prob)
+
+
+@pytest.mark.skipif(not has_sklearn(), reason='Needs scikit-learn')
+@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
+@pytest.mark.parametrize('clazz', [RandomForestClassifier, GradientBoostingClassifier])
+def test_skl_converter_binary_classifier(tmpdir, clazz, toolchain):
+    # pylint: disable=too-many-locals
+    """Convert scikit-learn binary classifier"""
+    X, y = load_breast_cancer(return_X_y=True)
+    kwargs = {}
+    if clazz == GradientBoostingClassifier:
+        kwargs['init'] = 'zero'
+    clf = clazz(max_depth=3, random_state=0, n_estimators=10, **kwargs)
+    clf.fit(X, y)
+    expected_prob = clf.predict_proba(X)[:, 1]
+
+    model = treelite.sklearn.import_model(clf)
+    assert model.num_feature == clf.n_features_
+    assert model.num_output_group == 1
+    assert model.num_tree == clf.n_estimators
+
+    dtrain = treelite_runtime.DMatrix(X, dtype='float64')
+    annotation_path = os.path.join(tmpdir, 'annotation.json')
+    annotator = treelite.Annotator()
+    annotator.annotate_branch(model=model, dmat=dtrain, verbose=True)
+    annotator.save(path=annotation_path)
+
+    libpath = os.path.join(tmpdir, 'skl' + _libext())
+    model.export_lib(toolchain=toolchain, libpath=libpath, params={'annotate_in': annotation_path},
+                     verbose=True)
+    predictor = treelite_runtime.Predictor(libpath=libpath)
+    assert predictor.num_feature == clf.n_features_
+    assert model.num_output_group == 1
+    assert (predictor.pred_transform
+            == ('sigmoid' if clazz == GradientBoostingClassifier else 'identity'))
+    assert predictor.global_bias == 0.0
+    assert predictor.sigmoid_alpha == 1.0
+    out_prob = predictor.predict(dtrain)
+    np.testing.assert_almost_equal(out_prob, expected_prob)
+
+
+@pytest.mark.skipif(not has_sklearn(), reason='Needs scikit-learn')
+@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
+@pytest.mark.parametrize('clazz', [RandomForestRegressor, GradientBoostingRegressor])
+def test_skl_converter_regressor(tmpdir, clazz, toolchain):  # pylint: disable=too-many-locals
+    """Convert scikit-learn regressor"""
+    X, y = load_boston(return_X_y=True)
+    kwargs = {}
+    if clazz == GradientBoostingRegressor:
+        kwargs['init'] = 'zero'
+    clf = clazz(max_depth=3, random_state=0, n_estimators=10, **kwargs)
+    clf.fit(X, y)
+    expected_pred = clf.predict(X)
+
+    model = treelite.sklearn.import_model(clf)
+    assert model.num_feature == clf.n_features_
+    assert model.num_output_group == 1
+    assert model.num_tree == clf.n_estimators
+
+    dtrain = treelite_runtime.DMatrix(X, dtype='float32')
+    annotation_path = os.path.join(tmpdir, 'annotation.json')
+    annotator = treelite.Annotator()
+    annotator.annotate_branch(model=model, dmat=dtrain, verbose=True)
+    annotator.save(path=annotation_path)
+
+    libpath = os.path.join(tmpdir, 'skl' + _libext())
+    model.export_lib(toolchain=toolchain, libpath=libpath, params={'annotate_in': annotation_path},
+                     verbose=True)
+    predictor = treelite_runtime.Predictor(libpath=libpath)
+    assert predictor.num_feature == clf.n_features_
+    assert model.num_output_group == 1
+    assert predictor.pred_transform == 'identity'
+    assert predictor.global_bias == 0.0
+    assert predictor.sigmoid_alpha == 1.0
+    out_pred = predictor.predict(dtrain)
+    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)

--- a/tests/python/test_skl_importer.py
+++ b/tests/python/test_skl_importer.py
@@ -13,7 +13,8 @@ from .util import os_compatible_toolchains, check_predictor
 
 if has_sklearn():
     from sklearn.ensemble import RandomForestClassifier, GradientBoostingClassifier, \
-        RandomForestRegressor, GradientBoostingRegressor
+        ExtraTreesClassifier, RandomForestRegressor, GradientBoostingRegressor, \
+        ExtraTreesRegressor
     from sklearn.datasets import load_iris, load_breast_cancer, load_boston
 else:
     class RandomForestClassifier:  # pylint: disable=missing-class-docstring, R0903
@@ -24,9 +25,18 @@ else:
         pass
 
 
+    class ExtraTreesClassifier:  # pylint: disable=missing-class-docstring, R0903
+        pass
+
+
+    class ExtraTreesRegressor:  # pylint: disable=missing-class-docstring, R0903
+        pass
+
+
 @pytest.mark.skipif(not has_sklearn(), reason='Needs scikit-learn')
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-@pytest.mark.parametrize('clazz', [RandomForestClassifier, GradientBoostingClassifier])
+@pytest.mark.parametrize('clazz', [RandomForestClassifier, ExtraTreesClassifier,
+                                   GradientBoostingClassifier])
 def test_skl_converter_multiclass_classifier(tmpdir, clazz, toolchain):
     # pylint: disable=too-many-locals
     """Convert scikit-learn multi-class classifier"""
@@ -66,7 +76,8 @@ def test_skl_converter_multiclass_classifier(tmpdir, clazz, toolchain):
 
 @pytest.mark.skipif(not has_sklearn(), reason='Needs scikit-learn')
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-@pytest.mark.parametrize('clazz', [RandomForestClassifier, GradientBoostingClassifier])
+@pytest.mark.parametrize('clazz', [RandomForestClassifier, ExtraTreesClassifier,
+                                   GradientBoostingClassifier])
 def test_skl_converter_binary_classifier(tmpdir, clazz, toolchain):
     # pylint: disable=too-many-locals
     """Convert scikit-learn binary classifier"""
@@ -105,7 +116,8 @@ def test_skl_converter_binary_classifier(tmpdir, clazz, toolchain):
 
 @pytest.mark.skipif(not has_sklearn(), reason='Needs scikit-learn')
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-@pytest.mark.parametrize('clazz', [RandomForestRegressor, GradientBoostingRegressor])
+@pytest.mark.parametrize('clazz', [RandomForestRegressor, ExtraTreesRegressor,
+                                   GradientBoostingRegressor])
 def test_skl_converter_regressor(tmpdir, clazz, toolchain):  # pylint: disable=too-many-locals
     """Convert scikit-learn regressor"""
     X, y = load_boston(return_X_y=True)

--- a/tests/python/test_skl_importer.py
+++ b/tests/python/test_skl_importer.py
@@ -8,7 +8,7 @@ import treelite
 import treelite_runtime
 from treelite.contrib import _libext
 from treelite.util import has_sklearn
-from .util import os_compatible_toolchains, check_predictor
+from .util import os_compatible_toolchains
 
 
 if has_sklearn():


### PR DESCRIPTION
Add support for `ExtraTreesRegressor` and `ExtraTreesClassifier`. Since they use the same decision tree class as `RandomForestRegressor` and `RandomForestClassifier`, we can reuse most of the importing logic in `treelite.sklearn`.

cc @wphicks @canonizer 