### PR TITLE
Enhance error handling in XGBoost-JSON frontend: show error message + diagnosis

### DIFF
--- a/src/frontend/xgboost_json.cc
+++ b/src/frontend/xgboost_json.cc
@@ -128,8 +128,22 @@ std::unique_ptr<treelite::Model> LoadXGBoostJSONModel(const char* filename) {
 
 std::unique_ptr<treelite::Model> LoadXGBoostJSONModelString(const char* json_str, size_t length) {
   auto input_stream = std::make_unique<rapidjson::MemoryStream>(json_str, length);
-  auto error_handler = [](size_t offset) -> std::string {
-    return "";
+  auto error_handler = [json_str](size_t offset) -> std::string {
+    size_t cur = (offset >= 50 ? (offset - 50) : 0);
+    std::ostringstream oss, oss2;
+    for (int i = 0; i < 100; ++i) {
+      if (!json_str[cur]) {
+        break;
+      }
+      oss << json_str[cur];
+      if (cur == offset) {
+        oss2 << "^";
+      } else {
+        oss2 << "~";
+      }
+      ++cur;
+    }
+    return oss.str() + "\n" + oss2.str();
   };
   return ParseStream(std::move(input_stream), error_handler);
 }

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -42,7 +42,9 @@ def test_xgb_boston(tmpdir, toolchain, objective, model_format):
         model_name = 'boston.json'
         model_path = os.path.join(tmpdir, model_name)
         bst.save_model(model_path)
-        model = treelite.Model.load(filename=model_path, model_format='xgboost_json')
+        with open(model_path, 'r') as f:
+            json_str = f.read()
+        model = treelite.Model.from_xgboost_json(json_str)
     else:
         model = treelite.Model.from_xgboost(bst)
 

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -42,9 +42,7 @@ def test_xgb_boston(tmpdir, toolchain, objective, model_format):
         model_name = 'boston.json'
         model_path = os.path.join(tmpdir, model_name)
         bst.save_model(model_path)
-        with open(model_path, 'r') as f:
-            json_str = f.read()
-        model = treelite.Model.from_xgboost_json(json_str)
+        model = treelite.Model.load(filename=model_path, model_format='xgboost_json')
     else:
         model = treelite.Model.from_xgboost(bst)
 


### PR DESCRIPTION
Improve error diagnosis by showing a human-readable message as well as the location of the error.

Before:
```
[23:27:30] ../src/frontend/xgboost_json.cc:374: Parsing error 16 at offset 438
treelite.util.TreeliteError: [23:27:30] ../src/frontend/xgboost_json.cc:376: Provided JSON could not be parsed
as XGBoost model
```

After:
```
treelite.util.TreeliteError: [23:25:20] ../src/frontend/xgboost_json.cc:450: Provided JSON could not be parsed
as XGBoost model. Parsing error at offset 438: Terminate parsing due to Handler error.
,1.0290909E1],"categories":[],"categories_nodes":[],"categories_segments":[],"categories_sizes":[],"
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```