### PR TITLE
Add support for "dart" booster in xgboost frontend

### DIFF
--- a/src/frontend/xgboost/xgboost_json.h
+++ b/src/frontend/xgboost/xgboost_json.h
@@ -277,6 +277,19 @@ class GradientBoosterHandler : public OutputHandler<treelite::ModelImpl<float, f
  public:
   using OutputHandler<treelite::ModelImpl<float, float>>::OutputHandler;
   bool String(const char *str, std::size_t length, bool copy) override;
+  bool StartArray() override;
+  bool StartObject() override;
+  bool EndObject(std::size_t memberCount) override;
+ private:
+  std::string name;
+  std::vector<double> weight_drop;
+};
+
+/*! \brief handler for GradientBoosterHandler objects from XGBoost schema for DART booster*/
+class DartGBTreeModelHandler : public OutputHandler<treelite::ModelImpl<float, float>> {
+ public:
+  using OutputHandler<treelite::ModelImpl<float, float>>::OutputHandler;
+  bool String(const char *str, std::size_t length, bool copy) override;
   bool StartObject() override;
 };
 

--- a/src/frontend/xgboost/xgboost_json.h
+++ b/src/frontend/xgboost/xgboost_json.h
@@ -285,14 +285,6 @@ class GradientBoosterHandler : public OutputHandler<treelite::ModelImpl<float, f
   std::vector<double> weight_drop;
 };
 
-/*! \brief handler for GradientBoosterHandler objects from XGBoost schema for DART booster*/
-class DartGBTreeModelHandler : public OutputHandler<treelite::ModelImpl<float, float>> {
- public:
-  using OutputHandler<treelite::ModelImpl<float, float>>::OutputHandler;
-  bool String(const char *str, std::size_t length, bool copy) override;
-  bool StartObject() override;
-};
-
 /*! \brief handler for ObjectiveHandler objects from XGBoost schema*/
 class ObjectiveHandler : public OutputHandler<std::string> {
   using OutputHandler<std::string>::OutputHandler;

--- a/src/frontend/xgboost_json.cc
+++ b/src/frontend/xgboost_json.cc
@@ -344,7 +344,8 @@ bool GradientBoosterHandler::String(const char *str,
 bool GradientBoosterHandler::StartObject() {
   if (push_key_handler<GBTreeModelHandler, treelite::ModelImpl<float, float>>("model", output)) {
     return true;
-  } else if (push_key_handler<DartGBTreeModelHandler, treelite::ModelImpl<float, float>>("gbtree", output)) {
+  } else if (push_key_handler<DartGBTreeModelHandler,treelite::ModelImpl<float, float>>("gbtree",
+                                                                                        output)) {
     // "dart" booster contains a standard gbtree under ["gradient_booster"]["gbtree"]["model"].
     return true;
   } else {

--- a/src/frontend/xgboost_json.cc
+++ b/src/frontend/xgboost_json.cc
@@ -344,8 +344,8 @@ bool GradientBoosterHandler::String(const char *str,
 bool GradientBoosterHandler::StartObject() {
   if (push_key_handler<GBTreeModelHandler, treelite::ModelImpl<float, float>>("model", output)) {
     return true;
-  } else if (push_key_handler<DartGBTreeModelHandler,treelite::ModelImpl<float, float>>("gbtree",
-                                                                                        output)) {
+  } else if (push_key_handler<GradientBoosterHandler, treelite::ModelImpl<float, float>>("gbtree",
+                                                                                         output)) {
     // "dart" booster contains a standard gbtree under ["gradient_booster"]["gbtree"]["model"].
     return true;
   } else {
@@ -370,33 +370,6 @@ bool GradientBoosterHandler::EndObject(std::size_t memberCount) {
     }
   }
   return pop_handler();
-}
-
-/******************************************************************************
- * DartGBTreeHandler
- * ***************************************************************************/
-bool DartGBTreeModelHandler::String(const char *str,
-                                    std::size_t length,
-                                    bool) {
-  if (!check_cur_key("name")) {
-    return false;
-  }
-  fmt::string_view name{str, length};
-  if (name != "gbtree") {
-    LOG(ERROR) << "Only GBTree-type boosters are currently supported.";
-    return false;
-  } else {
-    return true;
-  }
-}
-bool DartGBTreeModelHandler::StartObject() {
-  if (push_key_handler<GBTreeModelHandler, treelite::ModelImpl<float, float>>("model", output)) {
-    return true;
-  } else {
-    LOG(ERROR) << "Key \"" << get_cur_key()
-               << "\" not recognized. Is this a DART-type booster?";
-    return false;
-  }
 }
 
 /******************************************************************************

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -292,9 +292,9 @@ def test_xgb_categorical_split(tmpdir, toolchain, quantize, parallel_comp):
     check_predictor(predictor, dataset)
 
 
-@pytest.mark.parametrize('model_format', ['binary'])
+@pytest.mark.parametrize('model_format', ['binary', 'json'])
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-def test_xgb_dart_boston(tmpdir, toolchain, model_format):
+def test_xgb_dart(tmpdir, toolchain, model_format):
     # pylint: disable=too-many-locals,too-many-arguments
     """Test dart booster with dummy data"""
     np.random.seed(0)
@@ -317,12 +317,13 @@ def test_xgb_dart_boston(tmpdir, toolchain, model_format):
     bst = xgboost.train(param, dtrain=dtrain, num_boost_round=num_round)
 
     if model_format == 'json':
-        model_name = 'dart.json'
-        model_path = os.path.join(tmpdir, model_name)
-        bst.save_model(model_path)
-        model = treelite.Model.load(filename=model_path, model_format='xgboost_json')
+        model_json_path = os.path.join(tmpdir, 'serialized.json')
+        bst.save_model(model_json_path)
+        model = treelite.Model.load(model_json_path, model_format='xgboost_json')
     else:
-        model = treelite.Model.from_xgboost(bst)
+        model_bin_path = os.path.join(tmpdir, 'serialized.model')
+        bst.save_model(model_bin_path)
+        model = treelite.Model.load(model_bin_path, model_format='xgboost')
 
     assert model.num_feature == dtrain.num_col()
     assert model.num_class == 1

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -292,12 +292,11 @@ def test_xgb_categorical_split(tmpdir, toolchain, quantize, parallel_comp):
     check_predictor(predictor, dataset)
 
 
-# TODO(trevmorr): Enable json format when implemented.
 @pytest.mark.parametrize('model_format', ['binary'])
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())
 def test_xgb_dart_boston(tmpdir, toolchain, model_format):
     # pylint: disable=too-many-locals,too-many-arguments
-    """Test non-linear objectives with dummy data"""
+    """Test dart booster with dummy data"""
     np.random.seed(0)
     nrow = 16
     ncol = 8
@@ -315,14 +314,12 @@ def test_xgb_dart_boston(tmpdir, toolchain, model_format):
              'normalize_type': 'tree',
              'rate_drop': 0.1,
              'skip_drop': 0.5}
-    bst = xgboost.train(param,
-                        dtrain=dtrain, num_boost_round=num_round)
+    bst = xgboost.train(param, dtrain=dtrain, num_boost_round=num_round)
 
     if model_format == 'json':
         model_name = 'dart.json'
         model_path = os.path.join(tmpdir, model_name)
         bst.save_model(model_path)
-        bst.save_model('/home/ubuntu/debug-treelite/dart_test.json')
         model = treelite.Model.load(filename=model_path, model_format='xgboost_json')
     else:
         model = treelite.Model.from_xgboost(bst)


### PR DESCRIPTION
https://xgboost.readthedocs.io/en/latest/tutorials/dart.html

Dart booster is very similar to gbtree at inference time, except that the leaf values of each tree are scaled by the "weight_drop" value. Currently, this implementation applies the scaling directly to the leaf value so that no changes are needed in the treelite backend.

Dart binary format is the same as GBTree but followed by weight_drop vector: https://github.com/dmlc/xgboost/blob/9f15b9e322ac505189394ff840bda3f52a7abb1f/src/gbm/gbtree.cc#L619-L622

Edit: Thanks wphicks for help with JSON frontend. I have implented that too now.
The dart json schema can be seen here: https://github.com/dmlc/xgboost/blob/master/src/gbm/gbtree.cc#L550-L561 
```
{
"learner": {
  "gradient_booster": {
    "name": "dart",
    "weight_drop": [... weight drop vector...],
    "gbtree": { "name": "gbtree", "model": ... the model which GBTreeModelHandler can parse }
  }
}
}
```