### PR TITLE
Handle the case where left_categories={}

### DIFF
--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -60,6 +60,7 @@ class ContiguousArray {
   inline T& Back();
   inline const T& Back() const;
   inline std::size_t Size() const;
+  inline bool Empty() const;
   inline void Reserve(std::size_t newsize);
   inline void Resize(std::size_t newsize);
   inline void Resize(std::size_t newsize, T t);

--- a/include/treelite/tree_impl.h
+++ b/include/treelite/tree_impl.h
@@ -151,6 +151,12 @@ ContiguousArray<T>::Size() const {
 }
 
 template <typename T>
+inline bool
+ContiguousArray<T>::Empty() const {
+  return (Size() == 0);
+}
+
+template <typename T>
 inline void
 ContiguousArray<T>::Reserve(std::size_t newsize) {
   if (!owned_buffer_) {
@@ -714,7 +720,9 @@ Tree<ThresholdType, LeafOutputType>::SetCategoricalSplit(
   }
   std::for_each(&matching_categories_offset_.at(nid + 1), matching_categories_offset_.End(),
                 [new_end_oft](std::size_t& x) { x = new_end_oft; });
-  std::sort(&matching_categories_.at(end_oft), matching_categories_.End());
+  if (!matching_categories_.Empty()) {
+    std::sort(&matching_categories_.at(end_oft), matching_categories_.End());
+  }
 
   Node& node = nodes_.at(nid);
   if (default_left) split_index |= (1U << 31U);

--- a/tests/cpp/test_serializer.cc
+++ b/tests/cpp/test_serializer.cc
@@ -132,7 +132,8 @@ TEST(PyBufferInterfaceRoundTrip, TreeStumpLeafVec) {
 }
 
 template <typename ThresholdType, typename LeafOutputType>
-void PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit() {
+void PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit(
+    const std::vector<uint32_t>& left_categories) {
   TypeInfo threshold_type = TypeToInfo<ThresholdType>();
   TypeInfo leaf_output_type = TypeToInfo<LeafOutputType>();
   std::unique_ptr<frontend::ModelBuilder> builder{
@@ -144,7 +145,7 @@ void PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit() {
   tree->CreateNode(0);
   tree->CreateNode(1);
   tree->CreateNode(2);
-  tree->SetCategoricalTestNode(0, 0, {0, 1}, true, 1, 2);
+  tree->SetCategoricalTestNode(0, 0, left_categories, true, 1, 2);
   tree->SetRootNode(0);
   tree->SetLeafNode(1, frontend::Value::Create<LeafOutputType>(-1));
   tree->SetLeafNode(2, frontend::Value::Create<LeafOutputType>(1));
@@ -155,20 +156,27 @@ void PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit() {
 }
 
 TEST(PyBufferInterfaceRoundTrip, TreeStumpCategoricalSplit) {
-  PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<float, float>();
-  PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<float, uint32_t>();
-  PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<double, double>();
-  PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<double, uint32_t>();
-  ASSERT_THROW((PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<float, double>()),
-               std::runtime_error);
-  ASSERT_THROW((PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<double, float>()),
-               std::runtime_error);
-  ASSERT_THROW((PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<uint32_t, uint32_t>()),
-               std::runtime_error);
-  ASSERT_THROW((PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<uint32_t, float>()),
-               std::runtime_error);
-  ASSERT_THROW((PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<uint32_t, double>()),
-               std::runtime_error);
+  for (const auto& left_categories : std::vector<std::vector<uint32_t>>{ {}, {1}, {0, 1} }) {
+    PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<float, float>(left_categories);
+    PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<float, uint32_t>(left_categories);
+    PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<double, double>(left_categories);
+    PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<double, uint32_t>(left_categories);
+    ASSERT_THROW(
+        (PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<float, double>(left_categories)),
+        std::runtime_error);
+    ASSERT_THROW(
+        (PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<double, float>(left_categories)),
+        std::runtime_error);
+    ASSERT_THROW(
+        (PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<uint32_t, uint32_t>(left_categories)),
+        std::runtime_error);
+    ASSERT_THROW(
+        (PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<uint32_t, float>(left_categories)),
+        std::runtime_error);
+    ASSERT_THROW(
+        (PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit<uint32_t, double>(left_categories)),
+        std::runtime_error);
+  }
 }
 
 template <typename ThresholdType, typename LeafOutputType>


### PR DESCRIPTION
The bug was revealed in https://github.com/rapidsai/cuml/pull/4041. When the user is iteratively building a model using the model builder class and specifies a categorical split with an empty value `{}` for `left_categories`, Treelite throws an exception
```
nid out of range
```

This PR ensures that Treelite can represent categorical splits with empty left categories.