### PR TITLE
Fix PyBuffer serializer

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,13 +98,16 @@ jobs:
       ninja
     displayName: 'Building Treelite...'
   - script: |
-      python -m pip install --upgrade pip numpy scipy pandas pytest pytest-cov scikit-learn lightgbm
+      python -m pip install --upgrade pip numpy scipy pandas pytest pytest-cov scikit-learn lightgbm cython
       python -m pip install --pre xgboost
+      cd tests/cython
+      python setup.py build_ext --inplace
+      cd ../..
     displayName: 'Setting up Python environment...'
   - script: ./build/treelite_cpp_test
     displayName: 'Running C++ integration tests...'
   - script:
-      python -m pytest --cov=treelite --cov=treelite_runtime -v --fulltrace tests/python
+      python -m pytest --cov=treelite --cov=treelite_runtime -v --fulltrace tests/python tests/cython
     displayName: 'Running Python integration tests...'
     env:
       PYTHONPATH: ./python:./runtime/python

--- a/include/treelite/tree_impl.h
+++ b/include/treelite/tree_impl.h
@@ -866,7 +866,7 @@ ModelImpl<ThresholdType, LeafOutputType>::SerializeTemplate(
   header_primitive_field_handler(&average_tree_output);
   header_composite_field_handler(&task_param, "T{=B=?xx=I=I}");
   header_composite_field_handler(
-      &param, "T{" _TREELITE_STR(TREELITE_MAX_PRED_TRANSFORM_LENGTH) "s=f=f}");
+      &param, "T{" _TREELITE_STR(TREELITE_MAX_PRED_TRANSFORM_LENGTH) "s=f=f=f}");
 
   /* Body */
   for (Tree<ThresholdType, LeafOutputType>& tree : trees) {

--- a/tests/cython/serializer.pyx
+++ b/tests/cython/serializer.pyx
@@ -1,0 +1,131 @@
+# distutils: language = c++
+# cython: embedsignature = True
+# cython: language_level = 3
+"""Utilities to (de)serialize Treelite objects via Python protocol"""
+
+from libcpp.vector cimport vector
+from cython.operator cimport dereference as deref, preincrement as inc
+from cpython.object cimport PyObject
+from libcpp.memory cimport unique_ptr
+from libc.stdint cimport uintptr_t
+from typing import Tuple, Dict, List, Union
+import ctypes
+import treelite
+import numpy as np
+
+
+cdef extern from "treelite/c_api.h":
+    ctypedef void* ModelHandle
+
+
+cdef extern from "treelite/tree.h" namespace "treelite":
+    cdef struct PyBufferFrame:
+        void* buf
+        char* format
+        size_t itemsize
+        size_t nitem
+    cdef cppclass Model:
+        vector[PyBufferFrame] GetPyBuffer() except +
+        @staticmethod
+        unique_ptr[Model] CreateFromPyBuffer(vector[PyBufferFrame]) except +
+
+
+cdef extern from "Python.h":
+    Py_buffer* PyMemoryView_GET_BUFFER(PyObject* mview)
+
+
+cdef class PyBufferFrameWrapper:
+    cdef PyBufferFrame _handle
+    cdef Py_ssize_t shape[1]
+    cdef Py_ssize_t strides[1]
+
+    def __cinit__(self):
+        pass
+
+    def __dealloc__(self):
+        pass
+
+    def __getbuffer__(self, Py_buffer* buffer, int flags):
+        cdef Py_ssize_t itemsize = self._handle.itemsize
+
+        self.shape[0] = self._handle.nitem
+        self.strides[0] = itemsize
+
+        buffer.buf = self._handle.buf
+        buffer.format = self._handle.format
+        buffer.internal = NULL
+        buffer.itemsize = itemsize
+        buffer.len = self._handle.nitem * itemsize
+        buffer.ndim = 1
+        buffer.obj = self
+        buffer.readonly = 0
+        buffer.shape = self.shape
+        buffer.strides = self.strides
+        buffer.suboffsets = NULL
+
+    def __releasebuffer__(self, Py_buffer *buffer):
+        pass
+
+
+cdef PyBufferFrameWrapper MakePyBufferFrameWrapper(PyBufferFrame handle):
+    cdef PyBufferFrameWrapper wrapper = PyBufferFrameWrapper()
+    wrapper._handle = handle
+    return wrapper
+
+
+cdef list _get_frames(ModelHandle model):
+    return [memoryview(MakePyBufferFrameWrapper(v))
+            for v in (<Model*>model).GetPyBuffer()]
+
+
+cdef ModelHandle _init_from_frames(vector[PyBufferFrame] frames) except *:
+    return <ModelHandle>Model.CreateFromPyBuffer(frames).release()
+
+
+def get_frames(model: uintptr_t) -> List[memoryview]:
+    return _get_frames(<ModelHandle> model)
+
+
+def init_from_frames(frames: List[np.ndarray],
+                     format_str: List[str], itemsize: List[int]) -> uintptr_t:
+    cdef vector[PyBufferFrame] cpp_frames
+    cdef Py_buffer* buf
+    cdef PyBufferFrame cpp_frame
+    format_bytes = [s.encode('utf-8') for s in format_str]
+    for i, frame in enumerate(frames):
+        x = memoryview(frame)
+        buf = PyMemoryView_GET_BUFFER(<PyObject*>x)
+        cpp_frame.buf = buf.buf
+        cpp_frame.format = format_bytes[i]
+        cpp_frame.itemsize = itemsize[i]
+        cpp_frame.nitem = buf.len // itemsize[i]
+        cpp_frames.push_back(cpp_frame)
+    return <uintptr_t> _init_from_frames(cpp_frames)
+
+
+def _treelite_serialize(
+    model: uintptr_t
+) -> Dict[str, Union[List[str], List[np.ndarray]]]:
+    frames = get_frames(model)
+    header = {'format_str': [x.format for x in frames],
+              'itemsize': [x.itemsize for x in frames]}
+    return {'header': header, 'frames': [np.asarray(x) for x in frames]}
+
+
+def treelite_serialize(
+    model: treelite.Model
+) -> Dict[str, Union[List[str], List[np.ndarray]]]:
+    return _treelite_serialize(model.handle.value)
+
+
+def _treelite_deserialize(
+    payload: Dict[str, Union[List[str], List[bytes]]]
+) -> uintptr_t:
+    header, frames = payload['header'], payload['frames']
+    return init_from_frames(frames, header['format_str'], header['itemsize'])
+
+
+def treelite_deserialize(
+    payload: Dict[str, Union[List[str], List[bytes]]]
+) -> treelite.Model:
+    return treelite.Model(handle=ctypes.c_void_p(_treelite_deserialize(payload)))

--- a/tests/cython/setup.py
+++ b/tests/cython/setup.py
@@ -1,0 +1,27 @@
+import os
+from distutils.sysconfig import get_python_lib
+from setuptools import setup, find_packages
+from setuptools.extension import Extension
+from Cython.Distutils.build_ext import new_build_ext as build_ext
+
+extensions = [
+    Extension('*',
+              sources=['*.pyx'],
+              include_dirs=['../../include', '../../build/include'],
+              library_dirs=[get_python_lib(), '../../build/'],
+              #runtime_library_dirs=[os.path.join(os.sys.prefix, 'lib')],
+              libraries=['treelite'],
+              language='c++',
+              extra_compile_args=['--std=c++14'])
+]
+
+setup(
+    name='cython_test',
+    version='0.0.1',
+    setup_requires=['cython'],
+    ext_modules=extensions,
+    packages=find_packages(),
+    install_requires=['cython'],
+    cmdclass={'build_ext': build_ext},
+    zip_safe=False
+)

--- a/tests/cython/test_serialization.py
+++ b/tests/cython/test_serialization.py
@@ -15,6 +15,3 @@ def test_serialize_as_buffer():
     # This call should succeed
     tl_model2 = treelite_deserialize(frames)
     # This call should succeed too
-
-if __name__ == '__main__':
-    test_serialize_as_buffer()

--- a/tests/cython/test_serialization.py
+++ b/tests/cython/test_serialization.py
@@ -1,0 +1,20 @@
+"""Test for serialization, via buffer protocol"""
+import treelite
+from sklearn.datasets import load_iris
+from sklearn.ensemble import RandomForestClassifier
+from serializer import treelite_serialize, treelite_deserialize
+
+def test_serialize_as_buffer():
+    """Test whether Treelite objects can be serialized to a buffer"""
+    X, y = load_iris(return_X_y=True)
+    clf = RandomForestClassifier(max_depth=3, random_state=0, n_estimators=10)
+    clf.fit(X, y)
+
+    tl_model = treelite.sklearn.import_model(clf)
+    frames = treelite_serialize(tl_model)
+    # This call should succeed
+    tl_model2 = treelite_deserialize(frames)
+    # This call should succeed too
+
+if __name__ == '__main__':
+    test_serialize_as_buffer()


### PR DESCRIPTION
#322 silently broke the Protocol Buffer serializer (`GetPyBuffer()`). This PR fixes the serializer and also adds a testing coverage.

Error when calling `GetPyBuffer()`:
```
>       return array(a, dtype, copy=False, order=order)
E       RuntimeError: Item size 268 for PEP 3118 buffer format string T{256s=f=f} does not match the dtype V item size 264.
```
which means that the format string was incorrect. #322 added a new field to `ModelParam` but did not update the corresponding format string.