### PR TITLE
[CI] Downgrade libomp package to 11.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,7 @@ jobs:
 # dependent brew packages
 addons:
   homebrew:
-    packages:
-      - cmake
-      - libomp
-      - wget
-      - lcov
-      - ninja
-    update: true
+    update: false
   apt:
     sources:
       - sourceline: 'deb https://apt.kitware.com/ubuntu/ bionic main'

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -3,6 +3,12 @@
 set -eo pipefail
 
 if [ ${TRAVIS_OS_NAME} == "osx" ]; then
+  brew update
+  # Use libomp 11.1.0: https://github.com/dmlc/xgboost/issues/7039
+  wget https://raw.githubusercontent.com/Homebrew/homebrew-core/679923b4eb48a8dc7ecc1f05d06063cd79b3fc00/Formula/libomp.rb -O $(find $(brew --repository) -name libomp.rb)
+  brew install cmake libomp lcov ninja
+  brew pin libomp
+
   wget -O conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
 else
   wget -O conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh


### PR DESCRIPTION
https://app.travis-ci.com/github/dmlc/treelite/jobs/524580900#L3132:
```
tests/python/test_basic.py::test_basic[mushroom-True-None-True-gcc] 
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong
with the build itself.
Check the details on how to adjust your build configuration on:
https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
The build has been terminated
```

I suspect it has to do with the use of OpenMP in `src/annotator.cc`.