### PR TITLE
Add all objectives currently supported by XGBoost

### DIFF
--- a/src/compiler/native/pred_transform.h
+++ b/src/compiler/native/pred_transform.h
@@ -38,6 +38,19 @@ inline std::string signed_square(const Model& model) {
       "copysign"_a = native::CCopySignForTypeInfo(threshold_type));
 }
 
+inline std::string hinge(const Model& model) {
+  const TypeInfo threshold_type = model.GetThresholdType();
+  return fmt::format(
+      R"TREELITETEMPLATE(static inline {threshold_type} pred_transform({threshold_type} margin) {{
+  if (margin > 0) {{
+    return ({threshold_type})(1);
+  }} else {{
+    return ({threshold_type})(0);
+  }}
+}})TREELITETEMPLATE",
+      "threshold_type"_a = native::TypeInfoToCTypeString(threshold_type));
+}
+
 inline std::string sigmoid(const Model& model) {
   const float alpha = model.param.sigmoid_alpha;
   const TypeInfo threshold_type = model.GetThresholdType();

--- a/src/compiler/pred_transform.cc
+++ b/src/compiler/pred_transform.cc
@@ -33,6 +33,7 @@ FUNC_NAME(const std::string& backend, const Model& model) { \
 
 TREELITE_PRED_TRANSFORM_REGISTRY_DEFAULT_TEMPLATE(identity)
 TREELITE_PRED_TRANSFORM_REGISTRY_DEFAULT_TEMPLATE(signed_square)
+TREELITE_PRED_TRANSFORM_REGISTRY_DEFAULT_TEMPLATE(hinge)
 TREELITE_PRED_TRANSFORM_REGISTRY_DEFAULT_TEMPLATE(sigmoid)
 TREELITE_PRED_TRANSFORM_REGISTRY_DEFAULT_TEMPLATE(exponential)
 TREELITE_PRED_TRANSFORM_REGISTRY_DEFAULT_TEMPLATE(logarithm_one_plus_exp)
@@ -45,6 +46,7 @@ const std::unordered_map<std::string, PredTransformFuncGenerator>
 pred_transform_db = {
   PRED_TRANSFORM_FUNC(identity),
   PRED_TRANSFORM_FUNC(signed_square),
+  PRED_TRANSFORM_FUNC(hinge),
   PRED_TRANSFORM_FUNC(sigmoid),
   PRED_TRANSFORM_FUNC(exponential),
   PRED_TRANSFORM_FUNC(logarithm_one_plus_exp)
@@ -56,6 +58,9 @@ pred_transform_db = {
   - signed_square
     Apply the function f(x) = sign(x) * (x**2) element-wise to the margin vector. The
     output will be a vector of length [number of data points].
+  - hinge
+    Apply the function f(x) = (1 if x > 0 else 0) element-wise to the margin vector. The
+    output will be a vector of length [number of data points], filled with 0's and 1's.
   - sigmoid
     Apply the sigmoid function element-wise to the margin vector. The output
     will be a vector of length [number of data points] that contains the

--- a/src/frontend/xgboost.cc
+++ b/src/frontend/xgboost.cc
@@ -395,7 +395,7 @@ inline std::unique_ptr<treelite::Model> ParseStream(dmlc::Stream* fi) {
   // 1.0 it's the original value provided by user.
   const bool need_transform_to_margin = mparam_.major_version >= 1;
   if (need_transform_to_margin) {
-    treelite::details::xgboost::TransformGlobalBiasToMargin(&model->param);
+    treelite::details::xgboost::TransformGlobalBiasToMargin(name_obj_, &model->param);
   }
 
   // traverse trees

--- a/src/frontend/xgboost/xgboost.h
+++ b/src/frontend/xgboost/xgboost.h
@@ -33,7 +33,7 @@ extern const std::vector<std::string> exponential_objectives;
 void SetPredTransform(const std::string& objective_name, ModelParam* param);
 
 // Transform the global bias parameter from probability into margin score
-void TransformGlobalBiasToMargin(ModelParam* param);
+void TransformGlobalBiasToMargin(const std::string& objective_name, ModelParam* param);
 
 }  // namespace xgboost
 }  // namespace details

--- a/src/frontend/xgboost/xgboost_json.h
+++ b/src/frontend/xgboost/xgboost_json.h
@@ -292,10 +292,15 @@ class LearnerParamHandler : public OutputHandler<treelite::ModelImpl<float, floa
   bool String(const char *str, std::size_t length, bool copy) override;
 };
 
+struct XGBoostModelHandle {
+  treelite::ModelImpl<float, float>* model;
+  std::string objective_name;
+};
+
 /*! \brief handler for Learner objects from XGBoost schema*/
-class LearnerHandler : public OutputHandler<treelite::ModelImpl<float, float>> {
+class LearnerHandler : public OutputHandler<XGBoostModelHandle> {
  public:
-  using OutputHandler<treelite::ModelImpl<float, float>>::OutputHandler;
+  using OutputHandler<XGBoostModelHandle>::OutputHandler;
   bool StartObject() override;
   bool EndObject(std::size_t memberCount) override;
 
@@ -303,10 +308,10 @@ class LearnerHandler : public OutputHandler<treelite::ModelImpl<float, float>> {
   std::string objective;
 };
 
-/*! \brief handler for XGBoostModel objects from XGBoost schema*/
-class XGBoostModelHandler : public OutputHandler<treelite::ModelImpl<float, float>> {
+/*! \brief handler for XGBoostModel objects from XGBoost schema */
+class XGBoostModelHandler : public OutputHandler<XGBoostModelHandle> {
  public:
-  using OutputHandler<treelite::ModelImpl<float, float>>::OutputHandler;
+  using OutputHandler<XGBoostModelHandle>::OutputHandler;
   bool StartArray() override;
   bool StartObject() override;
   bool EndObject(std::size_t memberCount) override;
@@ -320,6 +325,8 @@ class RootHandler : public OutputHandler<std::unique_ptr<treelite::Model>> {
  public:
   using OutputHandler<std::unique_ptr<treelite::Model>>::OutputHandler;
   bool StartObject() override;
+ private:
+  XGBoostModelHandle handle;
 };
 
 /*! \brief handler which delegates JSON parsing to stack of delegates*/

--- a/src/frontend/xgboost_util.cc
+++ b/src/frontend/xgboost_util.cc
@@ -6,6 +6,7 @@
  */
 
 #include <treelite/tree.h>
+#include <dmlc/logging.h>
 #include <cstring>
 #include "xgboost/xgboost.h"
 
@@ -22,7 +23,7 @@ namespace details {
 namespace xgboost {
 
 const std::vector<std::string> exponential_objectives{
-    "count:poisson", "reg:gamma", "reg:tweedie"
+    "count:poisson", "reg:gamma", "reg:tweedie", "survival:cox", "survival:aft"
 };
 
 // set correct prediction transform function, depending on objective function
@@ -37,8 +38,18 @@ void SetPredTransform(const std::string& objective_name, ModelParam* param) {
   } else if (std::find(exponential_objectives.cbegin(), exponential_objectives.cend(),
                        objective_name) != exponential_objectives.cend()) {
     SetPredTransformString("exponential", param);
-  } else {
+  } else if (objective_name == "binary:hinge") {
+    SetPredTransformString("hinge", param);
+  } else if (objective_name == "reg:squarederror" || objective_name == "reg:linear"
+             || objective_name == "reg:squaredlogerror"
+             || objective_name == "reg:pseudohubererror"
+             || objective_name == "binary:logitraw"
+             || objective_name == "rank:pairwise"
+             || objective_name == "rank:ndcg"
+             || objective_name == "rank:map") {
     SetPredTransformString("identity", param);
+  } else {
+    LOG(FATAL) << "Unrecognized XGBoost objective: " << objective_name;
   }
 }
 

--- a/src/frontend/xgboost_util.cc
+++ b/src/frontend/xgboost_util.cc
@@ -54,10 +54,18 @@ void SetPredTransform(const std::string& objective_name, ModelParam* param) {
 }
 
 // Transform the global bias parameter from probability into margin score
-void TransformGlobalBiasToMargin(ModelParam* param) {
-  if (std::strcmp(param->pred_transform, "sigmoid") == 0) {
+void TransformGlobalBiasToMargin(const std::string& objective_name, ModelParam* param) {
+  std::string bias_transform{param->pred_transform};
+  if (objective_name == "binary:logitraw") {
+    // Special handling for 'logitraw', where the global bias is transformed with 'sigmoid',
+    // but the prediction is returned un-transformed.
+    CHECK_EQ(bias_transform, "identity");
+    bias_transform = "sigmoid";
+  }
+
+  if (bias_transform == "sigmoid") {
     param->global_bias = ProbToMargin::Sigmoid(param->global_bias);
-  } else if (std::strcmp(param->pred_transform, "exponential") == 0) {
+  } else if (bias_transform == "exponential") {
     param->global_bias = ProbToMargin::Exponential(param->global_bias);
   }
 }

--- a/tests/cpp/test_frontend.cc
+++ b/tests/cpp/test_frontend.cc
@@ -464,9 +464,10 @@ TEST(XGBoostModelHandlerSuite, XGBoostModelHandler) {
   std::shared_ptr<MockDelegator> delegator =
     std::make_shared<MockDelegator>();
 
-  ModelImpl<float, float> output;
-  details::LearnerParamHandler wrapped_handler {delegator, output};
-  MockObjectStarter handler {delegator, wrapped_handler};
+  ModelImpl<float, float> output_model;
+  details::XGBoostModelHandle output{&output_model, ""};
+  details::XGBoostModelHandler wrapped_handler{delegator, output};
+  MockObjectStarter handler{delegator, wrapped_handler};
 
   rapidjson::Reader reader;
   reader.Parse(input_stream, handler);
@@ -485,8 +486,8 @@ TEST(RootHandlerSuite, RootHandler) {
   std::shared_ptr<MockDelegator> delegator =
     std::make_shared<MockDelegator>();
 
-  ModelImpl<float, float> output;
-  details::LearnerParamHandler wrapped_handler {delegator, output};
+  std::unique_ptr<treelite::Model> output;
+  details::RootHandler wrapped_handler {delegator, output};
   MockObjectStarter handler {delegator, wrapped_handler};
 
   rapidjson::Reader reader;

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -21,8 +21,11 @@ except ImportError:
 
 @pytest.mark.skipif(not has_sklearn(), reason='Needs scikit-learn')
 @pytest.mark.parametrize('model_format', ['binary', 'json'])
+@pytest.mark.parametrize('objective', ['reg:linear', 'reg:squarederror', 'reg:squaredlogerror',
+                                       'reg:pseudohubererror'])
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-def test_xgb_boston(tmpdir, toolchain, model_format):  # pylint: disable=too-many-locals
+def test_xgb_boston(tmpdir, toolchain, objective, model_format):
+    # pylint: disable=too-many-locals
     """Test Boston data (regression)"""
     from sklearn.datasets import load_boston
     from sklearn.model_selection import train_test_split
@@ -31,7 +34,7 @@ def test_xgb_boston(tmpdir, toolchain, model_format):  # pylint: disable=too-man
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
     dtrain = xgboost.DMatrix(X_train, label=y_train)
     dtest = xgboost.DMatrix(X_test, label=y_test)
-    param = {'max_depth': 8, 'eta': 1, 'silent': 1, 'objective': 'reg:linear'}
+    param = {'max_depth': 8, 'eta': 1, 'silent': 1, 'objective': objective}
     num_round = 10
     bst = xgboost.train(param, dtrain, num_boost_round=num_round,
                         evals=[(dtrain, 'train'), (dtest, 'test')])
@@ -65,7 +68,8 @@ def test_xgb_boston(tmpdir, toolchain, model_format):  # pylint: disable=too-man
 @pytest.mark.skipif(not has_sklearn(), reason='Needs scikit-learn')
 @pytest.mark.parametrize('model_format', ['binary', 'json'])
 @pytest.mark.parametrize('objective,expected_pred_transform',
-                         [('multi:softmax', 'max_index'), ('multi:softprob', 'softmax')])
+                         [('multi:softmax', 'max_index'), ('multi:softprob', 'softmax')],
+                         ids=['multi:softmax', 'multi:softprob'])
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())
 def test_xgb_iris(tmpdir, toolchain, objective, model_format, expected_pred_transform):
     # pylint: disable=too-many-locals

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -112,8 +112,12 @@ def test_xgb_iris(tmpdir, toolchain, objective, model_format, expected_pred_tran
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())
 @pytest.mark.parametrize('model_format', ['binary', 'json'])
 @pytest.mark.parametrize('objective,max_label,expected_global_bias',
-                         [('binary:logistic', 2, 0), ('count:poisson', 4, math.log(0.5))],
-                         ids=['binary:logistic', 'count:poisson'])
+                         [('binary:logistic', 2, 0),
+                          ('binary:hinge', 2, 0.5),
+                          ('binary:logitraw', 2, 0),
+                          ('count:poisson', 4, math.log(0.5))],
+                         ids=['binary:logistic', 'binary:hinge', 'binary:logitraw',
+                              'count:poisson'])
 def test_nonlinear_objective(tmpdir, objective, max_label, expected_global_bias, toolchain,
                              model_format):
     # pylint: disable=too-many-locals,too-many-arguments
@@ -148,7 +152,10 @@ def test_nonlinear_objective(tmpdir, objective, max_label, expected_global_bias,
     libpath = os.path.join(tmpdir, objective_tag + _libext())
     model.export_lib(toolchain=toolchain, libpath=libpath, params={}, verbose=True)
 
-    expected_pred_transform = {'binary:logistic': 'sigmoid', 'count:poisson': 'exponential'}
+    expected_pred_transform = {'binary:logistic': 'sigmoid',
+                               'binary:hinge': 'hinge',
+                               'binary:logitraw': 'identity',
+                               'count:poisson': 'exponential'}
 
     predictor = treelite_runtime.Predictor(libpath=libpath, verbose=True)
     assert predictor.num_feature == dtrain.num_col()


### PR DESCRIPTION
Add objectives that are recently added in XGBoost:
* `binary:hinge`
* `reg:squarederror`, `reg:squaredlogerror`, `reg:pseudohubererror`
* `binary:logitraw`
* `survival:cox`, `survival:aft`
* `rank:pairwise`, `rank:ndcg`, `rank:map`

TODO. Add test coverage to the newly added objectives.

Closes #154

Depends on #217 and #218.
Will rebase this PR once both #217 and #218 are merged into the mainline branch.