### PR TITLE
[Breaking] Remove the use of dmlc parsers

### DIFF
--- a/include/treelite/c_api_common.h
+++ b/include/treelite/c_api_common.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2020 by Contributors
+ * Copyright (c) 2017-2021 by Contributors
  * \file c_api_common.h
  * \author Hyunsu Cho
  * \brief C API of Treelite, used for interfacing with other languages
@@ -50,18 +50,6 @@ TREELITE_DLL int TreeliteRegisterLogCallback(void (*callback)(const char*));
  * Data matrix interface
  * \{
  */
-/*!
- * \brief create a sparse DMatrix from a file
- * \param path file path
- * \param format file format
- * \param nthread number of threads to use
- * \param verbose whether to produce extra messages
- * \param out the created DMatrix
- * \return 0 for success, -1 for failure
- */
-TREELITE_DLL int TreeliteDMatrixCreateFromFile(
-    const char* path, const char* format, const char* data_type, int nthread, int verbose,
-    DMatrixHandle* out);
 /*!
  * \brief create DMatrix from a (in-memory) CSR matrix
  * \param data feature values

--- a/include/treelite/data.h
+++ b/include/treelite/data.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2020 by Contributors
+ * Copyright (c) 2017-2021 by Contributors
  * \file data.h
  * \author Hyunsu Cho
  * \brief Input data structure of Treelite
@@ -7,7 +7,6 @@
 #ifndef TREELITE_DATA_H_
 #define TREELITE_DATA_H_
 
-#include <dmlc/data.h>
 #include <treelite/typeinfo.h>
 #include <vector>
 #include <type_traits>
@@ -99,8 +98,6 @@ class CSRDMatrix : public DMatrix {
   static std::unique_ptr<CSRDMatrix> Create(
       TypeInfo type, const void* data, const uint32_t* col_ind, const size_t* row_ptr,
       size_t num_row, size_t num_col);
-  static std::unique_ptr<CSRDMatrix> Create(
-      const char* filename, const char* format, const char* data_type, int nthread, int verbose);
   size_t GetNumRow() const override = 0;
   size_t GetNumCol() const override = 0;
   size_t GetNumElem() const override = 0;

--- a/include/treelite/predictor.h
+++ b/include/treelite/predictor.h
@@ -7,12 +7,14 @@
 #ifndef TREELITE_PREDICTOR_H_
 #define TREELITE_PREDICTOR_H_
 
+#include <dmlc/common.h>
 #include <dmlc/logging.h>
 #include <treelite/typeinfo.h>
 #include <treelite/c_api_runtime.h>
 #include <treelite/data.h>
 #include <string>
 #include <memory>
+#include <mutex>
 #include <cstdint>
 
 namespace treelite {

--- a/python/treelite/util.py
+++ b/python/treelite/util.py
@@ -64,15 +64,6 @@ def log_info(filename, linenum, msg):
     print(f'[{time.strftime("%X")}] {filename}:{linenum}: {msg}')
 
 
-def has_sklearn():
-    """Check whether scikit-learn is available"""
-    try:
-        import sklearn  # pylint: disable=unused-import
-        return True
-    except ImportError:
-        return False
-
-
 def type_info_to_ctypes_type(type_info):
     """Obtain ctypes type corresponding to a given TypeInfo"""
     return _CTYPES_TYPE_TABLE[type_info]

--- a/runtime/python/treelite_runtime/predictor.py
+++ b/runtime/python/treelite_runtime/predictor.py
@@ -270,21 +270,16 @@ class DMatrix:
                  feature_names=None, feature_types=None,
                  verbose=False, nthread=None):
         if data is None:
-            raise TreeliteRuntimeError('\'data\' argument cannot be None')
+            raise TreeliteRuntimeError("'data' argument cannot be None")
 
         self.handle = ctypes.c_void_p()
 
         if isinstance(data, (str,)):
-            nthread = nthread if nthread is not None else 0
-            data_format = data_format if data_format is not None else "libsvm"
-            data_type = ctypes.c_char_p(None) if dtype is None else c_str(dtype)
-            _check_call(_LIB.TreeliteDMatrixCreateFromFile(
-                c_str(data),
-                c_str(data_format),
-                data_type,
-                ctypes.c_int(nthread),
-                ctypes.c_int(1 if verbose else 0),
-                ctypes.byref(self.handle)))
+            raise TreeliteRuntimeError(
+                "'data' argument cannot be a string. Did you mean to load data from a text file? "
+                "Please use the following packages to load the text file:\n"
+                "   * CSV file: Use pandas.read_csv() or numpy.loadtxt()\n"
+                "   * LIBSVM file: Use sklearn.datasets.load_svmlight_file()")
         elif isinstance(data, scipy.sparse.csr_matrix):
             self._init_from_csr(data, dtype=dtype)
         elif isinstance(data, scipy.sparse.csc_matrix):

--- a/src/annotator.cc
+++ b/src/annotator.cc
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2020 by Contributors
+ * Copyright (c) 2017-2021 by Contributors
  * \file annotator.cc
  * \author Hyunsu Cho
  * \brief Branch annotation tools
@@ -9,6 +9,7 @@
 #include <treelite/math.h>
 #include <treelite/omp.h>
 #include <dmlc/json.h>
+#include <dmlc/io.h>
 #include <limits>
 #include <cstdint>
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -18,6 +18,7 @@
 #include <treelite/math.h>
 #include <treelite/gtil.h>
 #include <dmlc/thread_local.h>
+#include <dmlc/io.h>
 #include <memory>
 #include <algorithm>
 

--- a/src/c_api/c_api_common.cc
+++ b/src/c_api/c_api_common.cc
@@ -30,15 +30,6 @@ int TreeliteRegisterLogCallback(void (*callback)(const char*)) {
   API_END();
 }
 
-int TreeliteDMatrixCreateFromFile(
-    const char* path, const char* format, const char* data_type, int nthread, int verbose,
-    DMatrixHandle* out) {
-  API_BEGIN();
-  std::unique_ptr<DMatrix> mat = CSRDMatrix::Create(path, format, data_type, nthread, verbose);
-  *out = static_cast<DMatrixHandle>(mat.release());
-  API_END();
-}
-
 int TreeliteDMatrixCreateFromCSR(
     const void* data, const char* data_type_str, const uint32_t* col_ind, const size_t* row_ptr,
     size_t num_row, size_t num_col, DMatrixHandle* out) {

--- a/src/compiler/ast_native.cc
+++ b/src/compiler/ast_native.cc
@@ -7,6 +7,7 @@
 #include <treelite/compiler.h>
 #include <treelite/compiler_param.h>
 #include <treelite/annotator.h>
+#include <dmlc/io.h>
 #include <fmt/format.h>
 #include <algorithm>
 #include <fstream>
@@ -22,7 +23,6 @@
 #include "./native/typeinfo_ctypes.h"
 #include "./common/format_util.h"
 #include "./common/code_folding_util.h"
-#include "./common/categorical_bitmap.h"
 
 #if defined(_MSC_VER) || defined(_WIN32)
 #define DLLEXPORT_KEYWORD "__declspec(dllexport) "

--- a/src/data.cc
+++ b/src/data.cc
@@ -1,93 +1,16 @@
 /*!
- * Copyright (c) 2017-2020 by Contributors
+ * Copyright (c) 2017-2021 by Contributors
  * \file data.cc
  * \author Hyunsu Cho
  * \brief Input data structure of Treelite
  */
 
+#include <dmlc/logging.h>
+#include <treelite/logging.h>
 #include <treelite/data.h>
-#include <treelite/omp.h>
 #include <memory>
 #include <limits>
 #include <cstdint>
-
-namespace {
-
-template <typename ElementType, typename DMLCParserDType>
-inline static std::unique_ptr<treelite::CSRDMatrix> CreateFromParserImpl(
-    const char* filename, const char* format, int nthread, int verbose) {
-  std::unique_ptr<dmlc::Parser<uint32_t, DMLCParserDType>> parser(
-      dmlc::Parser<uint32_t, DMLCParserDType>::Create(filename, 0, 1, format));
-
-  const int max_thread = omp_get_max_threads();
-  nthread = (nthread == 0) ? max_thread : std::min(nthread, max_thread);
-
-  std::vector<ElementType> data;
-  std::vector<uint32_t> col_ind;
-  std::vector<size_t> row_ptr;
-  row_ptr.resize(1, 0);
-  size_t num_row = 0;
-  size_t num_col = 0;
-  size_t num_elem = 0;
-
-  std::vector<size_t> max_col_ind(nthread, 0);
-  parser->BeforeFirst();
-  while (parser->Next()) {
-    const dmlc::RowBlock<uint32_t, DMLCParserDType>& batch = parser->Value();
-    num_row += batch.size;
-    num_elem += batch.offset[batch.size];
-    const size_t top = data.size();
-    data.resize(top + batch.offset[batch.size] - batch.offset[0]);
-    col_ind.resize(top + batch.offset[batch.size] - batch.offset[0]);
-    CHECK_LT(static_cast<int64_t>(batch.offset[batch.size]),
-             std::numeric_limits<int64_t>::max());
-    #pragma omp parallel for schedule(static) num_threads(nthread)
-    for (int64_t i = static_cast<int64_t>(batch.offset[0]);
-         i < static_cast<int64_t>(batch.offset[batch.size]); ++i) {
-      const int tid = omp_get_thread_num();
-      const uint32_t index = batch.index[i];
-      const ElementType fvalue
-        = ((batch.value == nullptr) ? static_cast<ElementType>(1)
-                                    : static_cast<ElementType>(batch.value[i]));
-      const size_t offset = top + i - batch.offset[0];
-      data[offset] = fvalue;
-      col_ind[offset] = index;
-      max_col_ind[tid] = std::max(max_col_ind[tid], static_cast<size_t>(index));
-    }
-    const size_t rtop = row_ptr.size();
-    row_ptr.resize(rtop + batch.size);
-    CHECK_LT(static_cast<int64_t>(batch.size), std::numeric_limits<int64_t>::max());
-    #pragma omp parallel for schedule(static) num_threads(nthread)
-    for (int64_t i = 0; i < static_cast<int64_t>(batch.size); ++i) {
-      row_ptr[rtop + i] = row_ptr[rtop - 1] + batch.offset[i + 1] - batch.offset[0];
-    }
-    if (verbose > 0) {
-      LOG(INFO) << num_row << " rows read into memory";
-    }
-  }
-  num_col = *std::max_element(max_col_ind.begin(), max_col_ind.end()) + 1;
-  return treelite::CSRDMatrix::Create(std::move(data), std::move(col_ind), std::move(row_ptr),
-                                      num_row, num_col);
-}
-
-std::unique_ptr<treelite::CSRDMatrix>
-CreateFromParser(
-    const char* filename, const char* format, treelite::TypeInfo dtype, int nthread, int verbose) {
-  switch (dtype) {
-  case treelite::TypeInfo::kFloat32:
-    return CreateFromParserImpl<float, float>(filename, format, nthread, verbose);
-  case treelite::TypeInfo::kFloat64:
-    return CreateFromParserImpl<double, float>(filename, format, nthread, verbose);
-  case treelite::TypeInfo::kUInt32:
-    return CreateFromParserImpl<uint32_t, int64_t>(filename, format, nthread, verbose);
-  default:
-    LOG(FATAL) << "Unrecognized TypeInfo: " << treelite::TypeInfoToString(dtype);
-  }
-  return CreateFromParserImpl<float, float>(filename, format, nthread, verbose);
-    // avoid missing value warning
-}
-
-}  // anonymous namespace
 
 namespace treelite {
 
@@ -223,13 +146,6 @@ CSRDMatrix::Create(TypeInfo type, const void* data, const uint32_t* col_ind, con
     LOG(FATAL) << "Invalid type for CSRDMatrix: " << TypeInfoToString(type);
   }
   return std::unique_ptr<CSRDMatrix>(nullptr);
-}
-
-std::unique_ptr<CSRDMatrix>
-CSRDMatrix::Create(
-    const char* filename, const char* format, const char* data_type, int nthread, int verbose) {
-  TypeInfo dtype = (data_type ? GetTypeInfoByName(data_type) : TypeInfo::kFloat32);
-  return CreateFromParser(filename, format, dtype, nthread, verbose);
 }
 
 TypeInfo

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -12,6 +12,7 @@
 #include <dmlc/logging.h>
 #include <limits>
 #include <vector>
+#include <cmath>
 #include <cstddef>
 #include "./pred_transform.h"
 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -6,6 +6,7 @@ import tempfile
 import pytest
 import treelite
 import treelite_runtime
+from sklearn.datasets import load_svmlight_file
 from .metadata import dataset_db
 
 
@@ -18,7 +19,8 @@ def annotation():
                                         model_format=dataset_db[dataset].format)
             if dataset_db[dataset].dtrain is None:
                 return None
-            dtrain = treelite_runtime.DMatrix(dataset_db[dataset].dtrain)
+            dtrain = treelite_runtime.DMatrix(
+                load_svmlight_file(dataset_db[dataset].dtrain, zero_based=True)[0])
             annotator = treelite.Annotator()
             annotator.annotate_branch(model=model, dmat=dtrain, verbose=True)
             annotation_path = os.path.join(tmpdir, f'{dataset}.json')

--- a/tests/python/test_model_builder.py
+++ b/tests/python/test_model_builder.py
@@ -7,6 +7,7 @@ import numpy as np
 import treelite
 import treelite_runtime
 from treelite.contrib import _libext
+from sklearn.datasets import load_svmlight_file
 from .metadata import dataset_db
 from .util import os_compatible_toolchains, check_predictor
 
@@ -89,7 +90,9 @@ def test_model_builder(tmpdir, use_annotation, quantize, toolchain, test_round_t
 
     annotation_path = os.path.join(tmpdir, 'annotation.json')
     if use_annotation:
-        dtrain = treelite_runtime.DMatrix(dataset_db['mushroom'].dtrain, dtype='float32')
+        dtrain = treelite_runtime.DMatrix(
+            load_svmlight_file(dataset_db['mushroom'].dtrain, zero_based=True)[0],
+            dtype='float32')
         annotator = treelite.Annotator()
         annotator.annotate_branch(model=model, dmat=dtrain, verbose=True)
         annotator.save(path=annotation_path)

--- a/tests/python/test_skl_importer.py
+++ b/tests/python/test_skl_importer.py
@@ -7,41 +7,13 @@ import numpy as np
 import treelite
 import treelite_runtime
 from treelite.contrib import _libext
-from treelite.util import has_sklearn
+from sklearn.ensemble import RandomForestClassifier, GradientBoostingClassifier, \
+    ExtraTreesClassifier, RandomForestRegressor, GradientBoostingRegressor, \
+    ExtraTreesRegressor
+from sklearn.datasets import load_iris, load_breast_cancer, load_boston
 from .util import os_compatible_toolchains
 
 
-if has_sklearn():
-    from sklearn.ensemble import RandomForestClassifier, GradientBoostingClassifier, \
-        ExtraTreesClassifier, RandomForestRegressor, GradientBoostingRegressor, \
-        ExtraTreesRegressor
-    from sklearn.datasets import load_iris, load_breast_cancer, load_boston
-else:
-    class RandomForestClassifier:  # pylint: disable=missing-class-docstring, R0903
-        pass
-
-
-    class RandomForestRegressor:  # pylint: disable=missing-class-docstring, R0903
-        pass
-
-
-    class GradientBoostingClassifier:  # pylint: disable=missing-class-docstring, R0903
-        pass
-
-
-    class GradientBoostingRegressor:  # pylint: disable=missing-class-docstring, R0903
-        pass
-
-
-    class ExtraTreesClassifier:  # pylint: disable=missing-class-docstring, R0903
-        pass
-
-
-    class ExtraTreesRegressor:  # pylint: disable=missing-class-docstring, R0903
-        pass
-
-
-@pytest.mark.skipif(not has_sklearn(), reason='Needs scikit-learn')
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())
 @pytest.mark.parametrize('clazz', [RandomForestClassifier, ExtraTreesClassifier,
                                    GradientBoostingClassifier])
@@ -86,7 +58,6 @@ def test_skl_converter_multiclass_classifier(tmpdir, import_method, clazz, toolc
     np.testing.assert_almost_equal(out_prob, expected_prob)
 
 
-@pytest.mark.skipif(not has_sklearn(), reason='Needs scikit-learn')
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())
 @pytest.mark.parametrize('clazz', [RandomForestClassifier, ExtraTreesClassifier,
                                    GradientBoostingClassifier])
@@ -130,7 +101,6 @@ def test_skl_converter_binary_classifier(tmpdir, import_method, clazz, toolchain
     np.testing.assert_almost_equal(out_prob, expected_prob)
 
 
-@pytest.mark.skipif(not has_sklearn(), reason='Needs scikit-learn')
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())
 @pytest.mark.parametrize('clazz', [RandomForestRegressor, ExtraTreesRegressor,
                                    GradientBoostingRegressor])

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -8,8 +8,9 @@ import numpy as np
 import pytest
 import treelite
 import treelite_runtime
-from treelite.util import has_sklearn
 from treelite.contrib import _libext
+from sklearn.datasets import load_boston, load_iris
+from sklearn.model_selection import train_test_split
 from .util import os_compatible_toolchains, check_predictor
 from .metadata import dataset_db
 
@@ -20,7 +21,6 @@ except ImportError:
     pytest.skip('XGBoost not installed; skipping', allow_module_level=True)
 
 
-@pytest.mark.skipif(not has_sklearn(), reason='Needs scikit-learn')
 @pytest.mark.parametrize('model_format', ['binary', 'json'])
 @pytest.mark.parametrize('objective', ['reg:linear', 'reg:squarederror', 'reg:squaredlogerror',
                                        'reg:pseudohubererror'])
@@ -28,9 +28,6 @@ except ImportError:
 def test_xgb_boston(tmpdir, toolchain, objective, model_format):
     # pylint: disable=too-many-locals
     """Test Boston data (regression)"""
-    from sklearn.datasets import load_boston
-    from sklearn.model_selection import train_test_split
-
     X, y = load_boston(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
     dtrain = xgboost.DMatrix(X_train, label=y_train)
@@ -66,7 +63,6 @@ def test_xgb_boston(tmpdir, toolchain, objective, model_format):
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
-@pytest.mark.skipif(not has_sklearn(), reason='Needs scikit-learn')
 @pytest.mark.parametrize('model_format', ['binary', 'json'])
 @pytest.mark.parametrize('objective,expected_pred_transform',
                          [('multi:softmax', 'max_index'), ('multi:softprob', 'softmax')],
@@ -75,9 +71,6 @@ def test_xgb_boston(tmpdir, toolchain, objective, model_format):
 def test_xgb_iris(tmpdir, toolchain, objective, model_format, expected_pred_transform):
     # pylint: disable=too-many-locals
     """Test Iris data (multi-class classification)"""
-    from sklearn.datasets import load_iris
-    from sklearn.model_selection import train_test_split
-
     X, y = load_iris(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
     dtrain = xgboost.DMatrix(X_train, label=y_train)
@@ -182,14 +175,10 @@ def test_nonlinear_objective(tmpdir, objective, max_label, expected_global_bias,
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
-@pytest.mark.skipif(not has_sklearn(), reason='Needs scikit-learn')
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())
 def test_xgb_deserializers(tmpdir, toolchain):
     # pylint: disable=too-many-locals
     """Test Boston data (regression)"""
-    from sklearn.datasets import load_boston
-    from sklearn.model_selection import train_test_split
-
     # Train xgboost model
     X, y = load_boston(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(

--- a/tests/python/util.py
+++ b/tests/python/util.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 
 import numpy as np
 import treelite_runtime
+from sklearn.datasets import load_svmlight_file
 from treelite.contrib import _libext
 from .metadata import dataset_db
 
@@ -55,7 +56,9 @@ def does_not_raise():
 
 def check_predictor(predictor, dataset):
     """Check whether a predictor produces correct predictions for a given dataset"""
-    dmat = treelite_runtime.DMatrix(dataset_db[dataset].dtest, dtype=dataset_db[dataset].dtype)
+    dmat = treelite_runtime.DMatrix(
+        load_svmlight_file(dataset_db[dataset].dtest, zero_based=True)[0],
+        dtype=dataset_db[dataset].dtype)
     out_margin = predictor.predict(dmat, pred_margin=True)
     out_prob = predictor.predict(dmat)
     check_predictor_output(dataset, dmat.shape, out_margin, out_prob)


### PR DESCRIPTION
Extracted from #285.
* Do not use `dmlc/data.h`.
* [Breaking] Drop support for loaindg DMatrix from text files in LIBSVM or CSV format. Users are asked to use 3rd-party libraries such as NumPy, Pandas, and scikit-learn to load data from text files. The C API function `TreeliteDMatrixCreateFromFile` is removed.
* Python tests now require `scikit-learn` package, in order to load test data from LIBSVM files.