### PR TITLE
[CI] Reduce env setup time in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,7 @@ jobs:
 # dependent brew packages
 addons:
   homebrew:
-    packages:
-      - cmake
-      - libomp
-      - wget
-      - lcov
-      - ninja
-    update: true
+    update: false
   apt:
     sources:
       - sourceline: 'deb https://apt.kitware.com/ubuntu/ bionic main'

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 if [ ${TRAVIS_OS_NAME} == "osx" ]; then
-  brew install cmake libomp wget lconv ninja
+  brew install cmake libomp wget lcov ninja
   wget -O conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
 else
   wget -O conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -3,6 +3,7 @@
 set -eo pipefail
 
 if [ ${TRAVIS_OS_NAME} == "osx" ]; then
+  brew install cmake libomp wget lconv ninja
   wget -O conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
 else
   wget -O conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh


### PR DESCRIPTION
Avoid running `brew update` to save the CI time on Travis CI.