### PR TITLE
Work around a compiler bug in GCC 7

### DIFF
--- a/src/annotator.cc
+++ b/src/annotator.cc
@@ -72,11 +72,11 @@ inline void ComputeBranchLoopImpl(
     const treelite::DenseDMatrixImpl<ElementType>* dmat, size_t rbegin, size_t rend, int nthread,
     const size_t* count_row_ptr, uint64_t* counts_tloc) {
   std::vector<Entry<ElementType>> inst(nthread * dmat->num_col, {-1});
-  const size_t ntree = model.trees.size();
+  size_t ntree = model.trees.size();
   TREELITE_CHECK_LE(rbegin, rend);
-  const size_t num_col = dmat->num_col;
-  const ElementType missing_value = dmat->missing_value;
-  const bool nan_missing = treelite::math::CheckNAN(missing_value);
+  size_t num_col = dmat->num_col;
+  ElementType missing_value = dmat->missing_value;
+  bool nan_missing = treelite::math::CheckNAN(missing_value);
   treelite::threading_utils::ParallelFor(rbegin, rend, nthread,
                                          [&](std::size_t rid, std::size_t thread_id) {
     const ElementType* row = &dmat->data[rid * num_col];
@@ -105,7 +105,7 @@ inline void ComputeBranchLoopImpl(
     const treelite::CSRDMatrixImpl<ElementType>* dmat, size_t rbegin, size_t rend, int nthread,
     const size_t* count_row_ptr, uint64_t* counts_tloc) {
   std::vector<Entry<ElementType>> inst(nthread * dmat->num_col, {-1});
-  const size_t ntree = model.trees.size();
+  size_t ntree = model.trees.size();
   TREELITE_CHECK_LE(rbegin, rend);
   treelite::threading_utils::ParallelFor(rbegin, rend, nthread,
                                          [&](std::size_t rid, std::size_t thread_id) {


### PR DESCRIPTION
https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=352612&view=results
```
[22/36] Building CXX object src/CMakeFiles/objtreelite.dir/annotator.cc.o
FAILED: src/CMakeFiles/objtreelite.dir/annotator.cc.o 
$BUILD_PREFIX/bin/x86_64-conda-linux-gnu-c++ -DFMT_HEADER_ONLY=1 -I$SRC_DIR/include -I$SRC_DIR/build/include -isystem $BUILD_PREFIX/include -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem $PREFIX/include -fdebug-prefix-map=$SRC_DIR=/usr/local/src/conda/treelite-2.0.0 -fdebug-prefix-map=$PREFIX=/usr/local/src/conda-prefix -O3 -DNDEBUG -fPIC -funroll-loops -std=gnu++14 -MD -MT src/CMakeFiles/objtreelite.dir/annotator.cc.o -MF src/CMakeFiles/objtreelite.dir/annotator.cc.o.d -o src/CMakeFiles/objtreelite.dir/annotator.cc.o -c $SRC_DIR/src/annotator.cc
$SRC_DIR/src/annotator.cc: In instantiation of '{anonymous}::ComputeBranchLoopImpl(const treelite::ModelImpl<ThresholdType, LeafOutputType>&, const treelite::DenseDMatrixImpl<ElementType>*, size_t, size_t, int, const size_t*, uint64_t*)::<lambda(std::size_t, std::size_t)> [with ElementType = unsigned int; ThresholdType = float; LeafOutputType = unsigned int; std::size_t = long unsigned int]':
$SRC_DIR/src/annotator.cc:94:51:   required from 'struct {anonymous}::ComputeBranchLoopImpl(const treelite::ModelImpl<ThresholdType, LeafOutputType>&, const treelite::DenseDMatrixImpl<ElementType>*, size_t, size_t, int, const size_t*, uint64_t*) [with ElementType = unsigned int; ThresholdType = float; LeafOutputType = unsigned int; size_t = long unsigned int; uint64_t = long unsigned int]::<lambda(std::size_t, std::size_t)>'
$SRC_DIR/src/annotator.cc:80:41:   required from 'void {anonymous}::ComputeBranchLoopImpl(const treelite::ModelImpl<ThresholdType, LeafOutputType>&, const treelite::DenseDMatrixImpl<ElementType>*, size_t, size_t, int, const size_t*, uint64_t*) [with ElementType = unsigned int; ThresholdType = float; LeafOutputType = unsigned int; size_t = long unsigned int; uint64_t = long unsigned int]'
$SRC_DIR/src/annotator.cc:138:26:   required from 'static void {anonymous}::ComputeBranchLoopDispatcherWithDenseDMatrix<ElementType>::Dispatch(const treelite::ModelImpl<ThresholdType, LeafOutputType>&, const treelite::DMatrix*, size_t, size_t, int, const size_t*, uint64_t*) [with ThresholdType = float; LeafOutputType = unsigned int; ElementType = unsigned int; size_t = long unsigned int; uint64_t = long unsigned int]'
$SRC_DIR/include/treelite/./typeinfo.h:90:42:   required from 'auto treelite::DispatchWithTypeInfo(treelite::TypeInfo, Args&& ...) [with Dispatcher = {anonymous}::ComputeBranchLoopDispatcherWithDenseDMatrix; Args = {const treelite::ModelImpl<float, unsigned int>&, const treelite::DMatrix*&, long unsigned int&, long unsigned int&, int&, const long unsigned int*&, long unsigned int*&}]'
$SRC_DIR/src/annotator.cc:163:80:   required from 'void {anonymous}::ComputeBranchLoop(const treelite::ModelImpl<ThresholdType, LeafOutputType>&, const treelite::DMatrix*, size_t, size_t, int, const size_t*, uint64_t*) [with ThresholdType = float; LeafOutputType = unsigned int; size_t = long unsigned int; uint64_t = long unsigned int]'
$SRC_DIR/src/annotator.cc:208:22:   required from 'void treelite::AnnotateImpl(const treelite::ModelImpl<ThresholdType, LeafOutputType>&, const treelite::DMatrix*, int, int, std::vector<std::vector<long unsigned int, std::allocator<long unsigned int> > >*) [with ThresholdType = float; LeafOutputType = unsigned int]'
$SRC_DIR/src/annotator.cc:233:17:   required from 'treelite::BranchAnnotator::Annotate(const treelite::Model&, const treelite::DMatrix*, int, int)::<lambda(auto:17&)> [with auto:17 = const treelite::ModelImpl<float, unsigned int>]'
$SRC_DIR/include/treelite/tree_impl.h:795:16:   required from 'static auto treelite::ModelDispatchImpl<ThresholdType, LeafOutputType>::Dispatch(const treelite::Model*, Func) [with Func = treelite::BranchAnnotator::Annotate(const treelite::Model&, const treelite::DMatrix*, int, int)::<lambda(auto:17&)>; ThresholdType = float; LeafOutputType = unsigned int]'
$SRC_DIR/include/treelite/./typeinfo.h:134:51:   required from 'auto treelite::DispatchWithModelTypes(treelite::TypeInfo, treelite::TypeInfo, Args&& ...) [with Dispatcher = treelite::ModelDispatchImpl; Args = {const treelite::Model*, treelite::BranchAnnotator::Annotate(const treelite::Model&, const treelite::DMatrix*, int, int)::<lambda(auto:17&)>&}]'
$SRC_DIR/include/treelite/tree_impl.h:808:51:   required from 'auto treelite::Model::Dispatch(Func) const [with Func = treelite::BranchAnnotator::Annotate(const treelite::Model&, const treelite::DMatrix*, int, int)::<lambda(auto:17&)>]'
$SRC_DIR/src/annotator.cc:234:4:   required from here
$SRC_DIR/src/annotator.cc:99:3: internal compiler error: in maybe_undo_parenthesized_ref, at cp/semantics.c:1740
   });
   ^
Please submit a full bug report,
with preprocessed source if appropriate.
See <https://gcc.gnu.org/bugs/> for instructions.
```

Work around a compiler bug in GCC 7, by removing a few const designations from local variables. The fix was inspired by kokkos/kokkos-kernels#349.