### PR TITLE
[CI] Fix broken java_coverage test suite by ensuring that JDK 8 is used

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -167,7 +167,7 @@ jobs:
   - checkout: self
   - script: |
       cd runtime/java/treelite4j
-      mvn test -DJNI.args=cpp-coverage
+      JAVA_HOME=$JAVA_HOME_8_X64 mvn test -DJNI.args=cpp-coverage
     displayName: 'Running integration tests for Java runtime (treelite4j)...'
   - script: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
     displayName: 'Submitting Java code (treelite4j) coverage data to CodeCov...'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -167,8 +167,10 @@ jobs:
   - checkout: self
   - script: |
       cd runtime/java/treelite4j
-      JAVA_HOME=$JAVA_HOME_8_X64 mvn test -DJNI.args=cpp-coverage
+      mvn test -DJNI.args=cpp-coverage
     displayName: 'Running integration tests for Java runtime (treelite4j)...'
+    env:
+      JAVA_HOME: $(JAVA_HOME_8_X64)
   - script: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
     displayName: 'Submitting Java code (treelite4j) coverage data to CodeCov...'
     env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,6 +171,7 @@ jobs:
     displayName: 'Running integration tests for Java runtime (treelite4j)...'
     env:
       JAVA_HOME: $(JAVA_HOME_8_X64)
+      PATH: $(JAVA_HOME_8_X64)/bin:$(PATH)
   - script: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
     displayName: 'Submitting Java code (treelite4j) coverage data to CodeCov...'
     env:


### PR DESCRIPTION
Address https://github.com/dmlc/treelite/pull/251#issuecomment-776199098