### PR TITLE
Remove use of dmlc::thread_local

### DIFF
--- a/include/treelite/logging.h
+++ b/include/treelite/logging.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2020 by Contributors
+ * Copyright (c) 2017-2021 by Contributors
  * \file logging.h
  * \brief logging facility for Treelite
  * \author Hyunsu Cho
@@ -7,7 +7,7 @@
 #ifndef TREELITE_LOGGING_H_
 #define TREELITE_LOGGING_H_
 
-#include <dmlc/thread_local.h>
+#include <treelite/thread_local.h>
 #include <iostream>
 
 namespace treelite {
@@ -27,7 +27,7 @@ class LogCallbackRegistry {
   Callback log_callback_;
 };
 
-using LogCallbackRegistryStore = dmlc::ThreadLocalStore<LogCallbackRegistry>;
+using LogCallbackRegistryStore = ThreadLocalStore<LogCallbackRegistry>;
 
 }  // namespace treelite
 

--- a/include/treelite/thread_local.h
+++ b/include/treelite/thread_local.h
@@ -1,0 +1,28 @@
+/*!
+ * Copyright (c) 2021 by Contributors
+ * \file thread_local.h
+ * \brief Helper class for thread-local storage
+ * \author Hyunsu Cho
+ */
+#ifndef TREELITE_THREAD_LOCAL_H_
+#define TREELITE_THREAD_LOCAL_H_
+
+namespace treelite {
+
+/*!
+ * \brief A thread-local storage
+ * \tparam T the type we like to store
+ */
+template <typename T>
+class ThreadLocalStore {
+ public:
+  /*! \return get a thread local singleton */
+  static T* Get() {
+    static thread_local T inst;
+    return &inst;
+  }
+};
+
+}  // namespace treelite
+
+#endif  // TREELITE_THREAD_LOCAL_H_

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,7 @@ target_sources(objtreelite
     ${PROJECT_SOURCE_DIR}/include/treelite/frontend_impl.h
     ${PROJECT_SOURCE_DIR}/include/treelite/gtil.h
     ${PROJECT_SOURCE_DIR}/include/treelite/omp.h
+    ${PROJECT_SOURCE_DIR}/include/treelite/thread_local.h
     ${PROJECT_SOURCE_DIR}/include/treelite/tree.h
     ${PROJECT_SOURCE_DIR}/include/treelite/tree_impl.h
 )

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1,10 +1,9 @@
 /*!
- * Copyright (c) 2017-2020 by Contributors
+ * Copyright (c) 2017-2021 by Contributors
  * \file c_api.cc
  * \author Hyunsu Cho
  * \brief C API of treelite, used for interfacing with other languages
  */
-
 
 #include <treelite/annotator.h>
 #include <treelite/c_api.h>
@@ -17,7 +16,6 @@
 #include <treelite/tree.h>
 #include <treelite/math.h>
 #include <treelite/gtil.h>
-#include <dmlc/thread_local.h>
 #include <memory>
 #include <algorithm>
 

--- a/src/c_api/c_api_common.cc
+++ b/src/c_api/c_api_common.cc
@@ -1,11 +1,11 @@
 /*!
- * Copyright (c) 2017-2020 by Contributors
+ * Copyright (c) 2017-2021 by Contributors
  * \file c_api_common.cc
  * \author Hyunsu Cho
  * \brief C API of treelite (this file is used by both runtime and main package)
  */
 
-#include <dmlc/thread_local.h>
+#include <treelite/thread_local.h>
 #include <treelite/logging.h>
 #include <treelite/data.h>
 #include <treelite/c_api_common.h>
@@ -20,8 +20,7 @@ struct TreeliteAPIThreadLocalEntry {
 };
 
 // define threadlocal store for returning information
-using TreeliteAPIThreadLocalStore
-  = dmlc::ThreadLocalStore<TreeliteAPIThreadLocalEntry>;
+using TreeliteAPIThreadLocalStore = ThreadLocalStore<TreeliteAPIThreadLocalEntry>;
 
 int TreeliteRegisterLogCallback(void (*callback)(const char*)) {
   API_BEGIN();

--- a/src/c_api/c_api_error.cc
+++ b/src/c_api/c_api_error.cc
@@ -1,17 +1,18 @@
 /*!
- * Copyright (c) 2017-2020 by Contributors
+ * Copyright (c) 2017-2021 by Contributors
  * \file c_api_error.cc
  * \author Hyunsu Cho
  * \brief C error handling
  */
-#include <dmlc/thread_local.h>
+#include <treelite/thread_local.h>
 #include <treelite/c_api_error.h>
+#include <string>
 
 struct TreeliteAPIErrorEntry {
   std::string last_error;
 };
 
-typedef dmlc::ThreadLocalStore<TreeliteAPIErrorEntry> TreeliteAPIErrorStore;
+using TreeliteAPIErrorStore = treelite::ThreadLocalStore<TreeliteAPIErrorEntry>;
 
 const char* TreeliteGetLastError() {
   return TreeliteAPIErrorStore::Get()->last_error.c_str();

--- a/src/c_api/c_api_runtime.cc
+++ b/src/c_api/c_api_runtime.cc
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2020 by Contributors
+ * Copyright (c) 2017-2021 by Contributors
  * \file c_api_runtime.cc
  * \author Hyunsu Cho
  * \brief C API of treelite (runtime portion)
@@ -8,7 +8,7 @@
 #include <treelite/predictor.h>
 #include <treelite/c_api_runtime.h>
 #include <treelite/c_api_error.h>
-#include <dmlc/thread_local.h>
+#include <treelite/thread_local.h>
 #include <string>
 #include <cstring>
 
@@ -23,8 +23,7 @@ struct TreeliteRuntimeAPIThreadLocalEntry {
 };
 
 // thread-local store for returning strings
-using TreeliteRuntimeAPIThreadLocalStore
-  = dmlc::ThreadLocalStore<TreeliteRuntimeAPIThreadLocalEntry>;
+using TreeliteRuntimeAPIThreadLocalStore = ThreadLocalStore<TreeliteRuntimeAPIThreadLocalEntry>;
 
 }  // anonymous namespace
 


### PR DESCRIPTION
Extracted from #285.

* Do not use `dmlc/thread_local.h`.
* Replace `dmlc::ThreadLocalStore` with `treelite::ThreadLocalStore`, which is a light wrapper around `thread_local` storage.