### PR TITLE
Fix from_xgboost() for models with categorical splits

### DIFF
--- a/python/.pylintrc
+++ b/python/.pylintrc
@@ -23,3 +23,6 @@ variable-rgx=[a-zA-Z_][a-z0-9_]{0,30}$
 [TYPECHECK]
 generated-members=np.float32,np.uintc,np.uintp,np.uint32
 
+[MESSAGES CONTROL]
+# globally disable pylint checks (comma separated)
+disable=fixme

--- a/python/treelite/frontend.py
+++ b/python/treelite/frontend.py
@@ -370,7 +370,6 @@ class Model:
            bst = xgboost.train(params, dtrain, 10, [(dtrain, 'train')])
            tl_model = Model.from_xgboost(bst)
         """
-        handle = ctypes.c_void_p()
         # attempt to import xgboost
         try:
             import xgboost

--- a/python/treelite/frontend.py
+++ b/python/treelite/frontend.py
@@ -379,14 +379,10 @@ class Model:
                                 '`xgboost.Booster` object') from e
         if not isinstance(booster, xgboost.Booster):
             raise ValueError('booster must be of type `xgboost.Booster`')
-        buffer = booster.save_raw()
-        ptr = (ctypes.c_char * len(buffer)).from_buffer(buffer)
-        length = ctypes.c_size_t(len(buffer))
-        _check_call(_LIB.TreeliteLoadXGBoostModelFromMemoryBuffer(
-            ptr,
-            length,
-            ctypes.byref(handle)))
-        return Model(handle)
+        # TODO(hcho3): Remove this line once XGBoost implements a method to save JSON model
+        # in-memory. (Right now, save_model() always saves to the disk.)
+        model_json_str = booster.__getstate__()['handle'].decode('utf-8')
+        return cls.from_xgboost_json(model_json_str)
 
     @classmethod
     def from_xgboost_json(cls, json_str):

--- a/src/frontend/xgboost/xgboost_json.h
+++ b/src/frontend/xgboost/xgboost_json.h
@@ -303,6 +303,7 @@ class LearnerParamHandler : public OutputHandler<treelite::ModelImpl<float, floa
 
 struct XGBoostModelHandle {
   treelite::ModelImpl<float, float>* model;
+  std::vector<unsigned> version;
   std::string objective_name;
 };
 
@@ -318,6 +319,14 @@ class LearnerHandler : public OutputHandler<XGBoostModelHandle> {
   std::string objective;
 };
 
+/*! \brief handler for XGBoost checkpoint */
+class XGBoostCheckpointHandler : public OutputHandler<XGBoostModelHandle> {
+ public:
+  using OutputHandler<XGBoostModelHandle>::OutputHandler;
+  bool StartArray() override;
+  bool StartObject() override;
+};
+
 /*! \brief handler for XGBoostModel objects from XGBoost schema */
 class XGBoostModelHandler : public OutputHandler<XGBoostModelHandle> {
  public:
@@ -325,9 +334,6 @@ class XGBoostModelHandler : public OutputHandler<XGBoostModelHandle> {
   bool StartArray() override;
   bool StartObject() override;
   bool EndObject(std::size_t memberCount) override;
-
- private:
-  std::vector<unsigned> version;
 };
 
 /*! \brief handler for root object of XGBoost schema*/

--- a/src/frontend/xgboost_json.cc
+++ b/src/frontend/xgboost_json.cc
@@ -391,6 +391,14 @@ bool ObjectiveHandler::String(const char *str, std::size_t length, bool) {
 bool LearnerParamHandler::String(const char *str,
                                  std::size_t,
                                  bool) {
+  int num_target = 1;
+  if (assign_value("num_target", std::atoi(str), num_target)) {
+    if (num_target != 1) {
+      TREELITE_LOG(ERROR) << "num_target must be 1; Treelite doesn't support multi-target regressor yet";
+      return false;
+    }
+    return true;
+  }
   return (assign_value("base_score", strtof(str, nullptr),
                        output.param.global_bias) ||
           assign_value("num_class", static_cast<unsigned int>(std::max(std::atoi(str), 1)),

--- a/src/frontend/xgboost_json.cc
+++ b/src/frontend/xgboost_json.cc
@@ -394,7 +394,8 @@ bool LearnerParamHandler::String(const char *str,
   int num_target = 1;
   if (assign_value("num_target", std::atoi(str), num_target)) {
     if (num_target != 1) {
-      TREELITE_LOG(ERROR) << "num_target must be 1; Treelite doesn't support multi-target regressor yet";
+      TREELITE_LOG(ERROR)
+        << "num_target must be 1; Treelite doesn't support multi-target regressor yet";
       return false;
     }
     return true;

--- a/tests/cpp/test_frontend.cc
+++ b/tests/cpp/test_frontend.cc
@@ -465,7 +465,7 @@ TEST(XGBoostModelHandlerSuite, XGBoostModelHandler) {
     std::make_shared<MockDelegator>();
 
   ModelImpl<float, float> output_model;
-  details::XGBoostModelHandle output{&output_model, ""};
+  details::XGBoostModelHandle output{&output_model, {}, ""};
   details::XGBoostModelHandler wrapped_handler{delegator, output};
   MockObjectStarter handler{delegator, wrapped_handler};
 


### PR DESCRIPTION
Currently, `from_xgboost()` doesn't work if the XGBoost model contains one or more categorical splits. The reason is that the method calls the `save_raw()` method in XGBoost, which uses a legacy serialization method that doesn't support categorical splits.

For `from_xgboost()` to work properly, it needs to access the JSON string serialization of the XGBoost model. Unfortunately, `save_model()` in XGBoost always saves to the disk, and XGBoost doesn't yet have a method to directly serialize the model object as a JSON string in-memory.

As a workaround, `from_xgboost()` calls the internal `__getstate__` method to serialize the model into a JSON string. The `__getstate__` method returns a JSON string of form
```
{
    "Config": { ... }
    "Model": { ... }
}
```
where we need to extract the model object using the `Model` key.

@trivialfis Would you be able to review this? I implemented the workaround since another release of XGBoost isn't yet in the horizon, and this feature is necessary to enable categorical support in cuML TreeExplainer.