### PR TITLE
Improve handling missing values for LightGBM models

### DIFF
--- a/include/treelite/math.h
+++ b/include/treelite/math.h
@@ -23,10 +23,10 @@ namespace math {
  * \tparam Iter type of iterator
  * \tparam T type of elements
  */
-template<class Iter, class T>
+template <class Iter, class T>
 Iter binary_search(Iter begin, Iter end, const T& val) {
   Iter i = std::lower_bound(begin, end, val);
-  if (i != end && !(val < *i)) {
+  if (i != end && val == *i) {
     return i;  // found
   } else {
     return end;  // not found

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -125,10 +125,9 @@ class Tree {
      */
     Operator cmp_;
     /* \brief Whether to convert missing value to zero.
-     * Only applicable when split_type_ is set to kCategorical.
      * When this flag is set, it overrides the behavior of default_left().
      */
-    bool missing_category_to_zero_;
+    bool missing_value_to_zero_;
     /*! \brief whether data_count_ field is present */
     bool data_count_present_;
     /*! \brief whether sum_hess_ field is present */
@@ -342,12 +341,11 @@ class Tree {
     return nodes_[nid].gain_;
   }
   /*!
-   * \brief test whether missing values should be converted into zero; only applicable for
-   *        categorical splits
+   * \brief test whether missing values should be converted into zero
    * \param nid ID of node being queried
    */
-  inline bool MissingCategoryToZero(int nid) const {
-    return nodes_[nid].missing_category_to_zero_;
+  inline bool MissingValueToZero(int nid) const {
+    return nodes_[nid].missing_value_to_zero_;
   }
 
   /** Setters **/
@@ -357,22 +355,24 @@ class Tree {
    * \param split_index feature index to split
    * \param threshold threshold value
    * \param default_left the default direction when feature is unknown
+   * \param missing_value_to_zero whether missing values should be converted into zero
    * \param cmp comparison operator to compare between feature value and
    *            threshold
    */
   inline void SetNumericalSplit(int nid, unsigned split_index, ThresholdType threshold,
-                                bool default_left, Operator cmp);
+                                bool default_left, bool missing_value_to_zero, Operator cmp);
   /*!
    * \brief create a categorical split
    * \param nid ID of node being updated
    * \param split_index feature index to split
    * \param threshold threshold value
    * \param default_left the default direction when feature is unknown
+   * \param missing_value_to_zero whether missing values should be converted into zero
    * \param cmp comparison operator to compare between feature value and
    *            threshold
    */
   inline void SetCategoricalSplit(int nid, unsigned split_index, bool default_left,
-                                  bool missing_category_to_zero,
+                                  bool missing_value_to_zero,
                                   const std::vector<uint32_t>& left_categories);
   /*!
    * \brief set the leaf value of the node

--- a/include/treelite/tree_impl.h
+++ b/include/treelite/tree_impl.h
@@ -428,7 +428,7 @@ inline void Tree<ThresholdType, LeafOutputType>::Node::Init() {
   info_.threshold = static_cast<ThresholdType>(0);
   data_count_ = 0;
   sum_hess_ = gain_ = 0.0;
-  missing_category_to_zero_ = false;
+  missing_value_to_zero_ = false;
   data_count_present_ = sum_hess_present_ = gain_present_ = false;
   split_type_ = SplitFeatureType::kNone;
   cmp_ = Operator::kNone;
@@ -504,7 +504,8 @@ Tree<ThresholdType, LeafOutputType>::GetCategoricalFeatures() const {
 template <typename ThresholdType, typename LeafOutputType>
 inline void
 Tree<ThresholdType, LeafOutputType>::SetNumericalSplit(
-    int nid, unsigned split_index, ThresholdType threshold, bool default_left, Operator cmp) {
+    int nid, unsigned split_index, ThresholdType threshold, bool default_left,
+    bool missing_value_to_zero, Operator cmp) {
   Node& node = nodes_[nid];
   if (split_index >= ((1U << 31U) - 1)) {
     throw std::runtime_error("split_index too big");
@@ -514,12 +515,13 @@ Tree<ThresholdType, LeafOutputType>::SetNumericalSplit(
   (node.info_).threshold = threshold;
   node.cmp_ = cmp;
   node.split_type_ = SplitFeatureType::kNumerical;
+  node.missing_value_to_zero_ = missing_value_to_zero;
 }
 
 template <typename ThresholdType, typename LeafOutputType>
 inline void
 Tree<ThresholdType, LeafOutputType>::SetCategoricalSplit(
-    int nid, unsigned split_index, bool default_left, bool missing_category_to_zero,
+    int nid, unsigned split_index, bool default_left, bool missing_value_to_zero,
     const std::vector<uint32_t>& node_left_categories) {
   if (split_index >= ((1U << 31U) - 1)) {
     throw std::runtime_error("split_index too big");
@@ -547,7 +549,7 @@ Tree<ThresholdType, LeafOutputType>::SetCategoricalSplit(
   if (default_left) split_index |= (1U << 31U);
   node.sindex_ = split_index;
   node.split_type_ = SplitFeatureType::kCategorical;
-  node.missing_category_to_zero_ = missing_category_to_zero;
+  node.missing_value_to_zero_ = missing_value_to_zero;
 }
 
 template <typename ThresholdType, typename LeafOutputType>

--- a/src/compiler/ast/ast.h
+++ b/src/compiler/ast/ast.h
@@ -102,19 +102,23 @@ class CodeFolderNode : public ASTNode {
 
 class ConditionNode : public ASTNode {
  public:
-  ConditionNode(unsigned split_index, bool default_left)
-    : split_index(split_index), default_left(default_left) {}
+  ConditionNode(unsigned split_index, bool default_left, bool convert_missing_to_zero)
+    : split_index(split_index), default_left(default_left),
+      convert_missing_to_zero(convert_missing_to_zero) {}
   unsigned split_index;
   bool default_left;
+  bool convert_missing_to_zero;
   dmlc::optional<double> gain;
 
   std::string GetDump() const override {
     if (gain) {
-      return fmt::format("ConditionNode {{ split_index: {}, default_left: {}, gain: {} }}",
-                         split_index, default_left, gain.value());
+      return fmt::format("ConditionNode {{ split_index: {}, default_left: {}, "
+                         "convert_missing_to_zero: {}, gain: {} }}",
+                         split_index, default_left, convert_missing_to_zero, gain.value());
     } else {
-      return fmt::format("ConditionNode {{ split_index: {}, default_left: {} }}",
-                         split_index, default_left);
+      return fmt::format("ConditionNode {{ split_index: {}, default_left: {}, "
+                         "convert_missing_to_zero: {} }}",
+                         split_index, default_left, convert_missing_to_zero);
     }
   }
 };
@@ -131,32 +135,34 @@ template <typename ThresholdType>
 class NumericalConditionNode : public ConditionNode {
  public:
   NumericalConditionNode(unsigned split_index, bool default_left,
+                         bool convert_missing_to_zero,
                          bool quantized, Operator op,
                          ThresholdVariant<ThresholdType> threshold)
-    : ConditionNode(split_index, default_left),
-      quantized(quantized), op(op), threshold(threshold) {}
+    : ConditionNode(split_index, default_left, convert_missing_to_zero),
+      quantized(quantized), op(op), threshold(threshold), zero_quantized(-1) {}
   bool quantized;
   Operator op;
   ThresholdVariant<ThresholdType> threshold;
+  int zero_quantized;  // quantized value of 0.0f (useful when convert_missing_to_zero is set)
 
   std::string GetDump() const override {
-    return fmt::format("NumericalConditionNode {{ {}, quantized: {}, op: {}, threshold: {} }}",
+    return fmt::format("NumericalConditionNode {{ {}, quantized: {}, op: {}, threshold: {}, "
+                       "zero_quantized: {} }}",
                        ConditionNode::GetDump(), quantized, OpName(op),
                        (quantized ? fmt::format("{}", threshold.int_val)
-                                  : fmt::format("{}", threshold.float_val)));
+                                  : fmt::format("{}", threshold.float_val)),
+                       zero_quantized);
   }
 };
 
 class CategoricalConditionNode : public ConditionNode {
  public:
   CategoricalConditionNode(unsigned split_index, bool default_left,
-                           const std::vector<uint32_t>& left_categories,
-                           bool convert_missing_to_zero)
-    : ConditionNode(split_index, default_left),
-      left_categories(left_categories),
-      convert_missing_to_zero(convert_missing_to_zero) {}
+                           bool convert_missing_to_zero,
+                           const std::vector<uint32_t>& left_categories)
+    : ConditionNode(split_index, default_left, convert_missing_to_zero),
+      left_categories(left_categories) {}
   std::vector<uint32_t> left_categories;
-  bool convert_missing_to_zero;
 
   std::string GetDump() const override {
     std::ostringstream oss;
@@ -165,9 +171,8 @@ class CategoricalConditionNode : public ConditionNode {
       oss << e << ", ";
     }
     oss << "]";
-    return fmt::format("CategoricalConditionNode {{ {}, left_categories: {}, "
-                       "convert_missing_to_zero: {} }}",
-                       ConditionNode::GetDump(), oss.str(), convert_missing_to_zero);
+    return fmt::format("CategoricalConditionNode {{ {}, left_categories: {} }}",
+                       ConditionNode::GetDump(), oss.str());
   }
 };
 

--- a/src/compiler/ast/build.cc
+++ b/src/compiler/ast/build.cc
@@ -50,15 +50,17 @@ ASTBuilder<ThresholdType, LeafOutputType>::BuildASTFromTree(
           parent,
           tree.SplitIndex(nid),
           tree.DefaultLeft(nid),
+          tree.MissingValueToZero(nid),
           false,
           tree.ComparisonOp(nid),
           ThresholdVariant<ThresholdType>(tree.Threshold(nid)));
     } else {
-      ast_node = AddNode<CategoricalConditionNode>(parent,
-                                                   tree.SplitIndex(nid),
-                                                   tree.DefaultLeft(nid),
-                                                   tree.LeftCategories(nid),
-                                                   tree.MissingCategoryToZero(nid));
+      ast_node = AddNode<CategoricalConditionNode>(
+          parent,
+          tree.SplitIndex(nid),
+          tree.DefaultLeft(nid),
+          tree.MissingValueToZero(nid),
+          tree.LeftCategories(nid));
     }
     if (tree.HasGain(nid)) {
       dynamic_cast<ConditionNode*>(ast_node)->gain = tree.Gain(nid);

--- a/src/compiler/ast/quantize.cc
+++ b/src/compiler/ast/quantize.cc
@@ -38,9 +38,19 @@ rewrite_thresholds(ASTNode* node, const std::vector<std::vector<ThresholdType>>&
     const ThresholdType threshold = num_cond->threshold.float_val;
     if (std::isfinite(threshold)) {
       const auto& v = cut_pts[num_cond->split_index];
-      auto loc = math::binary_search(v.begin(), v.end(), threshold);
-      CHECK(loc != v.end());
-      num_cond->threshold.int_val = static_cast<int>(loc - v.begin()) * 2;
+      {
+        auto loc = math::binary_search(v.begin(), v.end(), threshold);
+        CHECK(loc != v.end());
+        num_cond->threshold.int_val = static_cast<int>(loc - v.begin()) * 2;
+      }
+      {
+        ThresholdType zero = static_cast<ThresholdType>(0);
+        auto loc = std::lower_bound(v.begin(), v.end(), zero);
+        num_cond->zero_quantized = static_cast<int>(loc - v.begin()) * 2;
+        if (loc != v.end() && zero != *loc) {
+          --num_cond->zero_quantized;
+        }
+      }
       num_cond->quantized = true;
     }  // splits with infinite thresholds will not be quantized
   }

--- a/src/frontend/builder.cc
+++ b/src/frontend/builder.cc
@@ -471,7 +471,8 @@ ModelBuilderImpl::CommitModelImpl(ModelImpl<ThresholdType, LeafOutputType>* out_
           << TypeInfoToString(TypeToInfo<ThresholdType>())
           << " Given: " << TypeInfoToString(node->threshold.GetValueType());
         ThresholdType threshold = node->threshold.Get<ThresholdType>();
-        tree.SetNumericalSplit(nid, node->feature_id, threshold, node->default_left, node->op);
+        tree.SetNumericalSplit(nid, node->feature_id, threshold, node->default_left, false,
+                               node->op);
         Q.push({node->left_child, tree.LeftChild(nid)});
         Q.push({node->right_child, tree.RightChild(nid)});
       } else if (node->status == NodeDraft::Status::kCategoricalTest) {

--- a/src/frontend/lightgbm.cc
+++ b/src/frontend/lightgbm.cc
@@ -568,6 +568,7 @@ inline std::unique_ptr<treelite::Model> ParseStream(dmlc::Stream* fi) {
         }
       } else {  // non-leaf
         const auto split_index = static_cast<unsigned>(lgb_tree.split_feature[old_id]);
+        const auto missing_type = GetMissingType(lgb_tree.decision_type[old_id]);
 
         tree.AddChilds(new_id);
         if (GetDecisionType(lgb_tree.decision_type[old_id], kCategoricalMask)) {
@@ -578,8 +579,6 @@ inline std::unique_ptr<treelite::Model> ParseStream(dmlc::Stream* fi) {
                              + lgb_tree.cat_boundaries[cat_idx],
                            lgb_tree.cat_boundaries[cat_idx + 1]
                              - lgb_tree.cat_boundaries[cat_idx]);
-          const auto missing_type
-            = GetMissingType(lgb_tree.decision_type[old_id]);
           tree.SetCategoricalSplit(new_id, split_index, false, (missing_type != MissingType::kNaN),
                                    left_categories);
         } else {
@@ -588,7 +587,8 @@ inline std::unique_ptr<treelite::Model> ParseStream(dmlc::Stream* fi) {
           const bool default_left
             = GetDecisionType(lgb_tree.decision_type[old_id], kDefaultLeftMask);
           const treelite::Operator cmp_op = treelite::Operator::kLE;
-          tree.SetNumericalSplit(new_id, split_index, threshold, default_left, cmp_op);
+          tree.SetNumericalSplit(new_id, split_index, threshold, default_left,
+                                 (missing_type != MissingType::kNaN), cmp_op);
         }
         if (!lgb_tree.internal_count.empty()) {
           const int data_count = lgb_tree.internal_count[old_id];

--- a/src/frontend/xgboost.cc
+++ b/src/frontend/xgboost.cc
@@ -421,7 +421,7 @@ inline std::unique_ptr<treelite::Model> ParseStream(dmlc::Stream* fi) {
         const bst_float split_cond = node.split_cond();
         tree.AddChilds(new_id);
         tree.SetNumericalSplit(new_id, node.split_index(),
-            static_cast<float>(split_cond), node.default_left(), treelite::Operator::kLT);
+            static_cast<float>(split_cond), node.default_left(), false, treelite::Operator::kLT);
         tree.SetGain(new_id, stat.loss_chg);
         Q.push({node.cleft(), tree.LeftChild(new_id)});
         Q.push({node.cright(), tree.RightChild(new_id)});

--- a/src/frontend/xgboost_json.cc
+++ b/src/frontend/xgboost_json.cc
@@ -198,7 +198,7 @@ bool RegTreeHandler::EndObject(std::size_t memberCount) {
       output.AddChilds(new_id);
       output.SetNumericalSplit(
           new_id, split_indices[old_id], split_conditions[old_id],
-          default_left[old_id], treelite::Operator::kLT);
+          default_left[old_id], false, treelite::Operator::kLT);
       output.SetGain(new_id, loss_changes[old_id]);
       Q.push({left_children[old_id], output.LeftChild(new_id)});
       Q.push({right_children[old_id], output.RightChild(new_id)});

--- a/tests/python/test_lightgbm_integration.py
+++ b/tests/python/test_lightgbm_integration.py
@@ -3,6 +3,7 @@
 import os
 
 import numpy as np
+import scipy.sparse
 import pytest
 import treelite
 import treelite_runtime
@@ -149,6 +150,60 @@ def test_categorical_data(tmpdir, quantize, parallel_comp, toolchain):
     model.export_lib(toolchain=toolchain, libpath=libpath, params=params, verbose=True)
     predictor = treelite_runtime.Predictor(libpath=libpath, verbose=True)
     check_predictor(predictor, dataset)
+
+
+@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
+@pytest.mark.parametrize('quantize', [True, False])
+def test_sparse_ranking_model(tmpdir, quantize, toolchain):
+    """Generate a LightGBM ranking model with highly sparse data.
+    This example is inspired by https://github.com/dmlc/treelite/issues/222. It verifies that
+    Treelite is able to accommodate the unique behavior of LightGBM when it comes to handling
+    missing values.
+
+    LightGBM offers two modes of handling missing values:
+
+    1. Assign default direction per each test node: This is similar to how XGBoost handles missing
+       values.
+    2. Replace missing values with zeroes (0.0): This behavior is unique to LightGBM.
+
+    The mode is controlled by the missing_value_to_zero_ field of each test node.
+
+    This example is crafted so as to invoke the second mode of missing value handling.
+    """
+    rng = np.random.default_rng(seed=2020)
+    X = scipy.sparse.random(m=10, n=206947, format='csr', dtype=np.float64, random_state=0,
+                            density=0.0001)
+    X.data = rng.standard_normal(size=X.data.shape[0], dtype=np.float64)
+    y = rng.integers(low=0, high=5, size=X.shape[0])
+
+    params = {
+        'objective': 'lambdarank',
+        'num_leaves': 32,
+        'lambda_l1': 0.0,
+        'lambda_l2': 0.0,
+        'min_gain_to_split': 0.0,
+        'learning_rate': 1.0,
+        'min_data_in_leaf': 1
+    }
+
+    model_path = os.path.join(tmpdir, 'sparse_ranking_lightgbm.txt')
+    libpath = os.path.join(tmpdir, f'sparse_ranking_lgb' + _libext())
+
+    dtrain = lightgbm.Dataset(X, label=y, group=[X.shape[0]])
+
+    bst = lightgbm.train(params, dtrain, num_boost_round=1)
+    lgb_out = bst.predict(X)
+    bst.save_model(model_path)
+
+    model = treelite.Model.load(model_path, model_format='lightgbm')
+    model.export_lib(toolchain=toolchain, libpath=libpath, verbose=True)
+
+    predictor = treelite_runtime.Predictor(libpath, verbose=True)
+
+    dmat = treelite_runtime.DMatrix(X)
+    out = predictor.predict(dmat)
+
+    np.testing.assert_almost_equal(out, lgb_out)
 
 
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())

--- a/tests/python/test_lightgbm_integration.py
+++ b/tests/python/test_lightgbm_integration.py
@@ -155,6 +155,7 @@ def test_categorical_data(tmpdir, quantize, parallel_comp, toolchain):
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())
 @pytest.mark.parametrize('quantize', [True, False])
 def test_sparse_ranking_model(tmpdir, quantize, toolchain):
+    # pylint: disable=too-many-locals
     """Generate a LightGBM ranking model with highly sparse data.
     This example is inspired by https://github.com/dmlc/treelite/issues/222. It verifies that
     Treelite is able to accommodate the unique behavior of LightGBM when it comes to handling
@@ -187,7 +188,7 @@ def test_sparse_ranking_model(tmpdir, quantize, toolchain):
     }
 
     model_path = os.path.join(tmpdir, 'sparse_ranking_lightgbm.txt')
-    libpath = os.path.join(tmpdir, f'sparse_ranking_lgb' + _libext())
+    libpath = os.path.join(tmpdir, 'sparse_ranking_lgb' + _libext())
 
     dtrain = lightgbm.Dataset(X, label=y, group=[X.shape[0]])
 
@@ -196,7 +197,8 @@ def test_sparse_ranking_model(tmpdir, quantize, toolchain):
     bst.save_model(model_path)
 
     model = treelite.Model.load(model_path, model_format='lightgbm')
-    model.export_lib(toolchain=toolchain, libpath=libpath, verbose=True)
+    params = {'quantize': (1 if quantize else 0)}
+    model.export_lib(toolchain=toolchain, libpath=libpath, params=params, verbose=True)
 
     predictor = treelite_runtime.Predictor(libpath, verbose=True)
 


### PR DESCRIPTION
Closes #222 

Some LightGBM models replace all missing values with 0.0 prior to evaluating test thresholds. This is different from XGBoost, which always treats 0's and missing values differently.