### PR TITLE
Fix C++ compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,13 @@ option(USE_OPENMP "Use OpenMP" ON)
 option(BUILD_CPP_TEST "Build C++ tests" OFF)
 option(DETECT_CONDA_ENV "Enable detection of conda environment for dependencies" ON)
 option(BUILD_JVM_RUNTIME "Build Treelite runtime for JVM" OFF)
+option(ENABLE_ALL_WARNINGS "Enable all compiler warnings. Only effective for GCC/Clang" OFF)
+
+if(ENABLE_ALL_WARNINGS)
+  if((NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang") AND (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
+    message(SEND_ERROR "ENABLE_ALL_WARNINGS is only available for Clang and GCC.")
+  endif()
+endif()
 
 # When installing dependencies, use Conda environment if available
 if(DETECT_CONDA_ENV)

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -347,7 +347,7 @@ class Tree {
    * \param nid ID of node being queried
    */
   inline std::vector<LeafOutputType> LeafVector(int nid) const {
-    if (nid > leaf_vector_offset_.Size()) {
+    if (static_cast<size_t>(nid) > leaf_vector_offset_.Size()) {
       throw std::runtime_error("nid too large");
     }
     return std::vector<LeafOutputType>(&leaf_vector_[leaf_vector_offset_[nid]],
@@ -358,7 +358,7 @@ class Tree {
    * \param nid ID of node being queried
    */
   inline bool HasLeafVector(int nid) const {
-    if (nid > leaf_vector_offset_.Size()) {
+    if (static_cast<size_t>(nid) > leaf_vector_offset_.Size()) {
       throw std::runtime_error("nid too large");
     }
     return leaf_vector_offset_[nid] != leaf_vector_offset_[nid + 1];
@@ -386,7 +386,7 @@ class Tree {
    * \param nid ID of node being queried
    */
   inline std::vector<uint32_t> MatchingCategories(int nid) const {
-    if (nid > matching_categories_offset_.Size()) {
+    if (static_cast<size_t>(nid) > matching_categories_offset_.Size()) {
       throw std::runtime_error("nid too large");
     }
     return std::vector<uint32_t>(&matching_categories_[matching_categories_offset_[nid]],

--- a/include/treelite/tree_impl.h
+++ b/include/treelite/tree_impl.h
@@ -428,7 +428,7 @@ Tree<ThresholdType, LeafOutputType>::InitFromPyBuffer(
   }
   InitScalarFromPyBuffer(&num_nodes, *begin++);
   InitArrayFromPyBuffer(&nodes_, *begin++);
-  if (num_nodes != nodes_.Size()) {
+  if (static_cast<size_t>(num_nodes) != nodes_.Size()) {
     throw std::runtime_error("Could not load the correct number of nodes");
   }
   InitArrayFromPyBuffer(&leaf_vector_, *begin++);
@@ -664,7 +664,6 @@ Model::GetPyBuffer() {
 
 inline std::unique_ptr<Model>
 Model::CreateFromPyBuffer(std::vector<PyBufferFrame> frames) {
-  using TypeInfoInt = std::underlying_type<TypeInfo>::type;
   TypeInfo threshold_type, leaf_output_type;
   if (frames.size() < 2) {
     throw std::runtime_error("Insufficient number of frames: there must be at least two");

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,12 @@ else()
   message(STATUS "Disabling OpenMP")
 endif()
 
+if(ENABLE_ALL_WARNINGS)
+  foreach(target objtreelite objtreelite_runtime objtreelite_runtime)
+    target_compile_options(${target} PRIVATE -Wall -Wextra)
+  endforeach()
+endif()
+
 foreach(lib objtreelite objtreelite_runtime objtreelite_common)
   target_include_directories(${lib} PUBLIC
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>

--- a/src/annotator.cc
+++ b/src/annotator.cc
@@ -204,7 +204,6 @@ AnnotateImpl(
   counts_tloc.resize(count_row_ptr[ntree] * nthread, 0);
 
   const size_t num_row = dmat->GetNumRow();
-  const size_t num_col = dmat->GetNumCol();
   const size_t pstep = (num_row + 19) / 20;
   // interval to display progress
   for (size_t rbegin = 0; rbegin < num_row; rbegin += pstep) {

--- a/src/compiler/ast/build.cc
+++ b/src/compiler/ast/build.cc
@@ -25,8 +25,8 @@ ASTBuilder<ThresholdType, LeafOutputType>::BuildAST(
                                                model.num_feature);
   ASTNode* ac = AddNode<AccumulatorContextNode>(this->main_node);
   this->main_node->children.push_back(ac);
-  for (int tree_id = 0; tree_id < model.trees.size(); ++tree_id) {
-    ASTNode* tree_head = BuildASTFromTree(model.trees[tree_id], tree_id, 0, ac);
+  for (size_t tree_id = 0; tree_id < model.trees.size(); ++tree_id) {
+    ASTNode* tree_head = BuildASTFromTree(model.trees[tree_id], static_cast<int>(tree_id), 0, ac);
     ac->children.push_back(tree_head);
   }
   this->model_param = model.param.__DICT__();

--- a/src/compiler/ast/builder.h
+++ b/src/compiler/ast/builder.h
@@ -28,8 +28,7 @@ bool fold_code(ASTNode*, CodeFoldingContext*, ASTBuilder<ThresholdType, LeafOutp
 template <typename ThresholdType, typename LeafOutputType>
 class ASTBuilder {
  public:
-  ASTBuilder() : output_vector_flag(false), main_node(nullptr),
-                 quantize_threshold_flag(false) {}
+  ASTBuilder() : output_vector_flag(false), quantize_threshold_flag(false), main_node(nullptr) {}
 
   /* \brief initially build AST from model */
   void BuildAST(const ModelImpl<ThresholdType, LeafOutputType>& model);

--- a/src/compiler/ast_native.cc
+++ b/src/compiler/ast_native.cc
@@ -666,7 +666,7 @@ class ASTNativeCompiler : public Compiler {
         // multi-class classification with random forest
         CHECK_EQ(node->vector.size(), static_cast<size_t>(task_param_.num_class))
           << "Ill-formed model: leaf vector must be of length [num_class]";
-        for (int group_id = 0; group_id < task_param_.num_class; ++group_id) {
+        for (size_t group_id = 0; group_id < task_param_.num_class; ++group_id) {
           output_statement
             += fmt::format("sum[{group_id}] += ({leaf_output_type}){output};\n",
                  "group_id"_a = group_id,

--- a/src/compiler/common/format_util.h
+++ b/src/compiler/common/format_util.h
@@ -102,8 +102,8 @@ class ArrayFormatter {
 
  private:
   std::ostringstream oss_;  // string stream to store wrapped text
-  const size_t indent_;  // indent level, to indent each line
   const size_t text_width_;  // maximum length of each line
+  const size_t indent_;  // indent level, to indent each line
   const char delimiter_;  // delimiter (defaults to comma)
   const int default_precision_;  // default precision used by string stream
   size_t line_length_;  // width of current line

--- a/src/frontend/lightgbm.cc
+++ b/src/frontend/lightgbm.cc
@@ -467,7 +467,7 @@ inline std::unique_ptr<treelite::Model> ParseStream(dmlc::Stream* fi) {
         break;
       }
     }
-    CHECK(num_class >= 0 && num_class == model->task_param.num_class)
+    CHECK(num_class >= 0 && static_cast<size_t>(num_class) == model->task_param.num_class)
       << "Ill-formed LightGBM model file: not a valid multiclass objective";
 
     std::strncpy(model->param.pred_transform, "softmax", sizeof(model->param.pred_transform));
@@ -489,7 +489,8 @@ inline std::unique_ptr<treelite::Model> ParseStream(dmlc::Stream* fi) {
         }
       }
     }
-    CHECK(num_class >= 0 && num_class == model->task_param.num_class && alpha > 0.0f)
+    CHECK(num_class >= 0 && static_cast<size_t>(num_class) == model->task_param.num_class
+          && alpha > 0.0f)
       << "Ill-formed LightGBM model file: not a valid multiclassova objective";
 
     std::strncpy(model->param.pred_transform, "multiclass_ova",

--- a/src/frontend/xgboost/xgboost_json.h
+++ b/src/frontend/xgboost/xgboost_json.h
@@ -41,23 +41,23 @@ class BaseHandler
     delegator{parent_delegator} {};
 
   virtual bool Null() { return false; }
-  virtual bool Bool(bool b) { return false; }
-  virtual bool Int(int i) { return false; }
-  virtual bool Uint(unsigned u) { return false; }
-  virtual bool Int64(int64_t i) { return false; }
-  virtual bool Uint64(uint64_t u) { return false; }
-  virtual bool Double(double d) { return false; }
-  virtual bool String(const char *str, std::size_t length, bool copy) {
+  virtual bool Bool(bool) { return false; }
+  virtual bool Int(int) { return false; }
+  virtual bool Uint(unsigned) { return false; }
+  virtual bool Int64(int64_t) { return false; }
+  virtual bool Uint64(uint64_t) { return false; }
+  virtual bool Double(double) { return false; }
+  virtual bool String(const char *, std::size_t, bool) {
     return false;
   }
   virtual bool StartObject() { return false; }
-  virtual bool Key(const char *str, std::size_t length, bool copy) {
+  virtual bool Key(const char *str, std::size_t length, bool) {
     set_cur_key(str, length);
     return true;
   }
-  virtual bool EndObject(std::size_t memberCount) { return pop_handler(); }
+  virtual bool EndObject(std::size_t) { return pop_handler(); }
   virtual bool StartArray() { return false; }
-  virtual bool EndArray(std::size_t elementCount) { return pop_handler(); }
+  virtual bool EndArray(std::size_t) { return pop_handler(); }
 
  protected:
   /* \brief build handler of indicated type and push it onto delegator's stack
@@ -178,7 +178,7 @@ class ArrayHandler : public OutputHandler<std::vector<ElemType>> {
 
   template <typename ArgType, typename IntType = ElemType>
   typename std::enable_if<!std::is_integral<IntType>::value, bool>::type
-  store_int(ArgType i) {
+  store_int(ArgType) {
     return false;
   }
 
@@ -204,7 +204,7 @@ class ArrayHandler : public OutputHandler<std::vector<ElemType>> {
   template <typename StringType = ElemType>
   typename std::enable_if<!std::is_same<StringType, std::string>::value,
                           bool>::type
-  store_string(const char *str, std::size_t length, bool copy) {
+  store_string(const char *, std::size_t, bool) {
     return false;
   }
 
@@ -251,7 +251,6 @@ class RegTreeHandler : public OutputHandler<treelite::Tree<float, float>> {
   std::vector<double> loss_changes;
   std::vector<double> sum_hessian;
   std::vector<double> base_weights;
-  std::vector<int> leaf_child_counts;
   std::vector<int> left_children;
   std::vector<int> right_children;
   std::vector<int> parents;

--- a/src/frontend/xgboost_json.cc
+++ b/src/frontend/xgboost_json.cc
@@ -159,26 +159,26 @@ bool BaseHandler::assign_value(const std::string &key,
  * IgnoreHandler
  * ***************************************************************************/
 bool IgnoreHandler::Null() { return true; }
-bool IgnoreHandler::Bool(bool b) { return true; }
-bool IgnoreHandler::Int(int i) { return true; }
-bool IgnoreHandler::Uint(unsigned u) { return true; }
-bool IgnoreHandler::Int64(int64_t i) { return true; }
-bool IgnoreHandler::Uint64(uint64_t u) { return true; }
-bool IgnoreHandler::Double(double d) { return true; }
-bool IgnoreHandler::String(const char *str, std::size_t length, bool copy) {
+bool IgnoreHandler::Bool(bool) { return true; }
+bool IgnoreHandler::Int(int) { return true; }
+bool IgnoreHandler::Uint(unsigned) { return true; }
+bool IgnoreHandler::Int64(int64_t) { return true; }
+bool IgnoreHandler::Uint64(uint64_t) { return true; }
+bool IgnoreHandler::Double(double) { return true; }
+bool IgnoreHandler::String(const char *, std::size_t, bool) {
   return true; }
 bool IgnoreHandler::StartObject() { return push_handler<IgnoreHandler>(); }
-bool IgnoreHandler::Key(const char *str, std::size_t length, bool copy) {
+bool IgnoreHandler::Key(const char *, std::size_t, bool) {
   return true; }
 bool IgnoreHandler::StartArray() { return push_handler<IgnoreHandler>(); }
 
 /******************************************************************************
  * TreeParamHandler
  * ***************************************************************************/
-bool TreeParamHandler::String(const char *str, std::size_t length, bool copy) {
+bool TreeParamHandler::String(const char *str, std::size_t, bool) {
   // Key "num_deleted" deprecated but still present in some xgboost output
   return (check_cur_key("num_feature") ||
-          assign_value("num_nodes", atoi(str), output) ||
+          assign_value("num_nodes", std::atoi(str), output) ||
           check_cur_key("size_leaf_vector") || check_cur_key("num_deleted"));
 }
 
@@ -210,59 +210,59 @@ bool RegTreeHandler::StartObject() {
   return push_key_handler<TreeParamHandler, int>("tree_param", num_nodes);
 }
 
-bool RegTreeHandler::Uint(unsigned u) { return check_cur_key("id"); }
+bool RegTreeHandler::Uint(unsigned) { return check_cur_key("id"); }
 
-bool RegTreeHandler::EndObject(std::size_t memberCount) {
+bool RegTreeHandler::EndObject(std::size_t) {
   output.Init();
   if (split_type.empty()) {
     split_type.resize(num_nodes, details::xgboost::FeatureType::kNumerical);
   }
-  if (num_nodes != loss_changes.size()) {
+  if (static_cast<size_t>(num_nodes) != loss_changes.size()) {
     LOG(ERROR) << "Field loss_changes has an incorrect dimension. Expected: " << num_nodes
                << ", Actual: " << loss_changes.size();
     return false;
   }
-  if (num_nodes != sum_hessian.size()) {
+  if (static_cast<size_t>(num_nodes) != sum_hessian.size()) {
     LOG(ERROR) << "Field sum_hessian has an incorrect dimension. Expected: " << num_nodes
                << ", Actual: " << sum_hessian.size();
     return false;
   }
-  if (num_nodes != base_weights.size()) {
+  if (static_cast<size_t>(num_nodes) != base_weights.size()) {
     LOG(ERROR) << "Field base_weights has an incorrect dimension. Expected: " << num_nodes
                << ", Actual: " << base_weights.size();
     return false;
   }
-  if (num_nodes != left_children.size()) {
+  if (static_cast<size_t>(num_nodes) != left_children.size()) {
     LOG(ERROR) << "Field left_children has an incorrect dimension. Expected: " << num_nodes
                << ", Actual: " << left_children.size();
     return false;
   }
-  if (num_nodes != right_children.size()) {
+  if (static_cast<size_t>(num_nodes) != right_children.size()) {
     LOG(ERROR) << "Field right_children has an incorrect dimension. Expected: " << num_nodes
                << ", Actual: " << right_children.size();
     return false;
   }
-  if (num_nodes != parents.size()) {
+  if (static_cast<size_t>(num_nodes) != parents.size()) {
     LOG(ERROR) << "Field parents has an incorrect dimension. Expected: " << num_nodes
                << ", Actual: " << parents.size();
     return false;
   }
-  if (num_nodes != split_indices.size()) {
+  if (static_cast<size_t>(num_nodes) != split_indices.size()) {
     LOG(ERROR) << "Field split_indices has an incorrect dimension. Expected: " << num_nodes
                << ", Actual: " << split_indices.size();
     return false;
   }
-  if (num_nodes != split_type.size()) {
+  if (static_cast<size_t>(num_nodes) != split_type.size()) {
     LOG(ERROR) << "Field split_type has an incorrect dimension. Expected: " << num_nodes
                << ", Actual: " << split_type.size();
     return false;
   }
-  if (num_nodes != split_conditions.size()) {
+  if (static_cast<size_t>(num_nodes) != split_conditions.size()) {
     LOG(ERROR) << "Field split_conditions has an incorrect dimension. Expected: " << num_nodes
                << ", Actual: " << split_conditions.size();
     return false;
   }
-  if (num_nodes != default_left.size()) {
+  if (static_cast<size_t>(num_nodes) != default_left.size()) {
     LOG(ERROR) << "Field default_left has an incorrect dimension. Expected: " << num_nodes
                << ", Actual: " << default_left.size();
     return false;
@@ -329,7 +329,7 @@ bool GBTreeModelHandler::StartObject() {
  * ***************************************************************************/
 bool GradientBoosterHandler::String(const char *str,
                                     std::size_t length,
-                                    bool copy) {
+                                    bool) {
   if (!check_cur_key("name")) {
     return false;
   }
@@ -363,7 +363,7 @@ bool ObjectiveHandler::StartObject() {
           push_key_handler<IgnoreHandler>("aft_loss_param"));
 }
 
-bool ObjectiveHandler::String(const char *str, std::size_t length, bool copy) {
+bool ObjectiveHandler::String(const char *str, std::size_t length, bool) {
   return assign_value("name", std::string{str, length}, output);
 }
 
@@ -371,8 +371,8 @@ bool ObjectiveHandler::String(const char *str, std::size_t length, bool copy) {
  * LearnerParamHandler
  * ***************************************************************************/
 bool LearnerParamHandler::String(const char *str,
-                                 std::size_t length,
-                                 bool copy) {
+                                 std::size_t,
+                                 bool) {
   return (assign_value("base_score", strtof(str, nullptr),
                        output.param.global_bias) ||
           assign_value("num_class", static_cast<unsigned int>(std::max(std::atoi(str), 1)),
@@ -393,7 +393,7 @@ bool LearnerHandler::StartObject() {
           push_key_handler<IgnoreHandler>("attributes"));
 }
 
-bool LearnerHandler::EndObject(std::size_t memberCount) {
+bool LearnerHandler::EndObject(std::size_t) {
   xgboost::SetPredTransform(objective, &output.model->param);
   output.objective_name = objective;
   return pop_handler();

--- a/src/predictor/predictor.cc
+++ b/src/predictor/predictor.cc
@@ -51,7 +51,6 @@ inline size_t PredLoop(const treelite::CSRDMatrixImpl<ElementType>* dmat, int nu
   std::vector<treelite::predictor::Entry<ThresholdType>> inst(
     std::max(dmat->num_col, static_cast<size_t>(num_feature)), {-1});
   CHECK(rbegin < rend && rend <= dmat->num_row);
-  const size_t num_col = dmat->num_col;
   const ElementType* data = dmat->data.data();
   const uint32_t* col_ind = dmat->col_ind.data();
   const size_t* row_ptr = dmat->row_ptr.data();
@@ -106,8 +105,7 @@ class PredLoopDispatcherWithDenseDMatrix {
  public:
   template <typename ThresholdType, typename LeafOutputType, typename PredFunc>
   inline static size_t Dispatch(
-      const treelite::DMatrix* dmat, ThresholdType test_val,
-      int num_feature, size_t rbegin, size_t rend,
+      const treelite::DMatrix* dmat, ThresholdType, int num_feature, size_t rbegin, size_t rend,
       LeafOutputType* out_pred, PredFunc func) {
     const auto* dmat_ = static_cast<const treelite::DenseDMatrixImpl<ElementType>*>(dmat);
     return PredLoop<ElementType, ThresholdType, LeafOutputType, PredFunc>(
@@ -120,8 +118,7 @@ class PredLoopDispatcherWithCSRDMatrix {
  public:
   template <typename ThresholdType, typename LeafOutputType, typename PredFunc>
   inline static size_t Dispatch(
-      const treelite::DMatrix* dmat, ThresholdType test_val,
-      int num_feature, size_t rbegin, size_t rend,
+      const treelite::DMatrix* dmat, ThresholdType, int num_feature, size_t rbegin, size_t rend,
       LeafOutputType* out_pred, PredFunc func) {
     const auto* dmat_ = static_cast<const treelite::CSRDMatrixImpl<ElementType>*>(dmat);
     return PredLoop<ElementType, ThresholdType, LeafOutputType, PredFunc>(
@@ -254,7 +251,6 @@ PredFunctionImpl<ThresholdType, LeafOutputType>::PredictBatch(
   // Note that size of prediction may be smaller than out_pred (this occurs
   // when pred_function is set to "max_index").
   CHECK(rbegin < rend && rend <= dmat->GetNumRow());
-  size_t num_row = rend - rbegin;
   if (num_class_ > 1) {  // multi-class classification
     using PredFunc = size_t (*)(Entry<ThresholdType>*, int, LeafOutputType*);
     auto pred_func = reinterpret_cast<PredFunc>(handle_);

--- a/src/predictor/thread_pool/thread_pool.h
+++ b/src/predictor/thread_pool/thread_pool.h
@@ -70,8 +70,8 @@ class ThreadPool {
   std::vector<std::thread> thread_;
   std::vector<std::unique_ptr<SpscQueue<InputToken>>> incoming_queue_;
   std::vector<std::unique_ptr<SpscQueue<OutputToken>>> outgoing_queue_;
-  TaskFunc task_;
   const TaskContext* context_;
+  TaskFunc task_;
 
   inline void SetAffinity() {
 #ifdef _WIN32


### PR DESCRIPTION
This PR fixes C++ compiler warnings:
* Out-of-order initialization of struct members in the constructor
* Unused parameters
* Unused local variables
* Comparison between signed and unsigned variables

Also add a CMake option `ENABLE_ALL_WARNINGS` to enable all warnings from GCC/Clang.