### PR TITLE
Remove dmlc logger

### DIFF
--- a/include/treelite/c_api_error.h
+++ b/include/treelite/c_api_error.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2020 by Contributors
+ * Copyright (c) 2017-2021 by Contributors
  * \file c_api_error.h
  * \author Hyunsu Cho
  * \brief Error handling for C API.
@@ -7,7 +7,6 @@
 #ifndef TREELITE_C_API_ERROR_H_
 #define TREELITE_C_API_ERROR_H_
 
-#include <dmlc/logging.h>
 #include <treelite/c_api_common.h>
 #include <stdexcept>
 

--- a/include/treelite/frontend.h
+++ b/include/treelite/frontend.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2020 by Contributors
+ * Copyright (c) 2017-2021 by Contributors
  * \file frontend.h
  * \brief Collection of front-end methods to load or construct ensemble model
  * \author Hyunsu Cho
@@ -7,7 +7,6 @@
 #ifndef TREELITE_FRONTEND_H_
 #define TREELITE_FRONTEND_H_
 
-#include <dmlc/logging.h>
 #include <treelite/base.h>
 #include <string>
 #include <memory>

--- a/include/treelite/logging.h
+++ b/include/treelite/logging.h
@@ -9,8 +9,143 @@
 
 #include <treelite/thread_local.h>
 #include <iostream>
+#include <stdexcept>
+#include <string>
+#include <sstream>
+#include <memory>
+#include <cstdio>
+#include <ctime>
 
 namespace treelite {
+
+/*!
+ * \brief Exception class that will be thrown by Treelite
+ */
+struct Error : public std::runtime_error {
+  explicit Error(const std::string& s) : std::runtime_error(s) {}
+};
+
+template <typename X, typename Y>
+std::unique_ptr<std::string> LogCheckFormat(const X& x, const Y& y) {
+  std::ostringstream os;
+  os << " (" << x << " vs. " << y << ") ";
+  /* CHECK_XX(x, y) requires x and y can be serialized to string. Use CHECK(x OP y) otherwise. */
+  return std::make_unique<std::string>(os.str());
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+#define TREELITE_ALWAYS_INLINE inline __attribute__((__always_inline__))
+#elif defined(_MSC_VER)
+#define TREELITE_ALWAYS_INLINE __forceinline
+#else
+#define TREELITE_ALWAYS_INLINE inline
+#endif
+
+#define DEFINE_CHECK_FUNC(name, op)                                                        \
+  template <typename X, typename Y>                                                        \
+  TREELITE_ALWAYS_INLINE std::unique_ptr<std::string> LogCheck##name(const X& x, const Y& y) { \
+    if (x op y) return nullptr;                                                            \
+    return LogCheckFormat(x, y);                                                           \
+  }                                                                                        \
+  TREELITE_ALWAYS_INLINE std::unique_ptr<std::string> LogCheck##name(int x, int y) {           \
+    return LogCheck##name<int, int>(x, y);                                                 \
+  }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+DEFINE_CHECK_FUNC(_LT, <)
+DEFINE_CHECK_FUNC(_GT, >)
+DEFINE_CHECK_FUNC(_LE, <=)
+DEFINE_CHECK_FUNC(_GE, >=)
+DEFINE_CHECK_FUNC(_EQ, ==)
+DEFINE_CHECK_FUNC(_NE, !=)
+#pragma GCC diagnostic pop
+
+
+#define CHECK_BINARY_OP(name, op, x, y)                  \
+  if (auto __treelite__log__err = treelite::LogCheck##name(x, y))  \
+      treelite::LogMessageFatal(__FILE__, __LINE__).stream() \
+        << "Check failed: " << #x " " #op " " #y << *__treelite__log__err << ": "
+#define CHECK(x)                                               \
+  if (!(x))                                                    \
+    treelite::LogMessageFatal(__FILE__, __LINE__).stream()     \
+      << "Check failed: " #x << ": "
+#define CHECK_LT(x, y) CHECK_BINARY_OP(_LT, <, x, y)
+#define CHECK_GT(x, y) CHECK_BINARY_OP(_GT, >, x, y)
+#define CHECK_LE(x, y) CHECK_BINARY_OP(_LE, <=, x, y)
+#define CHECK_GE(x, y) CHECK_BINARY_OP(_GE, >=, x, y)
+#define CHECK_EQ(x, y) CHECK_BINARY_OP(_EQ, ==, x, y)
+#define CHECK_NE(x, y) CHECK_BINARY_OP(_NE, !=, x, y)
+
+#define LOG_INFO treelite::LogMessage(__FILE__, __LINE__)
+#define LOG_ERROR LOG_INFO
+#define LOG_FATAL treelite::LogMessageFatal(__FILE__, __LINE__)
+#define LOG(severity) LOG_##severity.stream()
+
+class DateLogger {
+ public:
+  DateLogger() {
+#if defined(_MSC_VER)
+    _tzset();
+#endif  // defined(_MSC_VER)
+  }
+  const char* HumanDate() {
+#if defined(_MSC_VER)
+    _strtime_s(buffer_, sizeof(buffer_));
+#else  // defined(_MSC_VER)
+    time_t time_value = std::time(nullptr);
+    struct tm* pnow;
+#if !defined(_WIN32)
+    struct tm now;
+    pnow = localtime_r(&time_value, &now);
+#else  // !defined(_WIN32)
+    pnow = std::localtime(&time_value);  // NOLINT(*)
+#endif  // !defined(_WIN32)
+    std::snprintf(buffer_, sizeof(buffer_), "%02d:%02d:%02d",
+                  pnow->tm_hour, pnow->tm_min, pnow->tm_sec);
+#endif  // defined(_MSC_VER)
+    return buffer_;
+  }
+
+ private:
+  char buffer_[9];
+};
+
+class LogMessageFatal {
+ public:
+  LogMessageFatal(const char* file, int line) {
+    log_stream_ << "[" << pretty_date_.HumanDate() << "] " << file << ":" << line << ": ";
+  }
+  LogMessageFatal(const LogMessageFatal&) = delete;
+  void operator=(const LogMessageFatal&) = delete;
+
+  std::ostringstream& stream() {
+    return log_stream_;
+  }
+  ~LogMessageFatal() noexcept(false) {
+    throw Error(log_stream_.str());
+  }
+
+ private:
+  std::ostringstream log_stream_;
+  DateLogger pretty_date_;
+};
+
+class LogMessage {
+ public:
+  LogMessage(const char* file, int line) {
+    log_stream_ << "[" << DateLogger().HumanDate() << "] " << file << ":"
+                << line << ": ";
+  }
+  ~LogMessage() {
+    Log(log_stream_.str());
+  }
+  std::ostream& stream() { return log_stream_; }
+  static void Log(const std::string& msg);
+
+ private:
+  std::ostringstream log_stream_;
+};
 
 class LogCallbackRegistry {
  public:

--- a/include/treelite/logging.h
+++ b/include/treelite/logging.h
@@ -63,12 +63,12 @@ DEFINE_CHECK_FUNC(_NE, !=)
 
 
 #define CHECK_BINARY_OP(name, op, x, y)                  \
-  if (auto __treelite__log__err = treelite::LogCheck##name(x, y))  \
+  if (auto __treelite__log__err = ::treelite::LogCheck##name(x, y))  \
       ::treelite::LogMessageFatal(__FILE__, __LINE__).stream() \
         << "Check failed: " << #x " " #op " " #y << *__treelite__log__err << ": "
 #define CHECK(x)                                               \
   if (!(x))                                                    \
-    treelite::LogMessageFatal(__FILE__, __LINE__).stream()     \
+    ::treelite::LogMessageFatal(__FILE__, __LINE__).stream()     \
       << "Check failed: " #x << ": "
 #define CHECK_LT(x, y) CHECK_BINARY_OP(_LT, <, x, y)
 #define CHECK_GT(x, y) CHECK_BINARY_OP(_GT, >, x, y)
@@ -77,9 +77,9 @@ DEFINE_CHECK_FUNC(_NE, !=)
 #define CHECK_EQ(x, y) CHECK_BINARY_OP(_EQ, ==, x, y)
 #define CHECK_NE(x, y) CHECK_BINARY_OP(_NE, !=, x, y)
 
-#define LOG_INFO treelite::LogMessage(__FILE__, __LINE__)
+#define LOG_INFO ::treelite::LogMessage(__FILE__, __LINE__)
 #define LOG_ERROR LOG_INFO
-#define LOG_FATAL treelite::LogMessageFatal(__FILE__, __LINE__)
+#define LOG_FATAL ::treelite::LogMessageFatal(__FILE__, __LINE__)
 #define LOG(severity) LOG_##severity.stream()
 
 class DateLogger {

--- a/include/treelite/logging.h
+++ b/include/treelite/logging.h
@@ -64,7 +64,7 @@ DEFINE_CHECK_FUNC(_NE, !=)
 
 #define CHECK_BINARY_OP(name, op, x, y)                  \
   if (auto __treelite__log__err = treelite::LogCheck##name(x, y))  \
-      treelite::LogMessageFatal(__FILE__, __LINE__).stream() \
+      ::treelite::LogMessageFatal(__FILE__, __LINE__).stream() \
         << "Check failed: " << #x " " #op " " #y << *__treelite__log__err << ": "
 #define CHECK(x)                                               \
   if (!(x))                                                    \

--- a/include/treelite/predictor.h
+++ b/include/treelite/predictor.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2020 by Contributors
+ * Copyright (c) 2017-2021 by Contributors
  * \file predictor.h
  * \author Hyunsu Cho
  * \brief Load prediction function exported as a shared library
@@ -8,7 +8,7 @@
 #define TREELITE_PREDICTOR_H_
 
 #include <dmlc/common.h>
-#include <dmlc/logging.h>
+#include <treelite/logging.h>
 #include <treelite/typeinfo.h>
 #include <treelite/c_api_runtime.h>
 #include <treelite/data.h>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,7 +34,6 @@ foreach(lib objtreelite objtreelite_runtime objtreelite_common)
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
   target_link_libraries(${lib} PUBLIC dmlc)
-  target_compile_definitions(${lib} PRIVATE -DDMLC_LOG_CUSTOMIZE)
   if(MSVC)
     target_compile_options(${lib} PRIVATE /MP)
     target_compile_definitions(${lib} PRIVATE -DNOMINMAX)

--- a/src/annotator.cc
+++ b/src/annotator.cc
@@ -5,6 +5,7 @@
  * \brief Branch annotation tools
  */
 
+#include <treelite/logging.h>
 #include <treelite/annotator.h>
 #include <treelite/math.h>
 #include <treelite/omp.h>

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -16,6 +16,7 @@
 #include <treelite/tree.h>
 #include <treelite/math.h>
 #include <treelite/gtil.h>
+#include <treelite/logging.h>
 #include <dmlc/io.h>
 #include <memory>
 #include <algorithm>

--- a/src/compiler/ast/dump.cc
+++ b/src/compiler/ast/dump.cc
@@ -4,6 +4,7 @@
  * \brief Generate text representation of AST
  */
 #include <dmlc/registry.h>
+#include <treelite/logging.h>
 #include "./builder.h"
 
 namespace {

--- a/src/compiler/ast/fold_code.cc
+++ b/src/compiler/ast/fold_code.cc
@@ -5,8 +5,9 @@
  * \author Hyunsu Cho
  */
 #include <dmlc/registry.h>
-#include <cmath>
+#include <treelite/logging.h>
 #include <limits>
+#include <cmath>
 #include "./builder.h"
 
 namespace treelite {

--- a/src/compiler/ast/quantize.cc
+++ b/src/compiler/ast/quantize.cc
@@ -5,6 +5,8 @@
  */
 #include <treelite/math.h>
 #include <dmlc/registry.h>
+#include <treelite/logging.h>
+#include <set>
 #include <cmath>
 #include "./builder.h"
 

--- a/src/compiler/ast/split.cc
+++ b/src/compiler/ast/split.cc
@@ -4,6 +4,7 @@
  * \brief Split prediction subroutine into multiple translation units (files)
  */
 #include <dmlc/registry.h>
+#include <treelite/logging.h>
 #include "./builder.h"
 
 namespace treelite {

--- a/src/compiler/common/code_folding_util.h
+++ b/src/compiler/common/code_folding_util.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2018-2020 by Contributors
+ * Copyright (c) 2018-2021 by Contributors
  * \file code_folding_util.h
  * \author Hyunsu Cho
  * \brief Utilities for code folding
@@ -7,8 +7,8 @@
 #ifndef TREELITE_COMPILER_COMMON_CODE_FOLDING_UTIL_H_
 #define TREELITE_COMPILER_COMMON_CODE_FOLDING_UTIL_H_
 
-#include <dmlc/logging.h>
 #include <fmt/format.h>
+#include <treelite/logging.h>
 #include <unordered_map>
 #include <queue>
 #include <set>

--- a/src/compiler/compiler.cc
+++ b/src/compiler/compiler.cc
@@ -5,7 +5,7 @@
  */
 #include <treelite/compiler.h>
 #include <treelite/compiler_param.h>
-#include <dmlc/logging.h>
+#include <treelite/logging.h>
 #include <rapidjson/document.h>
 #include <limits>
 #include "./ast_native.h"

--- a/src/compiler/elf/elf_formatter.cc
+++ b/src/compiler/elf/elf_formatter.cc
@@ -4,6 +4,7 @@
  * \author Hyunsu Cho
  * \brief Generate a relocatable object file containing a constant, read-only array
  */
+#include <treelite/logging.h>
 #include <dmlc/registry.h>
 #include <fstream>
 #include <iterator>

--- a/src/compiler/failsafe.cc
+++ b/src/compiler/failsafe.cc
@@ -9,7 +9,7 @@
 #include <treelite/tree.h>
 #include <treelite/compiler.h>
 #include <treelite/compiler_param.h>
-#include <dmlc/logging.h>
+#include <treelite/logging.h>
 #include <fmt/format.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>

--- a/src/compiler/native/pred_transform.h
+++ b/src/compiler/native/pred_transform.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2020 by Contributors
+ * Copyright (c) 2017-2021 by Contributors
  * \file pred_transform.h
  * \author Hyunsu Cho
  * \brief template for pred_transform() function in generated C code
@@ -8,7 +8,7 @@
 #ifndef TREELITE_COMPILER_NATIVE_PRED_TRANSFORM_H_
 #define TREELITE_COMPILER_NATIVE_PRED_TRANSFORM_H_
 
-#include <dmlc/logging.h>
+#include <treelite/logging.h>
 #include <fmt/format.h>
 #include <string>
 #include "./typeinfo_ctypes.h"

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -1,12 +1,12 @@
 /*!
- * Copyright (c) 2020 by Contributors
+ * Copyright (c) 2020-2021 by Contributors
  * \file filesystem.cc
  * \author Hyunsu Cho
  * \brief Cross-platform wrapper for common filesystem functions
  */
 
 #include <treelite/filesystem.h>
-#include <dmlc/logging.h>
+#include <treelite/logging.h>
 #include <fstream>
 
 #ifdef _WIN32

--- a/src/frontend/builder.cc
+++ b/src/frontend/builder.cc
@@ -8,6 +8,7 @@
 #include <dmlc/registry.h>
 #include <treelite/frontend.h>
 #include <treelite/tree.h>
+#include <treelite/logging.h>
 #include <memory>
 #include <queue>
 

--- a/src/frontend/lightgbm.cc
+++ b/src/frontend/lightgbm.cc
@@ -6,6 +6,7 @@
  */
 
 #include <dmlc/data.h>
+#include <treelite/logging.h>
 #include <treelite/frontend.h>
 #include <treelite/tree.h>
 #include <unordered_map>

--- a/src/frontend/sklearn.cc
+++ b/src/frontend/sklearn.cc
@@ -4,6 +4,7 @@
  * \brief Frontend for scikit-learn models
  * \author Hyunsu Cho
  */
+#include <treelite/logging.h>
 #include <treelite/frontend.h>
 #include <treelite/tree.h>
 #include <memory>

--- a/src/frontend/xgboost.cc
+++ b/src/frontend/xgboost.cc
@@ -8,6 +8,7 @@
 #include "xgboost/xgboost.h"
 #include <treelite/frontend.h>
 #include <treelite/tree.h>
+#include <treelite/logging.h>
 #include <algorithm>
 #include <memory>
 #include <queue>

--- a/src/frontend/xgboost_json.cc
+++ b/src/frontend/xgboost_json.cc
@@ -16,6 +16,7 @@
 #include <treelite/tree.h>
 #include <treelite/frontend.h>
 #include <treelite/math.h>
+#include <treelite/logging.h>
 
 #include <algorithm>
 #include <cstdio>

--- a/src/frontend/xgboost_util.cc
+++ b/src/frontend/xgboost_util.cc
@@ -1,12 +1,12 @@
 /*!
- * Copyright (c) 2020 by Contributors
+ * Copyright (c) 2020-2021 by Contributors
  * \file xgboost_util.cc
  * \brief Common utilities for XGBoost frontends
  * \author Hyunsu Cho
  */
 
 #include <treelite/tree.h>
-#include <dmlc/logging.h>
+#include <treelite/logging.h>
 #include <cstring>
 #include "xgboost/xgboost.h"
 

--- a/src/gtil/pred_transform.cc
+++ b/src/gtil/pred_transform.cc
@@ -6,9 +6,8 @@
  */
 
 #include "./pred_transform.h"
-#include <treelite/gtil.h>
 #include <treelite/tree.h>
-#include <dmlc/logging.h>
+#include <treelite/logging.h>
 #include <string>
 #include <unordered_map>
 #include <cmath>

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -9,7 +9,7 @@
 #include <treelite/gtil.h>
 #include <treelite/tree.h>
 #include <treelite/data.h>
-#include <dmlc/logging.h>
+#include <treelite/logging.h>
 #include <limits>
 #include <vector>
 #include <cmath>

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1,17 +1,15 @@
 /*!
- * Copyright (c) 2017-2020 by Contributors
+ * Copyright (c) 2017-2021 by Contributors
  * \file logging.cc
  * \author Hyunsu Cho
  * \brief logging facility for treelite
  */
 
-#include <dmlc/logging.h>
 #include <treelite/logging.h>
 
 // Override logging mechanism
-void dmlc::CustomLogMessage::Log(const std::string& msg) {
-  const treelite::LogCallbackRegistry* registry
-    = treelite::LogCallbackRegistryStore::Get();
+void treelite::LogMessage::Log(const std::string& msg) {
+  const treelite::LogCallbackRegistry* registry = treelite::LogCallbackRegistryStore::Get();
   auto callback = registry->Get();
   callback(msg.c_str());
 }

--- a/src/predictor/predictor.cc
+++ b/src/predictor/predictor.cc
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2020 by Contributors
+ * Copyright (c) 2017-2021 by Contributors
  * \file predictor.cc
  * \author Hyunsu Cho
  * \brief Load prediction function exported as a shared library
@@ -9,8 +9,6 @@
 #include <treelite/math.h>
 #include <treelite/data.h>
 #include <treelite/typeinfo.h>
-#include <dmlc/logging.h>
-#include <dmlc/io.h>
 #include <cstdint>
 #include <algorithm>
 #include <memory>

--- a/src/predictor/thread_pool/spsc_queue.h
+++ b/src/predictor/thread_pool/spsc_queue.h
@@ -1,5 +1,5 @@
 /*!
-* Copyright (c) 2018-2020 by Contributors
+* Copyright (c) 2018-2021 by Contributors
 * \file spsc_queue.h
 * \brief Lock-free single-producer-single-consumer queue
 * \author Yida Wang, Hyunsu Cho
@@ -7,7 +7,7 @@
 #ifndef TREELITE_PREDICTOR_THREAD_POOL_SPSC_QUEUE_H_
 #define TREELITE_PREDICTOR_THREAD_POOL_SPSC_QUEUE_H_
 
-#include <dmlc/logging.h>
+#include <treelite/logging.h>
 #include <atomic>
 #include <thread>
 #include <mutex>

--- a/tests/cpp/test_compiler_param.cc
+++ b/tests/cpp/test_compiler_param.cc
@@ -46,7 +46,7 @@ TEST(CompilerParam, NonExistentKey) {
     })JSON";
   EXPECT_THAT(
       [&]() { CompilerParam::ParseFromJSON(json_str.c_str()); },
-      ThrowsMessage<dmlc::Error>(HasSubstr("Unrecognized key 'nonexistent'")));
+      ThrowsMessage<treelite::Error>(HasSubstr("Unrecognized key 'nonexistent'")));
   json_str = R"JSON(
     {
       "quantize": 1,
@@ -57,7 +57,7 @@ TEST(CompilerParam, NonExistentKey) {
     })JSON";
   EXPECT_THAT(
       [&]() { CompilerParam::ParseFromJSON(json_str.c_str()); },
-      ThrowsMessage<dmlc::Error>(HasSubstr("Unrecognized key 'extra_object'")));
+      ThrowsMessage<treelite::Error>(HasSubstr("Unrecognized key 'extra_object'")));
 }
 
 TEST(CompilerParam, IncorrectType) {
@@ -68,7 +68,7 @@ TEST(CompilerParam, IncorrectType) {
     })JSON";
   EXPECT_THAT(
       [&]() { CompilerParam::ParseFromJSON(json_str.c_str()); },
-      ThrowsMessage<dmlc::Error>(HasSubstr("Expected an integer for 'quantize'")));
+      ThrowsMessage<treelite::Error>(HasSubstr("Expected an integer for 'quantize'")));
   json_str = R"JSON(
     {
       "code_folding_req": {
@@ -77,7 +77,7 @@ TEST(CompilerParam, IncorrectType) {
     })JSON";
   EXPECT_THAT(
       [&]() { CompilerParam::ParseFromJSON(json_str.c_str()); },
-      ThrowsMessage<dmlc::Error>(
+      ThrowsMessage<treelite::Error>(
         HasSubstr("Expected a floating-point decimal for 'code_folding_req'")));
   json_str = R"JSON(
     {
@@ -85,14 +85,14 @@ TEST(CompilerParam, IncorrectType) {
     })JSON";
   EXPECT_THAT(
       [&]() { CompilerParam::ParseFromJSON(json_str.c_str()); },
-      ThrowsMessage<dmlc::Error>(HasSubstr("Expected a string for 'native_lib_name'")));
+      ThrowsMessage<treelite::Error>(HasSubstr("Expected a string for 'native_lib_name'")));
   json_str = R"JSON(
     {
       "code_folding_req": 13bad
     })JSON";
   EXPECT_THAT(
       [&]() { CompilerParam::ParseFromJSON(json_str.c_str()); },
-      ThrowsMessage<dmlc::Error>(HasSubstr("Got an invalid JSON string")));
+      ThrowsMessage<treelite::Error>(HasSubstr("Got an invalid JSON string")));
 }
 
 TEST(CompilerParam, InvalidRange) {
@@ -104,7 +104,7 @@ TEST(CompilerParam, InvalidRange) {
     std::string expected_error = fmt::format("'{}' must be 0 or greater", key);
     EXPECT_THAT(
         [&]() { CompilerParam::ParseFromJSON(json_str.c_str()); },
-        ThrowsMessage<dmlc::Error>(HasSubstr(expected_error)));
+        ThrowsMessage<treelite::Error>(HasSubstr(expected_error)));
   }
 }
 


### PR DESCRIPTION
Extracted from #285. Re-implement logging functionalities such as `CHECK` and `LOG`, so that we no longer depend on the header `dmlc/logging.h`.