### PR TITLE
Add robust bounds check to getters of Tree class

### DIFF
--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -358,7 +358,7 @@ class Tree {
   inline std::vector<LeafOutputType> LeafVector(int nid) const {
     const size_t offset_begin = leaf_vector_offset_.at(nid);
     const size_t offset_end = leaf_vector_offset_.at(nid + 1);
-    if (offset_begin >= leaf_vector_.size() || offset_end > leaf_vector_.Size()) {
+    if (offset_begin >= leaf_vector_.Size() || offset_end > leaf_vector_.Size()) {
       // Return empty vector, to indicate the lack of leaf vector
       return std::vector<LeafOutputType>();
     }

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -358,10 +358,11 @@ class Tree {
   inline std::vector<LeafOutputType> LeafVector(int nid) const {
     const size_t offset_begin = leaf_vector_offset_.at(nid);
     const size_t offset_end = leaf_vector_offset_.at(nid + 1);
-    if (offset_end > leaf_vector_.Size()) {
-      throw std::range_error("Out-of-range access to leaf vector field");
+    if (offset_begin >= leaf_vector_.size() || offset_end > leaf_vector_.Size()) {
+      // Return empty vector, to indicate the lack of leaf vector
+      return std::vector<LeafOutputType>();
     }
-    return std::vector<LeafOutputType>(&leaf_vector_.at(offset_begin),
+    return std::vector<LeafOutputType>(&leaf_vector_[offset_begin],
                                        &leaf_vector_[offset_end]);
       // Use unsafe access here, since we may need to take the address of one past the last
       // element, to follow with the range semantic of std::vector<>.
@@ -398,13 +399,23 @@ class Tree {
   inline std::vector<uint32_t> MatchingCategories(int nid) const {
     const size_t offset_begin = matching_categories_offset_.at(nid);
     const size_t offset_end = matching_categories_offset_.at(nid + 1);
-    if (offset_end > matching_categories_.Size()) {
-      throw std::range_error("Out-of-range access to matching categories field");
+    if (offset_begin >= matching_categories_.Size() || offset_end > matching_categories_.Size()) {
+      // Return empty vector, to indicate the lack of any matching categories
+      // The node might be a numerical split
+      return std::vector<uint32_t>();
     }
-    return std::vector<uint32_t>(&matching_categories_.at(offset_begin),
+    return std::vector<uint32_t>(&matching_categories_[offset_begin],
                                  &matching_categories_[offset_end]);
       // Use unsafe access here, since we may need to take the address of one past the last
       // element, to follow with the range semantic of std::vector<>.
+  }
+  /*!
+   * \brief tests whether the node has a non-empty list for matching categories. See
+   *        MatchingCategories() for the definition of matching categories.
+   * \param nid ID of node being queried
+   */
+  inline bool HasMatchingCategories(int nid) const {
+    return matching_categories_offset_.at(nid) != matching_categories_offset_.at(nid + 1);
   }
   /*!
    * \brief get feature split type

--- a/include/treelite/tree_impl.h
+++ b/include/treelite/tree_impl.h
@@ -249,6 +249,42 @@ ContiguousArray<T>::operator[](size_t idx) const {
   return buffer_[idx];
 }
 
+template <typename T>
+inline T&
+ContiguousArray<T>::at(size_t idx) {
+  if (idx >= Size()) {
+    throw std::runtime_error("nid out of range");
+  }
+  return buffer_[idx];
+}
+
+template <typename T>
+inline const T&
+ContiguousArray<T>::at(size_t idx) const {
+  if (idx >= Size()) {
+    throw std::runtime_error("nid out of range");
+  }
+  return buffer_[idx];
+}
+
+template <typename T>
+inline T&
+ContiguousArray<T>::at(int idx) {
+  if (idx < 0 || static_cast<size_t>(idx) >= Size()) {
+    throw std::runtime_error("nid out of range");
+  }
+  return buffer_[static_cast<size_t>(idx)];
+}
+
+template <typename T>
+inline const T&
+ContiguousArray<T>::at(int idx) const {
+  if (idx < 0 || static_cast<size_t>(idx) >= Size()) {
+    throw std::runtime_error("nid out of range");
+  }
+  return buffer_[static_cast<size_t>(idx)];
+}
+
 template<typename Container>
 inline std::vector<std::pair<std::string, std::string> >
 ModelParam::InitAllowUnknown(const Container& kwargs) {
@@ -489,7 +525,7 @@ Tree<ThresholdType, LeafOutputType>::Init() {
   matching_categories_.Clear();
   matching_categories_offset_.Resize(2, 0);
   nodes_.Resize(1);
-  nodes_[0].Init();
+  nodes_.at(0).Init();
   SetLeaf(0, static_cast<LeafOutputType>(0));
 }
 
@@ -498,8 +534,8 @@ inline void
 Tree<ThresholdType, LeafOutputType>::AddChilds(int nid) {
   const int cleft = this->AllocNode();
   const int cright = this->AllocNode();
-  nodes_[nid].cleft_ = cleft;
-  nodes_[nid].cright_ = cright;
+  nodes_.at(nid).cleft_ = cleft;
+  nodes_.at(nid).cright_ = cright;
 }
 
 template <typename ThresholdType, typename LeafOutputType>
@@ -535,7 +571,7 @@ template <typename ThresholdType, typename LeafOutputType>
 inline void
 Tree<ThresholdType, LeafOutputType>::SetNumericalSplit(
     int nid, unsigned split_index, ThresholdType threshold, bool default_left, Operator cmp) {
-  Node& node = nodes_[nid];
+  Node& node = nodes_.at(nid);
   if (split_index >= ((1U << 31U) - 1)) {
     throw std::runtime_error("split_index too big");
   }
@@ -561,7 +597,7 @@ Tree<ThresholdType, LeafOutputType>::SetCategoricalSplit(
   if (end_oft != matching_categories_.Size()) {
     throw std::runtime_error("Invariant violated");
   }
-  if (!std::all_of(&matching_categories_offset_[nid + 1], matching_categories_offset_.End(),
+  if (!std::all_of(&matching_categories_offset_.at(nid + 1), matching_categories_offset_.End(),
                    [end_oft](size_t x) { return (x == end_oft); })) {
     throw std::runtime_error("Invariant violated");
   }
@@ -570,11 +606,11 @@ Tree<ThresholdType, LeafOutputType>::SetCategoricalSplit(
   if (new_end_oft != matching_categories_.Size()) {
     throw std::runtime_error("Invariant violated");
   }
-  std::for_each(&matching_categories_offset_[nid + 1], matching_categories_offset_.End(),
+  std::for_each(&matching_categories_offset_.at(nid + 1), matching_categories_offset_.End(),
                 [new_end_oft](size_t& x) { x = new_end_oft; });
-  std::sort(&matching_categories_[end_oft], matching_categories_.End());
+  std::sort(&matching_categories_.at(end_oft), matching_categories_.End());
 
-  Node& node = nodes_[nid];
+  Node& node = nodes_.at(nid);
   if (default_left) split_index |= (1U << 31U);
   node.sindex_ = split_index;
   node.split_type_ = SplitFeatureType::kCategorical;
@@ -584,7 +620,7 @@ Tree<ThresholdType, LeafOutputType>::SetCategoricalSplit(
 template <typename ThresholdType, typename LeafOutputType>
 inline void
 Tree<ThresholdType, LeafOutputType>::SetLeaf(int nid, LeafOutputType value) {
-  Node& node = nodes_[nid];
+  Node& node = nodes_.at(nid);
   (node.info_).leaf_value = value;
   node.cleft_ = -1;
   node.cright_ = -1;
@@ -600,7 +636,7 @@ Tree<ThresholdType, LeafOutputType>::SetLeafVector(
   if (end_oft != leaf_vector_.Size()) {
     throw std::runtime_error("Invariant violated");
   }
-  if (!std::all_of(&leaf_vector_offset_[nid + 1], leaf_vector_offset_.End(),
+  if (!std::all_of(&leaf_vector_offset_.at(nid + 1), leaf_vector_offset_.End(),
                    [end_oft](size_t x) { return (x == end_oft); })) {
     throw std::runtime_error("Invariant violated");
   }
@@ -609,10 +645,10 @@ Tree<ThresholdType, LeafOutputType>::SetLeafVector(
   if (new_end_oft != leaf_vector_.Size()) {
     throw std::runtime_error("Invariant violated");
   }
-  std::for_each(&leaf_vector_offset_[nid + 1], leaf_vector_offset_.End(),
+  std::for_each(&leaf_vector_offset_.at(nid + 1), leaf_vector_offset_.End(),
                 [new_end_oft](size_t& x) { x = new_end_oft; });
 
-  Node& node = nodes_[nid];
+  Node& node = nodes_.at(nid);
   node.cleft_ = -1;
   node.cright_ = -1;
   node.split_type_ = SplitFeatureType::kNone;

--- a/src/compiler/failsafe.cc
+++ b/src/compiler/failsafe.cc
@@ -149,7 +149,7 @@ inline std::pair<std::string, std::string> FormatNodesArray(
           "cright"_a = -1);
       } else {
         CHECK(tree.SplitType(nid) == treelite::SplitFeatureType::kNumerical
-              && tree.MatchingCategories(nid).empty())
+              && !tree.HasMatchingCategories(nid))
           << "categorical splits are not supported in FailSafeCompiler";
         nodes << fmt::format("{{ 0x{sindex:X}, {info}, {cleft}, {cright} }}",
             "sindex"_a
@@ -185,7 +185,7 @@ inline std::pair<std::vector<char>, std::string> FormatNodesArrayELF(
         val = {0, static_cast<float>(tree.LeafValue(nid)), -1, -1};
       } else {
         CHECK(tree.SplitType(nid) == treelite::SplitFeatureType::kNumerical
-              && tree.MatchingCategories(nid).empty())
+              && !tree.HasMatchingCategories(nid))
           << "categorical splits are not supported in FailSafeCompiler";
         val = {(tree.SplitIndex(nid) | (static_cast<uint32_t>(tree.DefaultLeft(nid)) << 31)),
                static_cast<float>(tree.Threshold(nid)), tree.LeftChild(nid), tree.RightChild(nid)};


### PR DESCRIPTION
Follow-up to #236.

Per @wphicks's suggestion, we should not simply silence the compiler warning by casting `int` to `size_t`. The node ID (`nid`) can potentially be -1 to indicate the lack of a child node, and casting -1 to `size_t` will cause undefined behavior.

This PR makes the bounds check more robust and removes the problematic cast from `int` to `size_t`.
* Add checked access method `at()` to `ContiguousArray` class. This is modeled after `std::vector::at()`.
* Replace all uses of `ContiguousArray::operator[]` with `ContiguousArray::at()`, to add automatic bounds check. Exception: `LeafVector()` and `MatchingCategories()` perform manual bounds checking, as they should return empty vectors instead of throwing out-of-bound exceptions. The reason is that many nodes will lack either leaf vector or matching categories.