### PR TITLE
Add a test to prepare for integer `default_left`

### DIFF
--- a/src/frontend/xgboost/xgboost_json.h
+++ b/src/frontend/xgboost/xgboost_json.h
@@ -349,14 +349,18 @@ class RootHandler : public OutputHandler<std::unique_ptr<treelite::Model>> {
 class DelegatedHandler
     : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, DelegatedHandler>,
       public Delegator {
-
  public:
-  /*! \brief create DelegatedHandler with initial RootHandler on stack */
-  static std::shared_ptr<DelegatedHandler> create() {
+  /*! \brief create DelegatedHandler with empty stack */
+  static std::shared_ptr<DelegatedHandler> create_empty() {
     struct make_shared_enabler : public DelegatedHandler {};
-
     std::shared_ptr<DelegatedHandler> new_handler =
       std::make_shared<make_shared_enabler>();
+    return new_handler;
+  }
+
+  /*! \brief create DelegatedHandler with initial RootHandler on stack */
+  static std::shared_ptr<DelegatedHandler> create() {
+    std::shared_ptr<DelegatedHandler> new_handler = create_empty();
     new_handler->push_delegate(std::make_shared<RootHandler>(
       new_handler,
       new_handler->result));


### PR DESCRIPTION
Respond to dmlc/xgboost#7556, which changes the type of `default_left` field in XGBoost models to integer array (the field used to be a boolean array).

It turns out that we don't need to change the parser at all. This PR simply adds a unit test.

cc @trivialfis 