### PR TITLE
Fix errors reported by Python linter

### DIFF
--- a/python/.pylintrc
+++ b/python/.pylintrc
@@ -1,7 +1,7 @@
 [MASTER]
 extension-pkg-whitelist=numpy
 
-disable=unexpected-special-method-signature,too-many-nested-blocks,useless-object-inheritance,import-outside-toplevel,unsubscriptable-object,attribute-defined-outside-init,unbalanced-tuple-unpacking
+disable=unexpected-special-method-signature,too-many-nested-blocks,useless-object-inheritance,import-outside-toplevel,unsubscriptable-object,attribute-defined-outside-init,unbalanced-tuple-unpacking,consider-using-f-string
 
 dummy-variables-rgx=(unused|)_.*
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -175,8 +175,6 @@ class InstallLib(install_lib.install_lib):
 
         outfiles = super().install()
 
-        global BUILD_TEMP_DIR   # pylint: disable=global-statement
-
         # Copy shared library
         libtreelite_name = lib_name()
         dst_dir = os.path.join(self.install_dir, 'treelite', 'lib')
@@ -196,6 +194,7 @@ class InstallLib(install_lib.install_lib):
             self.logger.info('Using %s built by CMake', libtreelite_name)
         else:
             # The library was built by setup.py
+            assert BUILD_TEMP_DIR is not None
             build_dir = BUILD_TEMP_DIR
             src = os.path.join(build_dir, libtreelite_name)
             assert os.path.exists(src)
@@ -244,7 +243,7 @@ if __name__ == '__main__':
     # From source tree `treelite/python`:
     # - python setup.py install
     # - python setup.py bdist_wheel && pip install <wheel-name>
-    with open(os.path.join(CURRENT_DIR, 'treelite/VERSION')) as f:
+    with open(os.path.join(CURRENT_DIR, 'treelite/VERSION'), 'r', encoding='UTF-8') as f:
         version = f.read().strip()
     logging.basicConfig(level=logging.INFO)
     setup(name='treelite',

--- a/python/treelite/__init__.py
+++ b/python/treelite/__init__.py
@@ -12,7 +12,7 @@ from . import sklearn
 from . import gtil
 
 VERSION_FILE = os.path.join(os.path.dirname(__file__), 'VERSION')
-with open(VERSION_FILE, 'r') as _f:
+with open(VERSION_FILE, 'r', encoding='UTF-8') as _f:
     __version__ = _f.read().strip()
 
 __all__ = ['Model', 'ModelBuilder', 'Annotator', 'create_shared', 'generate_makefile',

--- a/python/treelite/contrib/__init__.py
+++ b/python/treelite/contrib/__init__.py
@@ -63,7 +63,7 @@ def generate_makefile(dirpath, platform, toolchain, options=None):  # pylint: di
     if not os.path.isdir(dirpath):
         raise TreeliteError('Directory {} does not exist'.format(dirpath))
     try:
-        with open(os.path.join(dirpath, 'recipe.json')) as f:
+        with open(os.path.join(dirpath, 'recipe.json'), 'r', encoding='UTF-8') as f:
             recipe = json.load(f)
     except IOError as e:
         raise TreeliteError('Failed to open recipe.json') from e
@@ -99,7 +99,7 @@ def generate_makefile(dirpath, platform, toolchain, options=None):  # pylint: di
         from .gcc import _obj_ext, _obj_cmd, _lib_cmd
     obj_ext = _obj_ext()
 
-    with open(os.path.join(dirpath, 'Makefile'), 'w') as f:
+    with open(os.path.join(dirpath, 'Makefile'), 'w', encoding='UTF-8') as f:
         objects = [x['name'] + obj_ext for x in recipe['sources']] \
                   + recipe.get('extra', [])
         f.write('{}: {}\n'.format(recipe['target'] + lib_ext, ' '.join(objects)))
@@ -135,7 +135,7 @@ def generate_cmakelists(dirpath, options=None):
     if not os.path.isdir(dirpath):
         raise TreeliteError(f'Directory {dirpath} does not exist')
     try:
-        with open(os.path.join(dirpath, 'recipe.json')) as f:
+        with open(os.path.join(dirpath, 'recipe.json'), 'r', encoding='UTF-8') as f:
             recipe = json.load(f)
     except IOError as e:
         raise TreeliteError('Failed to open recipe.json') from e
@@ -154,7 +154,7 @@ def generate_cmakelists(dirpath, options=None):
     target = recipe['target']
     sources = ' '.join([x['name'] + '.c' for x in recipe['sources']])
     options = ' '.join(options)
-    with open(os.path.join(dirpath, 'CMakeLists.txt'), 'w') as f:
+    with open(os.path.join(dirpath, 'CMakeLists.txt'), 'w', encoding='UTF-8') as f:
         print('cmake_minimum_required(VERSION 3.13)', file=f)
         print('project(mushroom LANGUAGES C)\n', file=f)
         print(f'add_library({target} SHARED)', file=f)
@@ -240,7 +240,7 @@ def create_shared(toolchain, dirpath, *, nthread=None, verbose=False, options=No
     if not os.path.isdir(dirpath):
         raise TreeliteError('Directory {} does not exist'.format(dirpath))
     try:
-        with open(os.path.join(dirpath, 'recipe.json')) as f:
+        with open(os.path.join(dirpath, 'recipe.json'), 'r', encoding='UTF-8') as f:
             recipe = json.load(f)
     except IOError as e:
         raise TreeliteError('Failed to open recipe.json') from e

--- a/python/treelite/contrib/util.py
+++ b/python/treelite/contrib/util.py
@@ -85,7 +85,7 @@ def _wait(proc, args):
     tid = args['tid']
     dirpath = args['dirpath']
     stdout, _ = proc.communicate()
-    with open(os.path.join(dirpath, 'retcode_cpu{}.txt'.format(tid)), 'r') as f:
+    with open(os.path.join(dirpath, 'retcode_cpu{}.txt'.format(tid)), 'r', encoding='UTF-8') as f:
         retcode = [int(line) for line in f]
     return {'stdout': stdout.decode(), 'retcode': retcode}
 
@@ -124,7 +124,8 @@ def _create_shared_base(dirpath, recipe, nthread, verbose):
 
     for tid in range(ncpu):
         if not all(x == 0 for x in result[tid]['retcode']):
-            with open(os.path.join(dirpath, 'log_cpu{}.txt'.format(tid)), 'w') as f:
+            log_path = os.path.join(dirpath, f'log_cpu{tid}.txt')
+            with open(log_path, 'w', encoding='UTF-8') as f:
                 f.write(result[tid]['stdout'] + '\n')
             raise TreeliteError('Error occured in worker #{}: '.format(tid) + \
                                 '{}'.format(result[tid]['stdout']))
@@ -150,7 +151,7 @@ def _create_shared_base(dirpath, recipe, nthread, verbose):
     result = _wait(proc, workqueue)
 
     if result['retcode'][0] != 0:
-        with open(os.path.join(dirpath, 'log_cpu0.txt'), 'w') as f:
+        with open(os.path.join(dirpath, 'log_cpu0.txt'), 'w', encoding='UTF-8') as f:
             f.write(result['stdout'] + '\n')
         raise TreeliteError('Error occured while creating dynamic library: ' + \
                             '{}'.format(result['stdout']))

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -25,7 +25,7 @@ def annotation():
             annotator.annotate_branch(model=model, dmat=dtrain, verbose=True)
             annotation_path = os.path.join(tmpdir, f'{dataset}.json')
             annotator.save(annotation_path)
-            with open(annotation_path, 'r') as f:
+            with open(annotation_path, 'r', encoding='UTF-8') as f:
                 return f.read()
         annotation_db = {k: compute_annotation(k) for k in dataset_db}
     return annotation_db

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -35,7 +35,7 @@ def test_basic(tmpdir, annotation, dataset, use_annotation, quantize, parallel_c
     if use_annotation:
         if annotation[dataset] is None:
             pytest.skip('No training data available. Skipping annotation')
-        with open(annotation_path, 'w') as f:
+        with open(annotation_path, 'w', encoding='UTF-8') as f:
             f.write(annotation[dataset])
 
     params = {

--- a/tests/python/test_code_folding.py
+++ b/tests/python/test_code_folding.py
@@ -28,7 +28,7 @@ def test_code_folding(tmpdir, annotation, dataset, toolchain, code_folding_facto
     if annotation[dataset] is None:
         annotation_path = None
     else:
-        with open(annotation_path, 'w') as f:
+        with open(annotation_path, 'w', encoding='UTF-8') as f:
             f.write(annotation[dataset])
 
     params = {

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -204,7 +204,7 @@ def test_xgb_deserializers(tmpdir, toolchain):
     model_json = treelite.Model.load(
         model_json_path, model_format='xgboost_json'
     )
-    with open(model_json_path) as file_:
+    with open(model_json_path, 'r', encoding='UTF-8') as file_:
         json_str = file_.read()
     model_json_str = treelite.Model.from_xgboost_json(json_str)
 

--- a/tests/python/util.py
+++ b/tests/python/util.py
@@ -16,7 +16,7 @@ def load_txt(filename):
     if filename is None:
         return None
     content = []
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='UTF-8') as f:
         for line in f:
             content.append(float(line))
     return np.array(content, dtype=np.float32)


### PR DESCRIPTION
* Explicitly specify UTF-8 encoding in all `open()` calls
* Ignore warning `consider-using-f-string`, to avoid disruptive changes