### PR TITLE
[Breaking] Remove dmlc::Parameter

### DIFF
--- a/cmake/ExternalLibs.cmake
+++ b/cmake/ExternalLibs.cmake
@@ -52,13 +52,13 @@ add_library(RapidJSON::rapidjson ALIAS rapidjson)
 
 # Google C++ tests
 if(BUILD_CPP_TEST)
-  find_package(GTest CONFIG)
+  find_package(GTest 1.11.0 CONFIG)
   if(NOT GTEST_FOUND)
     message(STATUS "Did not find Google Test in the system root. Fetching Google Test now...")
     FetchContent_Declare(
       googletest
       GIT_REPOSITORY https://github.com/google/googletest.git
-      GIT_TAG        release-1.10.0
+      GIT_TAG        release-1.11.0
     )
     FetchContent_MakeAvailable(googletest)
     add_library(GTest::GTest ALIAS gtest)

--- a/include/treelite/c_api.h
+++ b/include/treelite/c_api.h
@@ -72,31 +72,22 @@ TREELITE_DLL int TreeliteAnnotationFree(AnnotationHandle handle);
  * \{
  */
 /*!
- * \brief create a compiler with a given name
+ * \brief Create a compiler with a given name
  * \param name name of compiler
+ * \param params_json_str JSON string representing the parameters for the compiler
  * \param out created compiler
  * \return 0 for success, -1 for failure
  */
-TREELITE_DLL int TreeliteCompilerCreate(const char* name,
-                                        CompilerHandle* out);
+TREELITE_DLL int TreeliteCompilerCreateV2(const char* name, const char* params_json_str,
+                                          CompilerHandle* out);
 /*!
- * \brief set a parameter for a compiler
- * \param handle compiler
- * \param name name of parameter
- * \param value value of parameter
- * \return 0 for success, -1 for failure
- */
-TREELITE_DLL int TreeliteCompilerSetParam(CompilerHandle handle,
-                                          const char* name,
-                                          const char* value);
-/*!
- * \brief generate prediction code from a tree ensemble model. The code will
+ * \brief Generate prediction code from a tree ensemble model. The code will
  *        be C99 compliant. One header file (.h) will be generated, along with
  *        one or more source files (.c).
  *
  * Usage example:
  * \code
- *   TreeliteCompilerGenerateCode(compiler, model, 1, "./my/model");
+ *   TreeliteCompilerGenerateCodeV2(compiler, model, "./my/model");
  *   // files to generate: ./my/model/header.h, ./my/model/main.c
  *   // if parallel compilation is enabled:
  *   // ./my/model/header.h, ./my/model/main.c, ./my/model/tu0.c,
@@ -104,14 +95,12 @@ TREELITE_DLL int TreeliteCompilerSetParam(CompilerHandle handle,
  * \endcode
  * \param compiler handle for compiler
  * \param model handle for tree ensemble model
- * \param verbose whether to produce extra messages
  * \param dirpath directory to store header and source files
  * \return 0 for success, -1 for failure
  */
-TREELITE_DLL int TreeliteCompilerGenerateCode(CompilerHandle compiler,
-                                              ModelHandle model,
-                                              int verbose,
-                                              const char* dirpath);
+TREELITE_DLL int TreeliteCompilerGenerateCodeV2(CompilerHandle compiler,
+                                                ModelHandle model,
+                                                const char* dirpath);
 /*!
  * \brief delete compiler from memory
  * \param handle compiler to remove

--- a/include/treelite/c_api_error.h
+++ b/include/treelite/c_api_error.h
@@ -7,9 +7,9 @@
 #ifndef TREELITE_C_API_ERROR_H_
 #define TREELITE_C_API_ERROR_H_
 
-#include <dmlc/base.h>
 #include <dmlc/logging.h>
 #include <treelite/c_api_common.h>
+#include <stdexcept>
 
 /*! \brief macro to guard beginning and end section of all functions */
 #define API_BEGIN() try {

--- a/include/treelite/compiler.h
+++ b/include/treelite/compiler.h
@@ -61,12 +61,18 @@ class Compiler {
    */
   virtual compiler::CompiledModel Compile(const Model& model) = 0;
   /*!
+   * \brief Query the parameters used to intiailize the compiler
+   * \return parameters used
+   */
+  virtual compiler::CompilerParam QueryParam() const = 0;
+  /*!
    * \brief create a compiler from given name
    * \param name name of compiler
+   * \param param_json_string JSON string representing
    * \return The created compiler
    */
   static Compiler* Create(const std::string& name,
-                          const compiler::CompilerParam& param);
+                          const char* param_json_str);
 };
 
 /*!

--- a/include/treelite/compiler_param.h
+++ b/include/treelite/compiler_param.h
@@ -7,7 +7,6 @@
 #ifndef TREELITE_COMPILER_PARAM_H_
 #define TREELITE_COMPILER_PARAM_H_
 
-#include <dmlc/parameter.h>
 #include <string>
 #include <limits>
 
@@ -15,7 +14,7 @@ namespace treelite {
 namespace compiler {
 
 /*! \brief parameters for tree compiler */
-struct CompilerParam : public dmlc::Parameter<CompilerParam> {
+struct CompilerParam {
   /*!
   * \defgroup compiler_param
   * parameters for tree compiler
@@ -49,24 +48,7 @@ struct CompilerParam : public dmlc::Parameter<CompilerParam> {
   int dump_array_as_elf;
   /*! \} */
 
-  // declare parameters
-  DMLC_DECLARE_PARAMETER(CompilerParam) {
-    DMLC_DECLARE_FIELD(annotate_in).set_default("NULL")
-      .describe("Name of model annotation file");
-    DMLC_DECLARE_FIELD(quantize).set_lower_bound(0).set_default(0)
-      .describe("whether to quantize threshold points (0: no, >0: yes)");
-    DMLC_DECLARE_FIELD(parallel_comp).set_lower_bound(0).set_default(0)
-      .describe("option to enable parallel compilation;"
-                "if set to nonzero, the trees will be evely distributed"
-                "into [parallel_comp] files.");
-    DMLC_DECLARE_FIELD(verbose).set_default(0)
-      .describe("if >0, produce extra messages");
-    DMLC_DECLARE_FIELD(native_lib_name).set_default("predictor");
-    DMLC_DECLARE_FIELD(code_folding_req)
-       .set_default(std::numeric_limits<double>::infinity())
-       .set_lower_bound(0);
-    DMLC_DECLARE_FIELD(dump_array_as_elf).set_lower_bound(0).set_default(0);
-  }
+  static CompilerParam ParseFromJSON(const char* param_json_str);
 };
 
 }  // namespace compiler

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -23,19 +23,6 @@
 
 using namespace treelite;
 
-namespace {
-
-struct CompilerHandleImpl {
-  std::string name;
-  std::vector<std::pair<std::string, std::string>> cfg;
-  std::unique_ptr<Compiler> compiler;
-  explicit CompilerHandleImpl(const std::string& name)
-    : name(name), cfg(), compiler(nullptr) {}
-  ~CompilerHandleImpl() = default;
-};
-
-}  // anonymous namespace
-
 int TreeliteAnnotateBranch(
     ModelHandle model, DMatrixHandle dmat, int nthread, int verbose, AnnotationHandle* out) {
   API_BEGIN();
@@ -63,66 +50,35 @@ int TreeliteAnnotationFree(AnnotationHandle handle) {
   API_END();
 }
 
-int TreeliteCompilerCreate(const char* name,
-                           CompilerHandle* out) {
+int TreeliteCompilerCreateV2(const char* name, const char* params_json_str, CompilerHandle* out) {
   API_BEGIN();
-  std::unique_ptr<CompilerHandleImpl> compiler{new CompilerHandleImpl(name)};
+  std::unique_ptr<Compiler> compiler{Compiler::Create(name, params_json_str)};
   *out = static_cast<CompilerHandle>(compiler.release());
   API_END();
 }
 
-int TreeliteCompilerSetParam(CompilerHandle handle,
-                             const char* name,
-                             const char* value) {
+int TreeliteCompilerGenerateCodeV2(CompilerHandle compiler,
+                                   ModelHandle model,
+                                   const char* dirpath) {
   API_BEGIN();
-  CompilerHandleImpl* impl = static_cast<CompilerHandleImpl*>(handle);
-  auto& cfg_ = impl->cfg;
-  std::string name_(name);
-  std::string value_(value);
-  // check for duplicate parameters
-  auto it = std::find_if(cfg_.begin(), cfg_.end(),
-    [&name_](const std::pair<std::string, std::string>& x) {
-      return x.first == name_;
-    });
-  if (it == cfg_.end()) {
-    cfg_.emplace_back(name_, value_);
-  } else {
-    it->second = value;
-  }
-  API_END();
-}
-
-int TreeliteCompilerGenerateCode(CompilerHandle compiler,
-                                 ModelHandle model,
-                                 int verbose,
-                                 const char* dirpath) {
-  API_BEGIN();
-  if (verbose > 0) {  // verbose enabled
-    int ret = TreeliteCompilerSetParam(compiler, "verbose",
-                                       std::to_string(verbose).c_str());
-    if (ret < 0) {  // SetParam failed
-      return ret;
-    }
-  }
   const Model* model_ = static_cast<Model*>(model);
-  CompilerHandleImpl* impl = static_cast<CompilerHandleImpl*>(compiler);
+  Compiler* compiler_ = static_cast<Compiler*>(compiler);
+  CHECK(model_);
+  CHECK(compiler_);
+  compiler::CompilerParam param = compiler_->QueryParam();
 
   // create directory named dirpath
   const std::string& dirpath_(dirpath);
   filesystem::CreateDirectoryIfNotExist(dirpath);
 
-  compiler::CompilerParam cparam;
-  cparam.Init(impl->cfg, dmlc::parameter::kAllMatch);
-
   /* compile model */
-  impl->compiler.reset(Compiler::Create(impl->name, cparam));
-  auto compiled_model = impl->compiler->Compile(*model_);
-  if (verbose > 0) {
+  auto compiled_model = compiler_->Compile(*model_);
+  if (param.verbose > 0) {
     LOG(INFO) << "Code generation finished. Writing code to files...";
   }
 
   for (const auto& it : compiled_model.files) {
-    if (verbose > 0) {
+    if (param.verbose > 0) {
       LOG(INFO) << "Writing file " << it.first << "...";
     }
     const std::string filename_full = dirpath_ + "/" + it.first;
@@ -138,7 +94,7 @@ int TreeliteCompilerGenerateCode(CompilerHandle compiler,
 
 int TreeliteCompilerFree(CompilerHandle handle) {
   API_BEGIN();
-  delete static_cast<CompilerHandleImpl*>(handle);
+  delete static_cast<Compiler*>(handle);
   API_END();
 }
 

--- a/src/compiler/ast_native.cc
+++ b/src/compiler/ast_native.cc
@@ -136,6 +136,10 @@ class ASTNativeCompiler : public Compiler {
     });
   }
 
+  CompilerParam QueryParam() const override {
+    return param;
+  }
+
  private:
   CompilerParam param;
   int num_feature_;

--- a/src/compiler/compiler.cc
+++ b/src/compiler/compiler.cc
@@ -6,29 +6,78 @@
 #include <treelite/compiler.h>
 #include <treelite/compiler_param.h>
 #include <dmlc/registry.h>
+#include <rapidjson/document.h>
+#include <limits>
 
 namespace dmlc {
 DMLC_REGISTRY_ENABLE(::treelite::CompilerReg);
 }  // namespace dmlc
 
 namespace treelite {
-Compiler* Compiler::Create(const std::string& name,
-                           const compiler::CompilerParam& param) {
+Compiler* Compiler::Create(const std::string& name, const char* param_json_str) {
+  compiler::CompilerParam param = compiler::CompilerParam::ParseFromJSON(param_json_str);
   auto *e = ::dmlc::Registry< ::treelite::CompilerReg>::Get()->Find(name);
   if (e == nullptr) {
     LOG(FATAL) << "Unknown compiler type " << name;
   }
   return (e->body)(param);
 }
-}  // namespace treelite
 
-namespace treelite {
 namespace compiler {
-// register compiler parameter
-DMLC_REGISTER_PARAMETER(CompilerParam);
+
+CompilerParam
+CompilerParam::ParseFromJSON(const char* param_json_str) {
+  CompilerParam param;
+  // Default values
+  param.annotate_in = "NULL";
+  param.quantize = 0;
+  param.parallel_comp = 0;
+  param.verbose = 0;
+  param.native_lib_name = "predictor";
+  param.code_folding_req = std::numeric_limits<double>::infinity();
+  param.dump_array_as_elf = 0;
+
+  rapidjson::Document doc;
+  doc.Parse(param_json_str);
+  CHECK(doc.IsObject()) << "Got an invalid JSON string:\n" << param_json_str;
+  for (const auto& e : doc.GetObject()) {
+    const std::string key = e.name.GetString();
+    if (key == "annotate_in") {
+      CHECK(e.value.IsString()) << "Expected a string for 'annotate_in'";
+      param.annotate_in = e.value.GetString();
+    } else if (key == "quantize") {
+      CHECK(e.value.IsInt()) << "Expected an integer for 'quantize'";
+      param.quantize = e.value.GetInt();
+      CHECK_GE(param.quantize, 0) << "'quantize' must be 0 or greater";
+    } else if (key == "parallel_comp") {
+      CHECK(e.value.IsInt()) << "Expected an integer for 'parallel_comp'";
+      param.parallel_comp = e.value.GetInt();
+      CHECK_GE(param.parallel_comp, 0) << "'parallel_comp' must be 0 or greater";
+    } else if (key == "verbose") {
+      CHECK(e.value.IsInt()) << "Expected an integer for 'verbose'";
+      param.verbose = e.value.GetInt();
+    } else if (key == "native_lib_name") {
+      CHECK(e.value.IsString()) << "Expected a string for 'native_lib_name'";
+      param.native_lib_name = e.value.GetString();
+    } else if (key == "code_folding_req") {
+      CHECK(e.value.IsDouble()) << "Expected a floating-point decimal for 'code_folding_req'";
+      param.code_folding_req = e.value.GetDouble();
+      CHECK_GE(param.code_folding_req, 0) << "'code_folding_req' must be 0 or greater";
+    } else if (key == "dump_array_as_elf") {
+      CHECK(e.value.IsInt()) << "Expected an integer for 'dump_array_as_elf'";
+      param.dump_array_as_elf = e.value.GetInt();
+      CHECK_GE(param.dump_array_as_elf, 0) << "'dump_array_as_elf' must be 0 or greater";
+    } else {
+      LOG(FATAL) << "Unrecognized key '" << key << "' in JSON";
+    }
+  }
+
+  return param;
+}
 
 // List of files that will be force linked in static links.
 DMLC_REGISTRY_LINK_TAG(ast_native);
 DMLC_REGISTRY_LINK_TAG(failsafe);
 }  // namespace compiler
+
 }  // namespace treelite

--- a/src/compiler/failsafe.cc
+++ b/src/compiler/failsafe.cc
@@ -388,6 +388,10 @@ class FailSafeCompiler : public Compiler {
     return cm;
   }
 
+  CompilerParam QueryParam() const override {
+    return param;
+  }
+
  private:
   CompilerParam param;
   int num_feature_;

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -5,7 +5,7 @@ set_target_properties(treelite_cpp_test
     CXX_STANDARD_REQUIRED ON)
 target_link_libraries(treelite_cpp_test
     PRIVATE objtreelite objtreelite_runtime objtreelite_common rapidjson
-    GTest::GTest GTest::gmock)
+    GTest::GTest GTest::gmock fmt::fmt-header-only)
 set_output_directory(treelite_cpp_test ${PROJECT_BINARY_DIR})
 
 if(MSVC)
@@ -25,6 +25,7 @@ target_sources(treelite_cpp_test
   PRIVATE  test_main.cc
            test_serializer.cc
            test_frontend.cc
+           test_compiler_param.cc
 )
 
 target_include_directories(treelite_cpp_test

--- a/tests/cpp/test_compiler_param.cc
+++ b/tests/cpp/test_compiler_param.cc
@@ -1,0 +1,112 @@
+/*!
+ * Copyright (c) 2021 by Contributors
+ * \file test_compiler_param.cc
+ * \author Hyunsu Cho
+ * \brief C++ tests for ingesting compiler parameters
+ */
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <treelite/compiler_param.h>
+#include <treelite/logging.h>
+#include <dmlc/logging.h>
+#include <fmt/format.h>
+
+using namespace testing;
+
+namespace treelite {
+namespace compiler {
+
+TEST(CompilerParam, Basic) {
+  std::string json_str = R"JSON(
+    {
+      "quantize": 1,
+      "parallel_comp": 100,
+      "native_lib_name": "predictor",
+      "annotate_in": "annotation.json",
+      "verbose": 3,
+      "code_folding_req": 1.0,
+      "dump_array_as_elf": 0
+    })JSON";
+  CompilerParam param = CompilerParam::ParseFromJSON(json_str.c_str());
+  EXPECT_EQ(param.quantize, 1);
+  EXPECT_EQ(param.parallel_comp, 100);
+  EXPECT_EQ(param.native_lib_name, "predictor");
+  EXPECT_EQ(param.annotate_in, "annotation.json");
+  EXPECT_EQ(param.verbose, 3);
+  EXPECT_EQ(param.code_folding_req, 1.0);
+  EXPECT_EQ(param.dump_array_as_elf, 0);
+}
+
+TEST(CompilerParam, NonExistentKey) {
+  std::string json_str = R"JSON(
+    {
+      "quantize": 1,
+      "parallel_comp": 100,
+      "nonexistent": 0.3
+    })JSON";
+  EXPECT_THAT(
+      [&]() { CompilerParam::ParseFromJSON(json_str.c_str()); },
+      ThrowsMessage<dmlc::Error>(HasSubstr("Unrecognized key 'nonexistent'")));
+  json_str = R"JSON(
+    {
+      "quantize": 1,
+      "parallel_comp": 100,
+      "extra_object": {
+        "extra": 30
+      }
+    })JSON";
+  EXPECT_THAT(
+      [&]() { CompilerParam::ParseFromJSON(json_str.c_str()); },
+      ThrowsMessage<dmlc::Error>(HasSubstr("Unrecognized key 'extra_object'")));
+}
+
+TEST(CompilerParam, IncorrectType) {
+  using namespace testing;
+  std::string json_str = R"JSON(
+    {
+      "quantize": "bad_type"
+    })JSON";
+  EXPECT_THAT(
+      [&]() { CompilerParam::ParseFromJSON(json_str.c_str()); },
+      ThrowsMessage<dmlc::Error>(HasSubstr("Expected an integer for 'quantize'")));
+  json_str = R"JSON(
+    {
+      "code_folding_req": {
+        "bad_type": 30
+      }
+    })JSON";
+  EXPECT_THAT(
+      [&]() { CompilerParam::ParseFromJSON(json_str.c_str()); },
+      ThrowsMessage<dmlc::Error>(
+        HasSubstr("Expected a floating-point decimal for 'code_folding_req'")));
+  json_str = R"JSON(
+    {
+      "native_lib_name": -10.0
+    })JSON";
+  EXPECT_THAT(
+      [&]() { CompilerParam::ParseFromJSON(json_str.c_str()); },
+      ThrowsMessage<dmlc::Error>(HasSubstr("Expected a string for 'native_lib_name'")));
+  json_str = R"JSON(
+    {
+      "code_folding_req": 13bad
+    })JSON";
+  EXPECT_THAT(
+      [&]() { CompilerParam::ParseFromJSON(json_str.c_str()); },
+      ThrowsMessage<dmlc::Error>(HasSubstr("Got an invalid JSON string")));
+}
+
+TEST(CompilerParam, InvalidRange) {
+  std::string json_str;
+  for (const auto& key : std::vector<std::string>{"quantize", "parallel_comp",
+                                                  "code_folding_req", "dump_array_as_elf"}) {
+    std::string literal = (key == "code_folding_req" ? "-1.0" : "-1");
+    json_str = fmt::format(R"JSON({{ "{0}": {1} }})JSON", key, literal);
+    std::string expected_error = fmt::format("'{}' must be 0 or greater", key);
+    EXPECT_THAT(
+        [&]() { CompilerParam::ParseFromJSON(json_str.c_str()); },
+        ThrowsMessage<dmlc::Error>(HasSubstr(expected_error)));
+  }
+}
+
+}  // namespace compiler
+}  // namespace treelite

--- a/tests/example_app/example.cc
+++ b/tests/example_app/example.cc
@@ -1,7 +1,6 @@
 #include <treelite/tree.h>
 #include <treelite/frontend.h>
 #include <treelite/compiler.h>
-#include <treelite/compiler_param.h>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -28,9 +27,7 @@ int main(void) {
   auto model = builder->CommitModel();
   std::cout << model->GetNumTree() << std::endl;
 
-  treelite::compiler::CompilerParam param;
-  param.Init(std::map<std::string, std::string>{});
-  std::unique_ptr<treelite::Compiler> compiler{treelite::Compiler::Create("ast_native", param)};
+  std::unique_ptr<treelite::Compiler> compiler{treelite::Compiler::Create("ast_native", "{}")};
   treelite::compiler::CompiledModel cm = compiler->Compile(*model.get());
   for (const auto& kv : cm.files) {
     std::cout << "=================" << kv.first << "=================" << std::endl;

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -42,7 +42,7 @@ then
   rm -rf build/
   mkdir build
   cd build
-  cmake .. -DUSE_OPENMP=ON -DBUILD_STATIC_LIBS=ON -GNinja
+  cmake .. -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX" -DCMAKE_INSTALL_LIBDIR="lib" -DUSE_OPENMP=ON -DBUILD_STATIC_LIBS=ON -GNinja
   ninja install
 
   # Try compiling a sample application


### PR DESCRIPTION
Extracted from #285.

* Do not use `dmlc/parameter.h`.
* `CompilerParam` no longer inherits from `dmlc::Parameter`. Consequently, it now implements a special method `ParseFromJSON()` that ingests parameters from a JSON string.
* Now parameters are set with JSON strings.
Before:
```cpp
CompilerHandle handle;
TreeliteCompilerCreate("ast_native", &handle);
TreeliteCompilerSetParam(handle, "quantize", "1");
TreeliteCompilerSetParam(handle, "parallel_comp", "100");
TreeliteCompilerSetParam(handle, "native_lib_name", "predictor");
```
After:
```cpp
CompilerHandle handle;
const char* params = "{\"quantize\": 1, \"parallel_comp\": 100,"
                     " \"native_lib_name\": \"predictor\"}";
TreeliteCompilerCreateV2("ast_native", params, &handle);
```

* Breaking: The C API functions `TreeliteCompilerCreate` and `TreeliteCompilerGenerateCode` are renamed to `TreeliteCompilerCreateV2` and `TreeliteCompilerGenerateCodeV2`, respectively, to indicate the different calling signature. In addition, `TreeliteCompilerSetParam` has been removed.
* Add C++ tests to test the correctness of `ParseFromJSON()`.
* Upgrade Google Test framework to 1.11.0 to test the content of exceptions.