### PR TITLE
Enforce invariant: Treelite codegen doesn't support uint32 leaf output

### DIFF
--- a/src/compiler/ast_native.cc
+++ b/src/compiler/ast_native.cc
@@ -128,6 +128,8 @@ class ASTNativeCompiler : public Compiler {
   }
 
   CompiledModel Compile(const Model& model) override {
+    CHECK(model.GetLeafOutputType() != TypeInfo::kUInt32)
+      << "Integer leaf outputs not yet supported";
     this->pred_tranform_func_ = PredTransformFunction("native", model);
     return model.Dispatch([this](const auto& model_handle) {
       return this->CompileImpl(model_handle);


### PR DESCRIPTION
Follow-up to #229 and #198.

Currently, the Treelite's C codegen only supports float32 and float64 type for leaf outputs. We should explicitly reject models with uint32 leaves.