### PR TITLE
Add weighted_n_node_samples field in sklearn importer

### DIFF
--- a/include/treelite/c_api.h
+++ b/include/treelite/c_api.h
@@ -181,6 +181,8 @@ TREELITE_DLL int TreeliteLoadXGBoostModelFromMemoryBuffer(const void* buf,
  *              if node k is a leaf node.
  * \param n_node_samples n_node_samples[i][k] stores the number of data samples associated with
  *                       node k of the i-th tree.
+ * \param weighted_n_node_samples weighted_n_node_samples[i][k] stores the sum of weighted data
+ *                                samples associated with node k of the i-th tree.
  * \param impurity impurity[i][k] stores the impurity measure (gini, entropy etc) associated with
  *                 node k of the i-th tree.
  * \param out pointer to store the loaded model
@@ -189,8 +191,8 @@ TREELITE_DLL int TreeliteLoadXGBoostModelFromMemoryBuffer(const void* buf,
 TREELITE_DLL int TreeliteLoadSKLearnRandomForestRegressor(
     int n_estimators, int n_features, const int64_t* node_count, const int64_t** children_left,
     const int64_t** children_right, const int64_t** feature, const double** threshold,
-    const double** value, const int64_t** n_node_samples, const double** impurity,
-    ModelHandle* out);
+    const double** value, const int64_t** n_node_samples, const double** weighted_n_node_samples,
+    const double** impurity, ModelHandle* out);
 
 /*!
  * \brief Load a scikit-learn isolation forest model from a collection of arrays. Refer to
@@ -211,6 +213,8 @@ TREELITE_DLL int TreeliteLoadSKLearnRandomForestRegressor(
  *              only defined if node k is a leaf node.
  * \param n_node_samples n_node_samples[i][k] stores the number of data samples associated with
  *                       node k of the i-th tree.
+ * \param weighted_n_node_samples weighted_n_node_samples[i][k] stores the sum of weighted data
+ *                                samples associated with node k of the i-th tree.
  * \param impurity not used, but must be passed as array of arrays for each tree and node.
  * \param ratio_c standardizing constant to use for calculation of the anomaly score.
  * \param out pointer to store the loaded model
@@ -219,8 +223,8 @@ TREELITE_DLL int TreeliteLoadSKLearnRandomForestRegressor(
 TREELITE_DLL int TreeliteLoadSKLearnIsolationForest(
     int n_estimators, int n_features, const int64_t* node_count, const int64_t** children_left,
     const int64_t** children_right, const int64_t** feature, const double** threshold,
-    const double** value, const int64_t** n_node_samples, const double** impurity,
-    const double ratio_c, ModelHandle* out);
+    const double** value, const int64_t** n_node_samples, const double** weighted_n_node_samples,
+    const double** impurity, const double ratio_c, ModelHandle* out);
 
 /*!
  * \brief Load a scikit-learn random forest classifier model from a collection of arrays. Refer to
@@ -243,6 +247,8 @@ TREELITE_DLL int TreeliteLoadSKLearnIsolationForest(
  *              if node k is a leaf node.
  * \param n_node_samples n_node_samples[i][k] stores the number of data samples associated with
  *                       node k of the i-th tree.
+ * \param weighted_n_node_samples weighted_n_node_samples[i][k] stores the sum of weighted data
+ *                                samples associated with node k of the i-th tree.
  * \param impurity impurity[i][k] stores the impurity measure (gini, entropy etc) associated with
  *                 node k of the i-th tree.
  * \param out pointer to store the loaded model
@@ -252,7 +258,7 @@ TREELITE_DLL int TreeliteLoadSKLearnRandomForestClassifier(
     int n_estimators, int n_features, int n_classes, const int64_t* node_count,
     const int64_t** children_left, const int64_t** children_right, const int64_t** feature,
     const double** threshold, const double** value, const int64_t** n_node_samples,
-    const double** impurity, ModelHandle* out);
+    const double** weighted_n_node_samples, const double** impurity, ModelHandle* out);
 
 /*!
  * \brief Load a scikit-learn gradient boosting regressor model from a collection of arrays. Refer
@@ -273,6 +279,8 @@ TREELITE_DLL int TreeliteLoadSKLearnRandomForestClassifier(
  *              if node k is a leaf node.
  * \param n_node_samples n_node_samples[i][k] stores the number of data samples associated with
  *                       node k of the i-th tree.
+ * \param weighted_n_node_samples weighted_n_node_samples[i][k] stores the sum of weighted data
+ *                                samples associated with node k of the i-th tree.
  * \param impurity impurity[i][k] stores the impurity measure (gini, entropy etc) associated with
  *                 node k of the i-th tree.
  * \param out pointer to store the loaded model
@@ -281,8 +289,8 @@ TREELITE_DLL int TreeliteLoadSKLearnRandomForestClassifier(
 TREELITE_DLL int TreeliteLoadSKLearnGradientBoostingRegressor(
     int n_estimators, int n_features, const int64_t* node_count, const int64_t** children_left,
     const int64_t** children_right, const int64_t** feature, const double** threshold,
-    const double** value, const int64_t** n_node_samples, const double** impurity,
-    ModelHandle* out);
+    const double** value, const int64_t** n_node_samples, const double** weighted_n_node_samples,
+    const double** impurity, ModelHandle* out);
 
 /*!
  * \brief Load a scikit-learn gradient boosting classifier model from a collection of arrays. Refer
@@ -304,6 +312,8 @@ TREELITE_DLL int TreeliteLoadSKLearnGradientBoostingRegressor(
  *              if node k is a leaf node.
  * \param n_node_samples n_node_samples[i][k] stores the number of data samples associated with
  *                       node k of the i-th tree.
+ * \param weighted_n_node_samples weighted_n_node_samples[i][k] stores the sum of weighted data
+ *                                samples associated with node k of the i-th tree.
  * \param impurity impurity[i][k] stores the impurity measure (gini, entropy etc) associated with
  *                 node k of the i-th tree.
  * \param out pointer to store the loaded model
@@ -313,7 +323,7 @@ TREELITE_DLL int TreeliteLoadSKLearnGradientBoostingClassifier(
     int n_estimators, int n_features, int n_classes, const int64_t* node_count,
     const int64_t** children_left, const int64_t** children_right, const int64_t** feature,
     const double** threshold, const double** value, const int64_t** n_node_samples,
-    const double** impurity, ModelHandle* out);
+    const double** weighted_n_node_samples, const double** impurity, ModelHandle* out);
 
 /*!
  * \brief Query the number of trees in the model

--- a/include/treelite/frontend.h
+++ b/include/treelite/frontend.h
@@ -77,6 +77,8 @@ std::unique_ptr<treelite::Model> LoadXGBoostJSONModelString(const char* json_str
  *              if node k is a leaf node.
  * \param n_node_samples n_node_samples[i][k] stores the number of data samples associated with
  *                       node k of the i-th tree.
+ * \param weighted_n_node_samples weighted_n_node_samples[i][k] stores the sum of weighted data
+ *                                samples associated with node k of the i-th tree.
  * \param impurity impurity[i][k] stores the impurity measure (gini, entropy etc) associated with
  *                 node k of the i-th tree.
  * \return loaded model
@@ -84,7 +86,8 @@ std::unique_ptr<treelite::Model> LoadXGBoostJSONModelString(const char* json_str
 std::unique_ptr<treelite::Model> LoadSKLearnRandomForestRegressor(
     int n_estimators, int n_features, const int64_t* node_count, const int64_t** children_left,
     const int64_t** children_right, const int64_t** feature, const double** threshold,
-    const double** value, const int64_t** n_node_samples, const double** impurity);
+    const double** value, const int64_t** n_node_samples, const double** weighted_n_node_samples,
+    const double** impurity);
 /*!
  * \brief Load a scikit-learn isolation forest model from a collection of arrays. Refer to
  *        https://scikit-learn.org/stable/auto_examples/tree/plot_unveil_tree_structure.html to
@@ -104,6 +107,8 @@ std::unique_ptr<treelite::Model> LoadSKLearnRandomForestRegressor(
  *              only defined if node k is a leaf node.
  * \param n_node_samples n_node_samples[i][k] stores the number of data samples associated with
  *                       node k of the i-th tree.
+ * \param weighted_n_node_samples weighted_n_node_samples[i][k] stores the sum of weighted data
+ *                                samples associated with node k of the i-th tree.
  * \param impurity not used, but must be passed as array of arrays for each tree and node.
  * \param ratio_c standardizing constant to use for calculation of the anomaly score.
  * \return loaded model
@@ -111,8 +116,8 @@ std::unique_ptr<treelite::Model> LoadSKLearnRandomForestRegressor(
 std::unique_ptr<treelite::Model> LoadSKLearnIsolationForest(
     int n_estimators, int n_features, const int64_t* node_count, const int64_t** children_left,
     const int64_t** children_right, const int64_t** feature, const double** threshold,
-    const double** value, const int64_t** n_node_samples, const double** impurity,
-    const double ratio_c);
+    const double** value, const int64_t** n_node_samples, const double** weighted_n_node_samples,
+    const double** impurity, const double ratio_c);
 /*!
  * \brief Load a scikit-learn random forest classifier model from a collection of arrays. Refer to
  *        https://scikit-learn.org/stable/auto_examples/tree/plot_unveil_tree_structure.html to
@@ -134,6 +139,8 @@ std::unique_ptr<treelite::Model> LoadSKLearnIsolationForest(
  *              if node k is a leaf node.
  * \param n_node_samples n_node_samples[i][k] stores the number of data samples associated with
  *                       node k of the i-th tree.
+ * \param weighted_n_node_samples weighted_n_node_samples[i][k] stores the sum of weighted data
+ *                                samples associated with node k of the i-th tree.
  * \param impurity impurity[i][k] stores the impurity measure (gini, entropy etc) associated with
  *                 node k of the i-th tree.
  * \return loaded model
@@ -142,7 +149,7 @@ std::unique_ptr<treelite::Model> LoadSKLearnRandomForestClassifier(
     int n_estimators, int n_features, int n_classes, const int64_t* node_count,
     const int64_t** children_left, const int64_t** children_right, const int64_t** feature,
     const double** threshold, const double** value, const int64_t** n_node_samples,
-    const double** impurity);
+    const double** weighted_n_node_samples, const double** impurity);
 /*!
  * \brief Load a scikit-learn gradient boosting regressor model from a collection of arrays. Refer
  *        to https://scikit-learn.org/stable/auto_examples/tree/plot_unveil_tree_structure.html to
@@ -162,6 +169,8 @@ std::unique_ptr<treelite::Model> LoadSKLearnRandomForestClassifier(
  *              if node k is a leaf node.
  * \param n_node_samples n_node_samples[i][k] stores the number of data samples associated with
  *                       node k of the i-th tree.
+ * \param weighted_n_node_samples weighted_n_node_samples[i][k] stores the sum of weighted data
+ *                                samples associated with node k of the i-th tree.
  * \param impurity impurity[i][k] stores the impurity measure (gini, entropy etc) associated with
  *                 node k of the i-th tree.
  * \return loaded model
@@ -169,7 +178,8 @@ std::unique_ptr<treelite::Model> LoadSKLearnRandomForestClassifier(
 std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingRegressor(
     int n_estimators, int n_features, const int64_t* node_count, const int64_t** children_left,
     const int64_t** children_right, const int64_t** feature, const double** threshold,
-    const double** value, const int64_t** n_node_samples, const double** impurity);
+    const double** value, const int64_t** n_node_samples, const double** weighted_n_node_samples,
+    const double** impurity);
 /*!
  * \brief Load a scikit-learn gradient boosting classifier model from a collection of arrays. Refer
  *        to https://scikit-learn.org/stable/auto_examples/tree/plot_unveil_tree_structure.html to
@@ -190,6 +200,8 @@ std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingRegressor(
  *              if node k is a leaf node.
  * \param n_node_samples n_node_samples[i][k] stores the number of data samples associated with
  *                       node k of the i-th tree.
+ * \param weighted_n_node_samples weighted_n_node_samples[i][k] stores the sum of weighted data
+ *                                samples associated with node k of the i-th tree.
  * \param impurity impurity[i][k] stores the impurity measure (gini, entropy etc) associated with
  *                 node k of the i-th tree.
  * \return loaded model
@@ -198,7 +210,7 @@ std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingClassifier(
     int n_estimators, int n_features, int n_classes, const int64_t* node_count,
     const int64_t** children_left, const int64_t** children_right, const int64_t** feature,
     const double** threshold, const double** value, const int64_t** n_node_samples,
-    const double** impurity);
+    const double** weighted_n_node_samples, const double** impurity);
 
 //--------------------------------------------------------------------------
 // model builder interface: build trees incrementally

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -151,12 +151,12 @@ int TreeliteLoadXGBoostModelFromMemoryBuffer(const void* buf, size_t len, ModelH
 int TreeliteLoadSKLearnRandomForestRegressor(
     int n_estimators, int n_features, const int64_t* node_count, const int64_t** children_left,
     const int64_t** children_right, const int64_t** feature, const double** threshold,
-    const double** value, const int64_t** n_node_samples, const double** impurity,
-    ModelHandle* out) {
+    const double** value, const int64_t** n_node_samples, const double** weighted_n_node_samples,
+    const double** impurity, ModelHandle* out) {
   API_BEGIN();
   std::unique_ptr<Model> model = frontend::LoadSKLearnRandomForestRegressor(
       n_estimators, n_features, node_count, children_left, children_right, feature, threshold,
-      value, n_node_samples, impurity);
+      value, n_node_samples, weighted_n_node_samples, impurity);
   *out = static_cast<ModelHandle>(model.release());
   API_END();
 }
@@ -164,12 +164,12 @@ int TreeliteLoadSKLearnRandomForestRegressor(
 int TreeliteLoadSKLearnIsolationForest(
     int n_estimators, int n_features, const int64_t* node_count, const int64_t** children_left,
     const int64_t** children_right, const int64_t** feature, const double** threshold,
-    const double** value, const int64_t** n_node_samples, const double** impurity,
-    const double ratio_c, ModelHandle* out) {
+    const double** value, const int64_t** n_node_samples, const double** weighted_n_node_samples,
+    const double** impurity, const double ratio_c, ModelHandle* out) {
   API_BEGIN();
   std::unique_ptr<Model> model = frontend::LoadSKLearnIsolationForest(
       n_estimators, n_features, node_count, children_left, children_right, feature, threshold,
-      value, n_node_samples, impurity, ratio_c);
+      value, n_node_samples, weighted_n_node_samples, impurity, ratio_c);
   *out = static_cast<ModelHandle>(model.release());
   API_END();
 }
@@ -178,11 +178,11 @@ int TreeliteLoadSKLearnRandomForestClassifier(
     int n_estimators, int n_features, int n_classes, const int64_t* node_count,
     const int64_t** children_left, const int64_t** children_right, const int64_t** feature,
     const double** threshold, const double** value, const int64_t** n_node_samples,
-    const double** impurity, ModelHandle* out) {
+    const double** weighted_n_node_samples, const double** impurity, ModelHandle* out) {
   API_BEGIN();
   std::unique_ptr<Model> model = frontend::LoadSKLearnRandomForestClassifier(
       n_estimators, n_features, n_classes, node_count, children_left, children_right, feature,
-      threshold, value, n_node_samples, impurity);
+      threshold, value, n_node_samples, weighted_n_node_samples, impurity);
   *out = static_cast<ModelHandle>(model.release());
   API_END();
 }
@@ -190,12 +190,12 @@ int TreeliteLoadSKLearnRandomForestClassifier(
 int TreeliteLoadSKLearnGradientBoostingRegressor(
     int n_estimators, int n_features, const int64_t* node_count, const int64_t** children_left,
     const int64_t** children_right, const int64_t** feature, const double** threshold,
-    const double** value, const int64_t** n_node_samples, const double** impurity,
-    ModelHandle* out) {
+    const double** value, const int64_t** n_node_samples, const double** weighted_n_node_samples,
+    const double** impurity, ModelHandle* out) {
   API_BEGIN();
   std::unique_ptr<Model> model = frontend::LoadSKLearnGradientBoostingRegressor(
       n_estimators, n_features, node_count, children_left, children_right, feature, threshold,
-      value, n_node_samples, impurity);
+      value, n_node_samples, weighted_n_node_samples, impurity);
   *out = static_cast<ModelHandle>(model.release());
   API_END();
 }
@@ -204,11 +204,11 @@ int TreeliteLoadSKLearnGradientBoostingClassifier(
     int n_estimators, int n_features, int n_classes, const int64_t* node_count,
     const int64_t** children_left, const int64_t** children_right, const int64_t** feature,
     const double** threshold, const double** value, const int64_t** n_node_samples,
-    const double** impurity, ModelHandle* out) {
+    const double** weighted_n_node_samples, const double** impurity, ModelHandle* out) {
   API_BEGIN();
   std::unique_ptr<Model> model = frontend::LoadSKLearnGradientBoostingClassifier(
       n_estimators, n_features, n_classes, node_count, children_left, children_right, feature,
-      threshold, value, n_node_samples, impurity);
+      threshold, value, n_node_samples, weighted_n_node_samples, impurity);
   *out = static_cast<ModelHandle>(model.release());
   API_END();
 }


### PR DESCRIPTION
Scikit-learn tree models has two fields for sample counts in nodes: `n_node_samples` (unweighted count, int64) and `weighted_n_node_samples` (weighted count, float64). So far, Treelite kept only the unweighted count and discarded the weighted count.

This PR stores `weighted_n_node_samples` in the Treelite object, using the `sum_hess` field.

Required by rapidsai/cuml#4447