### PR TITLE
When version mismatch happens, show versions

### DIFF
--- a/include/treelite/c_api_common.h
+++ b/include/treelite/c_api_common.h
@@ -46,6 +46,12 @@ TREELITE_DLL const char* TreeliteGetLastError(void);
 TREELITE_DLL int TreeliteRegisterLogCallback(void (*callback)(const char*));
 
 /*!
+ * \brief Get the version string for the Treelite library.
+ * \return version string, of form MAJOR.MINOR.PATCH
+ */
+TREELITE_DLL const char* TreeliteQueryTreeliteVersion(void);
+
+/*!
  * \defgroup dmatrix
  * Data matrix interface
  * \{

--- a/include/treelite/c_api_common.h
+++ b/include/treelite/c_api_common.h
@@ -51,6 +51,10 @@ TREELITE_DLL int TreeliteRegisterLogCallback(void (*callback)(const char*));
  */
 TREELITE_DLL const char* TreeliteQueryTreeliteVersion(void);
 
+extern "C" {
+  extern const char* TREELITE_VERSION;
+}
+
 /*!
  * \defgroup dmatrix
  * Data matrix interface

--- a/include/treelite/tree_impl.h
+++ b/include/treelite/tree_impl.h
@@ -840,7 +840,13 @@ Model::DeserializeTemplate(HeaderPrimitiveFieldHandlerFunc header_primitive_fiel
   header_primitive_field_handler(&minor_ver);
   header_primitive_field_handler(&patch_ver);
   if (major_ver != TREELITE_VER_MAJOR || minor_ver != TREELITE_VER_MINOR) {
-    throw std::runtime_error("Cannot deserialize model from a different version of Treelite");
+    std::ostringstream oss;
+    oss << "Cannot deserialize model from a different version of Treelite." << std::endl
+        << "Currently running Treelite version " << TREELITE_VER_MAJOR << "."
+        << TREELITE_VER_MINOR << "." << TREELITE_VER_PATCH << std::endl
+        << "The model checkpoint was generated from Treelite version " << major_ver << "."
+        << minor_ver << "." << patch_ver;
+    throw std::runtime_error(oss.str());
   }
   header_primitive_field_handler(&threshold_type);
   header_primitive_field_handler(&leaf_output_type);

--- a/src/c_api/c_api_error.cc
+++ b/src/c_api/c_api_error.cc
@@ -10,6 +10,10 @@
 #include <string>
 #include <sstream>
 
+// Stringify an integer macro constant
+#define STR_IMPL_(x) #x
+#define STR(x) STR_IMPL_(x)
+
 namespace {
 
 struct TreeliteAPIErrorEntry {
@@ -36,3 +40,6 @@ const char* TreeliteQueryTreeliteVersion() {
   version_str = oss.str();
   return version_str.c_str();
 }
+
+const char* TREELITE_VERSION = "TREELITE_VERSION_" STR(TREELITE_VER_MAJOR) "."
+    STR(TREELITE_VER_MINOR) "." STR(TREELITE_VER_PATCH);

--- a/src/c_api/c_api_error.cc
+++ b/src/c_api/c_api_error.cc
@@ -6,12 +6,15 @@
  */
 #include <treelite/thread_local.h>
 #include <treelite/c_api_error.h>
+#include <treelite/version.h>
 #include <string>
+#include <sstream>
 
 namespace {
 
 struct TreeliteAPIErrorEntry {
   std::string last_error;
+  std::string version_str;
 };
 
 using TreeliteAPIErrorStore = treelite::ThreadLocalStore<TreeliteAPIErrorEntry>;
@@ -24,4 +27,12 @@ const char* TreeliteGetLastError() {
 
 void TreeliteAPISetLastError(const char* msg) {
   TreeliteAPIErrorStore::Get()->last_error = msg;
+}
+
+const char* TreeliteQueryTreeliteVersion() {
+  std::ostringstream oss;
+  oss << TREELITE_VER_MAJOR << "." << TREELITE_VER_MINOR << "." <<  TREELITE_VER_PATCH;
+  std::string& version_str = TreeliteAPIErrorStore::Get()->version_str;
+  version_str = oss.str();
+  return version_str.c_str();
 }


### PR DESCRIPTION
Before:
```
Cannot deserialize model from a different version of Treelite
```

After:
```
Cannot deserialize model from a different version of Treelite.
Currently running Treelite version X.X.X
The model checkpoint was generated from Treelite version X.X.X
```

Also, add the C API function `TreeliteQueryTreeliteVersion` so that users can query the version of the Treelite library.