### PR TITLE
Bugfix in XGBoost-JSON frontend: Use correct field to set leaf outputs

### DIFF
--- a/src/frontend/xgboost_json.cc
+++ b/src/frontend/xgboost_json.cc
@@ -193,7 +193,7 @@ bool RegTreeHandler::EndObject(std::size_t memberCount) {
     Q.pop();
 
     if (left_children[old_id] == -1) {
-      output.SetLeaf(new_id, base_weights[old_id]);
+      output.SetLeaf(new_id, split_conditions[old_id]);
     } else {
       output.AddChilds(new_id);
       output.SetNumericalSplit(


### PR DESCRIPTION
In the XGBoost JSON model spec, it is the `split_conditions` field that holds the leaf output values, not `base_weights`.

Also expand test coverage for XGBoost-JSON, so that we don't run into similar bugs later.