### PR TITLE
Eschew global static object, to avoid issue with double-free

### DIFF
--- a/include/treelite/typeinfo.h
+++ b/include/treelite/typeinfo.h
@@ -29,7 +29,7 @@ static_assert(std::is_same<std::underlying_type<TypeInfo>::type, uint8_t>::value
               "TypeInfo must use uint8_t as underlying type");
 
 /*! \brief conversion table from string to TypeInfo, defined in tables.cc */
-extern const std::unordered_map<std::string, TypeInfo> typeinfo_table;
+TypeInfo GetTypeInfoByName(const std::string& str);
 
 /*!
  * \brief Get string representation of type info

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -216,7 +216,7 @@ int TreeliteSetTreeLimit(ModelHandle handle, size_t limit) {
 int TreeliteTreeBuilderCreateValue(const void* init_value, const char* type, ValueHandle* out) {
   API_BEGIN();
   std::unique_ptr<frontend::Value> value = std::make_unique<frontend::Value>();
-  *value = frontend::Value::Create(init_value, typeinfo_table.at(type));
+  *value = frontend::Value::Create(init_value, GetTypeInfoByName(type));
   *out = static_cast<ValueHandle>(value.release());
   API_END();
 }
@@ -231,8 +231,8 @@ int TreeliteCreateTreeBuilder(const char* threshold_type, const char* leaf_outpu
                               TreeBuilderHandle* out) {
   API_BEGIN();
   std::unique_ptr<frontend::TreeBuilder> builder{
-    new frontend::TreeBuilder(typeinfo_table.at(threshold_type),
-                              typeinfo_table.at(leaf_output_type))
+    new frontend::TreeBuilder(GetTypeInfoByName(threshold_type),
+                              GetTypeInfoByName(leaf_output_type))
   };
   *out = static_cast<TreeBuilderHandle>(builder.release());
   API_END();
@@ -323,8 +323,8 @@ int TreeliteCreateModelBuilder(
     const char* leaf_output_type, ModelBuilderHandle* out) {
   API_BEGIN();
   std::unique_ptr<frontend::ModelBuilder> builder{new frontend::ModelBuilder(
-      num_feature, num_class, (average_tree_output != 0), typeinfo_table.at(threshold_type),
-      typeinfo_table.at(leaf_output_type))};
+      num_feature, num_class, (average_tree_output != 0), GetTypeInfoByName(threshold_type),
+      GetTypeInfoByName(leaf_output_type))};
   *out = static_cast<ModelBuilderHandle>(builder.release());
   API_END();
 }

--- a/src/c_api/c_api_common.cc
+++ b/src/c_api/c_api_common.cc
@@ -43,7 +43,7 @@ int TreeliteDMatrixCreateFromCSR(
     const void* data, const char* data_type_str, const uint32_t* col_ind, const size_t* row_ptr,
     size_t num_row, size_t num_col, DMatrixHandle* out) {
   API_BEGIN();
-  TypeInfo data_type = typeinfo_table.at(data_type_str);
+  TypeInfo data_type = GetTypeInfoByName(data_type_str);
   std::unique_ptr<DMatrix> matrix
     = CSRDMatrix::Create(data_type, data, col_ind, row_ptr, num_row, num_col);
   *out = static_cast<DMatrixHandle>(matrix.release());
@@ -54,7 +54,7 @@ int TreeliteDMatrixCreateFromMat(
     const void* data, const char* data_type_str, size_t num_row, size_t num_col,
     const void* missing_value, DMatrixHandle* out) {
   API_BEGIN();
-  TypeInfo data_type = typeinfo_table.at(data_type_str);
+  TypeInfo data_type = GetTypeInfoByName(data_type_str);
   std::unique_ptr<DMatrix> matrix
     = DenseDMatrix::Create(data_type, data, missing_value, num_row, num_col);
   *out = static_cast<DMatrixHandle>(matrix.release());

--- a/src/data.cc
+++ b/src/data.cc
@@ -206,7 +206,7 @@ CSRDMatrix::Create(TypeInfo type, const void* data, const uint32_t* col_ind, con
 std::unique_ptr<CSRDMatrix>
 CSRDMatrix::Create(
     const char* filename, const char* format, const char* data_type, int nthread, int verbose) {
-  TypeInfo dtype = (data_type ? typeinfo_table.at(data_type) : TypeInfo::kFloat32);
+  TypeInfo dtype = (data_type ? GetTypeInfoByName(data_type) : TypeInfo::kFloat32);
   return CreateFromParser(filename, format, dtype, nthread, verbose);
 }
 

--- a/src/predictor/predictor.cc
+++ b/src/predictor/predictor.cc
@@ -331,10 +331,10 @@ Predictor::Load(const char* libpath) {
   /* 6. Query the data type for thresholds and leaf outputs */
   auto* threshold_type_query_func
     = lib_.LoadFunctionWithSignature<StringQueryFunc>("get_threshold_type");
-  threshold_type_ = typeinfo_table.at(threshold_type_query_func());
+  threshold_type_ = GetTypeInfoByName(threshold_type_query_func());
   auto* leaf_output_type_query_func
     = lib_.LoadFunctionWithSignature<StringQueryFunc>("get_leaf_output_type");
-  leaf_output_type_ = typeinfo_table.at(leaf_output_type_query_func());
+  leaf_output_type_ = GetTypeInfoByName(leaf_output_type_query_func());
 
   /* 7. load appropriate function for margin prediction */
   CHECK_GT(num_class_, 0) << "num_class cannot be zero";

--- a/src/typeinfo.cc
+++ b/src/typeinfo.cc
@@ -13,10 +13,17 @@
 
 namespace treelite {
 
-const std::unordered_map<std::string, TypeInfo> typeinfo_table{
-  {"uint32", TypeInfo::kUInt32},
-  {"float32", TypeInfo::kFloat32},
-  {"float64", TypeInfo::kFloat64}
-};
+TypeInfo GetTypeInfoByName(const std::string& str) {
+  if (str == "uint32") {
+    return TypeInfo::kUInt32;
+  } else if (str == "float32") {
+    return TypeInfo::kFloat32;
+  } else if (str == "float64") {
+    return TypeInfo::kFloat64;
+  } else {
+    throw std::runtime_error("Unrecognized type");
+    return TypeInfo::kInvalid;
+  }
+}
 
 }  // namespace treelite


### PR DESCRIPTION
When I was working on rapidsai/cuml#3316, I noticed that both libraries `libtreelite.so` and `libtreelite_runtime.so` contain a reference to the global static constant `typeinfo_table`. Since the constant was of type `std::unordered_map<std::string, std::string>`, it contains a non-trivial destructor. When both libraries are unloaded, both will attempt to simultaneously free the constant `typeinfo_table` from memory, leading to double-free and thus undefined behavior.

Fix: Eliminate the use of global static constant and replace it with a function instead. Allocating memory in the local scope is safer and does not risk the possibility of double-free.