### PR TITLE
Factor out common logics from xgboost and xgboost_json frontends

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,6 +86,7 @@ target_sources(objtreelite
     frontend/lightgbm.cc
     frontend/xgboost.cc
     frontend/xgboost_json.cc
+    frontend/xgboost_util.cc
     annotator.cc
     filesystem.cc
     optable.cc

--- a/src/frontend/xgboost.cc
+++ b/src/frontend/xgboost.cc
@@ -386,6 +386,9 @@ inline std::unique_ptr<treelite::Model> ParseStream(dmlc::Stream* fi) {
   model->num_output_group = std::max(mparam_.num_class, 1);
   model->random_forest_flag = false;
 
+  // set correct prediction transform function, depending on objective function
+  treelite::details::xgboost::SetPredTransform(name_obj_, &model->param);
+
   // set global bias
   model->param.global_bias = static_cast<float>(mparam_.base_score);
   // Before XGBoost 1.0.0, the global bias saved in model is a transformed value.  After
@@ -394,9 +397,6 @@ inline std::unique_ptr<treelite::Model> ParseStream(dmlc::Stream* fi) {
   if (need_transform_to_margin) {
     treelite::details::xgboost::TransformGlobalBiasToMargin(&model->param);
   }
-
-  // set correct prediction transform function, depending on objective function
-  treelite::details::xgboost::SetPredTransform(name_obj_, &model->param);
 
   // traverse trees
   for (const auto& xgb_tree : xgb_trees_) {

--- a/src/frontend/xgboost.cc
+++ b/src/frontend/xgboost.cc
@@ -379,10 +379,6 @@ inline std::unique_ptr<treelite::Model> ParseStream(dmlc::Stream* fi) {
   }
   CHECK_EQ(gbm_param_.num_roots, 1) << "multi-root trees not supported";
 
-  // Before XGBoost 1.0.0, the global bias saved in model is a transformed value.  After
-  // 1.0 it's the original value provided by user.
-  bool need_transform_to_margin = mparam_.major_version >= 1;
-
   /* 2. Export model */
   std::unique_ptr<treelite::Model> model_ptr = treelite::Model::Create<float, float>();
   auto* model = dynamic_cast<treelite::ModelImpl<float, float>*>(model_ptr.get());
@@ -392,36 +388,15 @@ inline std::unique_ptr<treelite::Model> ParseStream(dmlc::Stream* fi) {
 
   // set global bias
   model->param.global_bias = static_cast<float>(mparam_.base_score);
-  std::vector<std::string> exponential_family {
-    "count:poisson", "reg:gamma", "reg:tweedie"
-  };
+  // Before XGBoost 1.0.0, the global bias saved in model is a transformed value.  After
+  // 1.0 it's the original value provided by user.
+  const bool need_transform_to_margin = mparam_.major_version >= 1;
   if (need_transform_to_margin) {
-    if (name_obj_ == "reg:logistic" || name_obj_ == "binary:logistic") {
-      model->param.global_bias = treelite::details::ProbToMargin::Sigmoid(model->param.global_bias);
-    } else if (std::find(exponential_family.cbegin() , exponential_family.cend(), name_obj_)
-               != exponential_family.cend()) {
-      model->param.global_bias = treelite::details::ProbToMargin::Exponential(
-          model->param.global_bias);
-    }
+    treelite::details::xgboost::TransformGlobalBiasToMargin(&model->param);
   }
 
   // set correct prediction transform function, depending on objective function
-  if (name_obj_ == "multi:softmax") {
-    std::strncpy(model->param.pred_transform, "max_index",
-                 sizeof(model->param.pred_transform));
-  } else if (name_obj_ == "multi:softprob") {
-    std::strncpy(model->param.pred_transform, "softmax", sizeof(model->param.pred_transform));
-  } else if (name_obj_ == "reg:logistic" || name_obj_ == "binary:logistic") {
-    std::strncpy(model->param.pred_transform, "sigmoid", sizeof(model->param.pred_transform));
-    model->param.sigmoid_alpha = 1.0f;
-  } else if (std::find(exponential_family.cbegin() , exponential_family.cend(), name_obj_)
-             != exponential_family.cend()) {
-    std::strncpy(model->param.pred_transform, "exponential",
-                 sizeof(model->param.pred_transform));
-  } else {
-    std::strncpy(model->param.pred_transform, "identity",
-                 sizeof(model->param.pred_transform));
-  }
+  treelite::details::xgboost::SetPredTransform(name_obj_, &model->param);
 
   // traverse trees
   for (const auto& xgb_tree : xgb_trees_) {

--- a/src/frontend/xgboost/xgboost.h
+++ b/src/frontend/xgboost/xgboost.h
@@ -7,10 +7,17 @@
 #ifndef TREELITE_FRONTEND_XGBOOST_XGBOOST_H_
 #define TREELITE_FRONTEND_XGBOOST_XGBOOST_H_
 
+#include <string>
+#include <vector>
 #include <cmath>
 
 namespace treelite {
+
+struct ModelParam;  // forward declaration
+
 namespace details {
+namespace xgboost {
+
 struct ProbToMargin {
   static float Sigmoid(float global_bias) {
     return -logf(1.0f / global_bias - 1.0f);
@@ -19,6 +26,16 @@ struct ProbToMargin {
     return logf(global_bias);
   }
 };
+
+extern const std::vector<std::string> exponential_objectives;
+
+// set correct prediction transform function, depending on objective function
+void SetPredTransform(const std::string& objective_name, ModelParam* param);
+
+// Transform the global bias parameter from probability into margin score
+void TransformGlobalBiasToMargin(ModelParam* param);
+
+}  // namespace xgboost
 }  // namespace details
 }  // namespace treelite
 #endif  // TREELITE_FRONTEND_XGBOOST_XGBOOST_H_

--- a/src/frontend/xgboost_util.cc
+++ b/src/frontend/xgboost_util.cc
@@ -1,0 +1,56 @@
+/*!
+ * Copyright (c) 2020 by Contributors
+ * \file xgboost_util.cc
+ * \brief Common utilities for XGBoost frontends
+ * \author Hyunsu Cho
+ */
+
+#include <treelite/tree.h>
+#include <cstring>
+#include "xgboost/xgboost.h"
+
+namespace {
+
+inline void SetPredTransformString(const char* value, treelite::ModelParam* param) {
+  std::strncpy(param->pred_transform, value, sizeof(param->pred_transform));
+}
+
+}  // anonymous namespace
+
+namespace treelite {
+namespace details {
+namespace xgboost {
+
+const std::vector<std::string> exponential_objectives{
+    "count:poisson", "reg:gamma", "reg:tweedie"
+};
+
+// set correct prediction transform function, depending on objective function
+void SetPredTransform(const std::string& objective_name, ModelParam* param) {
+  if (objective_name == "multi:softmax") {
+    SetPredTransformString("max_index", param);
+  } else if (objective_name == "multi:softprob") {
+    SetPredTransformString("softmax", param);
+  } else if (objective_name == "reg:logistic" || objective_name == "binary:logistic") {
+    SetPredTransformString("sigmoid", param);
+    param->sigmoid_alpha = 1.0f;
+  } else if (std::find(exponential_objectives.cbegin(), exponential_objectives.cend(),
+                       objective_name) != exponential_objectives.cend()) {
+    SetPredTransformString("exponential", param);
+  } else {
+    SetPredTransformString("identity", param);
+  }
+}
+
+// Transform the global bias parameter from probability into margin score
+void TransformGlobalBiasToMargin(ModelParam* param) {
+  if (std::strcmp(param->pred_transform, "sigmoid") == 0) {
+    param->global_bias = ProbToMargin::Sigmoid(param->global_bias);
+  } else if (std::strcmp(param->pred_transform, "exponential") == 0) {
+    param->global_bias = ProbToMargin::Exponential(param->global_bias);
+  }
+}
+
+}  // namespace xgboost
+}  // namespace details
+}  // namespace treelite


### PR DESCRIPTION
Factor out common functions `TransformGlobalBiasToMargin` and `SetPredTransform` from `xgboost` and `xgboost_json` frontends. This way, it's easier to add support for more objectives from XGBoost.

Depends on #218
Will rebase after #218 is merged to the mainline.