### PR TITLE
[CI] Comply with new pylint convention

### DIFF
--- a/python/treelite/contrib/util.py
+++ b/python/treelite/contrib/util.py
@@ -65,6 +65,7 @@ def _enqueue(args):
     create_log_cmd = args['create_log_cmd']
     save_retcode_cmd = args['save_retcode_cmd']
 
+    # pylint: disable=R1732
     proc = subprocess.Popen(_shell(), shell=True,
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE,


### PR DESCRIPTION
```
************* Module treelite.contrib.util                          
python/treelite/contrib/util.py:68: refactor (R1732, consider-using-with, _enqueue) Consider using 'with'
for resource-allocating operations
```

We don't want to release the allocated process when the function `_enqueue` returns, so just disable this warning.