### PR TITLE
Fix `IsolationForest` with `max_samples="auto"`

### DIFF
--- a/python/treelite/sklearn/importer.py
+++ b/python/treelite/sklearn/importer.py
@@ -132,7 +132,7 @@ def import_model(sklearn_model):
         raise TreeliteError("Gradient boosted trees must be trained with the option init='zero'")
 
     if isinstance(sklearn_model, IsolationForest):
-        ratio_c = expected_depth(sklearn_model.max_samples)
+        ratio_c = expected_depth(sklearn_model.max_samples_)
 
     node_count = []
     children_left = ArrayOfArrays(dtype=np.int64)


### PR DESCRIPTION
Fixes #322 

Currently, importing an `IsolationForest` model from scikit-learn will fail if the default `max_samples` is set to `"auto"`. This PR fixes it to take the actual `max_samples` that ends up used when passing `"auto"`.