### PR TITLE
Add Rust Runtime API into documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -156,8 +156,10 @@ Contents
   treelite-runtime-api
   treelite-c-api
   javadoc/packages
+  Treelite runtime Rust API <http://dovahcrow.github.io/treerite/treerite/>
   knobs/index
   Internal docs <http://treelite.readthedocs.io/en/latest/dev/>
+  
 
 *******
 Indices


### PR DESCRIPTION
Hi @hcho3, I've made the documentation for runtime API for Rust online at http://dovahcrow.github.io/treerite/treerite/. Here's the corresponding change to the treelite documentation site. 