### PR TITLE
Add back Clone() method to the Tree class

### DIFF
--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -259,6 +259,8 @@ class Tree {
   Tree(Tree&&) noexcept = default;
   Tree& operator=(Tree&&) noexcept = default;
 
+  inline Tree<ThresholdType, LeafOutputType> Clone() const;
+
   inline const char* GetFormatStringForNode();
   inline void GetPyBuffer(std::vector<PyBufferFrame>* dest);
   inline void InitFromPyBuffer(std::vector<PyBufferFrame>::iterator begin,

--- a/include/treelite/tree_impl.h
+++ b/include/treelite/tree_impl.h
@@ -397,6 +397,19 @@ inline void InitScalarFromPyBuffer(T* scalar, PyBufferFrame buffer) {
 }
 
 template <typename ThresholdType, typename LeafOutputType>
+inline Tree<ThresholdType, LeafOutputType>
+Tree<ThresholdType, LeafOutputType>::Clone() const {
+  Tree<ThresholdType, LeafOutputType> tree;
+  tree.num_nodes = num_nodes;
+  tree.nodes_ = nodes_.Clone();
+  tree.leaf_vector_ = leaf_vector_.Clone();
+  tree.leaf_vector_offset_ = leaf_vector_offset_.Clone();
+  tree.matching_categories_ = matching_categories_.Clone();
+  tree.matching_categories_offset_ = matching_categories_offset_.Clone();
+  return tree;
+}
+
+template <typename ThresholdType, typename LeafOutputType>
 inline const char*
 Tree<ThresholdType, LeafOutputType>::GetFormatStringForNode() {
   if (std::is_same<ThresholdType, float>::value) {


### PR DESCRIPTION
In the recent refactor (#198, #199, #201, and #203) to add support for multiple data types, I accidentally remove the `Clone()` method from the `Tree` class. This PR adds it back.