### PR TITLE
[CI] Build and package Treelite with OpenMP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,14 @@ jobs:
     - os: osx
       env: TASK=python_coverage_test
       osx_image: xcode10.2
+    # Build Python wheels for MacOS Intel and Apple Silicon
+    # pypa/cibuildwheel is used, hence CIBW prefix
+    - os: osx
+      env: TASK=python_wheels CIBW_PLATFORM_ID=macosx_x86_64
+      osx_image: xcode12.5
+    - os: osx
+      env: TASK=python_wheels CIBW_PLATFORM_ID=macosx_arm64
+      osx_image: xcode12.5
 
 # dependent brew packages
 addons:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ if(MSVC)
 endif()
 
 option(TEST_COVERAGE "C++ test coverage" OFF)
+option(USE_OPENMP "Use OpenMP" ON)
 option(BUILD_CPP_TEST "Build C++ tests" OFF)
 option(BUILD_STATIC_LIBS "Build static libs, in addition to dynamic libs" OFF)
 option(DETECT_CONDA_ENV "Enable detection of conda environment for dependencies" ON)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,9 +26,10 @@ jobs:
   - script: |
       TAG=manylinux2014_x86_64
       tests/ci_build/ci_build.sh cpu bash -c "cd python/ && python setup.py bdist_wheel --universal"
-      tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py python/dist/*.whl $(Build.SourceVersion) ${TAG}
       tests/ci_build/ci_build.sh auditwheel_x86_64 auditwheel repair --only-plat --plat ${TAG} python/dist/*.whl
+      rm -v python/dist/*.whl
       mv -v wheelhouse/*.whl python/dist/
+      tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py python/dist/*.whl $(Build.SourceVersion) ${TAG}
     displayName: 'Packaging Python wheel for Treelite...'
   - task: PublishPipelineArtifact@0
     inputs:
@@ -37,9 +38,10 @@ jobs:
   - script: |
       TAG=manylinux2014_x86_64
       tests/ci_build/ci_build.sh cpu bash -c "cd runtime/python/ && python setup.py bdist_wheel --universal"
-      tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py runtime/python/dist/*.whl $(Build.SourceVersion) ${TAG}
       tests/ci_build/ci_build.sh auditwheel_x86_64 auditwheel repair --only-plat --plat ${TAG} runtime/python/dist/*.whl
+      rm -v runtime/python/dist/*.whl
       mv -v wheelhouse/*.whl runtime/python/dist/
+      tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py runtime/python/dist/*.whl $(Build.SourceVersion) ${TAG}
     displayName: 'Packaging Python wheel for Treelite runtime...'
   - task: PublishPipelineArtifact@1
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,8 +27,7 @@ jobs:
       TAG=manylinux2014_x86_64
       tests/ci_build/ci_build.sh cpu bash -c "cd python/ && python setup.py bdist_wheel --universal"
       tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py python/dist/*.whl $(Build.SourceVersion) ${TAG}
-      tests/ci_build/ci_build.sh auditwheel_x86_64 auditwheel repair --plat ${TAG} python/dist/*.whl
-      tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py wheelhouse/*.whl $(Build.SourceVersion) ${TAG}
+      tests/ci_build/ci_build.sh auditwheel_x86_64 auditwheel repair --only-plat --plat ${TAG} python/dist/*.whl
       mv -v wheelhouse/*.whl python/dist/
     displayName: 'Packaging Python wheel for Treelite...'
   - task: PublishPipelineArtifact@0
@@ -39,8 +38,7 @@ jobs:
       TAG=manylinux2014_x86_64
       tests/ci_build/ci_build.sh cpu bash -c "cd runtime/python/ && python setup.py bdist_wheel --universal"
       tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py runtime/python/dist/*.whl $(Build.SourceVersion) ${TAG}
-      tests/ci_build/ci_build.sh auditwheel_x86_64 auditwheel repair --plat ${TAG} runtime/python/dist/*.whl
-      tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py wheelhouse/*.whl $(Build.SourceVersion) ${TAG}
+      tests/ci_build/ci_build.sh auditwheel_x86_64 auditwheel repair --only-plat --plat ${TAG} runtime/python/dist/*.whl
       mv -v wheelhouse/*.whl runtime/python/dist/
     displayName: 'Packaging Python wheel for Treelite runtime...'
   - task: PublishPipelineArtifact@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,14 +24,22 @@ jobs:
   - script: tests/ci_build/ci_build.sh cpu tests/ci_build/build_via_cmake.sh
     displayName: 'Building Treelite...'
   - script: |
+      TAG=manylinux2014_x86_64
       tests/ci_build/ci_build.sh cpu bash -c "cd python/ && python setup.py bdist_wheel --universal"
+      tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py python/dist/*.whl $(Build.SourceVersion) ${TAG}
+      tests/ci_build/ci_build.sh auditwheel_x86_64 auditwheel repair --plat ${TAG} python/dist/*.whl
+      mv -v wheelhouse/*.whl python/dist/
     displayName: 'Packaging Python wheel for Treelite...'
   - task: PublishPipelineArtifact@0
     inputs:
       artifactName: 'python_linux_whl'
       targetPath: 'python/dist/'
   - script: |
+      TAG=manylinux2014_x86_64
       tests/ci_build/ci_build.sh cpu bash -c "cd runtime/python/ && python setup.py bdist_wheel --universal"
+      tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py runtime/python/dist/*.whl $(Build.SourceVersion) ${TAG}
+      tests/ci_build/ci_build.sh auditwheel_x86_64 auditwheel repair --plat ${TAG} runtime/python/dist/*.whl
+      mv -v wheelhouse/*.whl runtime/python/dist/
     displayName: 'Packaging Python wheel for Treelite runtime...'
   - task: PublishPipelineArtifact@1
     inputs:
@@ -210,9 +218,6 @@ jobs:
   - script: python -m pytest -v --fulltrace tests/python/test_basic.py
     displayName: 'Running Python tests...'
   - script: |
-      TAG=manylinux2014_x86_64
-      python tests/ci_build/rename_whl.py main/*.whl $(Build.SourceVersion) ${TAG}
-      python tests/ci_build/rename_whl.py runtime/*.whl $(Build.SourceVersion) ${TAG}
       python -m awscli s3 cp main/*.whl s3://treelite-wheels/ --acl public-read || true
       python -m awscli s3 cp runtime/*.whl s3://treelite-wheels/ --acl public-read || true
     displayName: 'Uploading Python wheels...'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,9 +26,10 @@ jobs:
   - script: |
       TAG=manylinux2014_x86_64
       tests/ci_build/ci_build.sh cpu bash -c "cd python/ && python setup.py bdist_wheel --universal"
-      tests/ci_build/ci_build.sh auditwheel_x86_64 auditwheel repair --plat ${TAG} python/dist/*.whl
-      mv -v wheelhouse/*.whl python/dist/
       tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py python/dist/*.whl $(Build.SourceVersion) ${TAG}
+      tests/ci_build/ci_build.sh auditwheel_x86_64 auditwheel repair --plat ${TAG} python/dist/*.whl
+      tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py wheelhouse/*.whl $(Build.SourceVersion) ${TAG}
+      mv -v wheelhouse/*.whl python/dist/
     displayName: 'Packaging Python wheel for Treelite...'
   - task: PublishPipelineArtifact@0
     inputs:
@@ -37,9 +38,10 @@ jobs:
   - script: |
       TAG=manylinux2014_x86_64
       tests/ci_build/ci_build.sh cpu bash -c "cd runtime/python/ && python setup.py bdist_wheel --universal"
-      tests/ci_build/ci_build.sh auditwheel_x86_64 auditwheel repair --plat ${TAG} runtime/python/dist/*.whl
-      mv -v wheelhouse/*.whl runtime/python/dist/
       tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py runtime/python/dist/*.whl $(Build.SourceVersion) ${TAG}
+      tests/ci_build/ci_build.sh auditwheel_x86_64 auditwheel repair --plat ${TAG} runtime/python/dist/*.whl
+      tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py wheelhouse/*.whl $(Build.SourceVersion) ${TAG}
+      mv -v wheelhouse/*.whl runtime/python/dist/
     displayName: 'Packaging Python wheel for Treelite runtime...'
   - task: PublishPipelineArtifact@1
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,9 +26,9 @@ jobs:
   - script: |
       TAG=manylinux2014_x86_64
       tests/ci_build/ci_build.sh cpu bash -c "cd python/ && python setup.py bdist_wheel --universal"
-      tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py python/dist/*.whl $(Build.SourceVersion) ${TAG}
       tests/ci_build/ci_build.sh auditwheel_x86_64 auditwheel repair --plat ${TAG} python/dist/*.whl
       mv -v wheelhouse/*.whl python/dist/
+      tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py python/dist/*.whl $(Build.SourceVersion) ${TAG}
     displayName: 'Packaging Python wheel for Treelite...'
   - task: PublishPipelineArtifact@0
     inputs:
@@ -37,9 +37,9 @@ jobs:
   - script: |
       TAG=manylinux2014_x86_64
       tests/ci_build/ci_build.sh cpu bash -c "cd runtime/python/ && python setup.py bdist_wheel --universal"
-      tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py runtime/python/dist/*.whl $(Build.SourceVersion) ${TAG}
       tests/ci_build/ci_build.sh auditwheel_x86_64 auditwheel repair --plat ${TAG} runtime/python/dist/*.whl
       mv -v wheelhouse/*.whl runtime/python/dist/
+      tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py runtime/python/dist/*.whl $(Build.SourceVersion) ${TAG}
     displayName: 'Packaging Python wheel for Treelite runtime...'
   - task: PublishPipelineArtifact@1
     inputs:

--- a/cmake/TreeliteConfig.cmake.in
+++ b/cmake/TreeliteConfig.cmake.in
@@ -2,7 +2,10 @@
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(Threads)
+set(USE_OPENMP @USE_OPENMP@)
+if(USE_OPENMP)
+  find_dependency(OpenMP)
+endif()
 
 if(NOT TARGET treelite::treelite)
   include(${CMAKE_CURRENT_LIST_DIR}/TreeliteTargets.cmake)

--- a/python/setup.py
+++ b/python/setup.py
@@ -98,6 +98,13 @@ class BuildExt(build_ext.build_ext):  # pylint: disable=too-many-ancestors
         """Build the core library with CMake."""
         cmake_cmd = ['cmake', src_dir, generator]
 
+        # Flag for cross-compiling for Apple Silicon
+        # We use environment variable because it's the only way to pass down custom flags
+        # through the cibuildwheel package, which otherwise calls `python setup.py bdist_wheel`
+        # command.
+        if 'CIBW_TARGET_OSX_ARM64' in os.environ:
+            cmake_cmd.append("-DCMAKE_OSX_ARCHITECTURES=arm64")
+
         self.logger.info('Run CMake command: %s', str(cmake_cmd))
         subprocess.check_call(cmake_cmd, cwd=build_dir)
 

--- a/runtime/python/setup.py
+++ b/runtime/python/setup.py
@@ -97,6 +97,13 @@ class BuildExt(build_ext.build_ext):  # pylint: disable=too-many-ancestors
         """Build the runtime with CMake."""
         cmake_cmd = ['cmake', src_dir, generator]
 
+        # Flag for cross-compiling for Apple Silicon
+        # We use environment variable because it's the only way to pass down custom flags
+        # through the cibuildwheel package, which otherwise calls `python setup.py bdist_wheel`
+        # command.
+        if 'CIBW_TARGET_OSX_ARM64' in os.environ:
+            cmake_cmd.append("-DCMAKE_OSX_ARCHITECTURES=arm64")
+
         self.logger.info('Run CMake command: %s', str(cmake_cmd))
         subprocess.check_call(cmake_cmd, cwd=build_dir)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,16 @@ endif(UNIX)
 
 add_library(objtreelite_common OBJECT)  # Component shared by both main package and runtime
 
-find_package(Threads REQUIRED)
+if(USE_OPENMP)
+  if (APPLE)
+    # Require CMake 3.16+ on Mac OSX, as previous versions of CMake had trouble locating
+    # OpenMP on Mac. See https://github.com/dmlc/xgboost/pull/5146#issuecomment-568312706
+    cmake_minimum_required(VERSION 3.16)
+  endif (APPLE)
+  find_package(OpenMP REQUIRED)
+else()
+  message(STATUS "Disabling OpenMP")
+endif()
 
 if(ENABLE_ALL_WARNINGS)
   foreach(target objtreelite objtreelite_runtime objtreelite_runtime)
@@ -24,13 +33,16 @@ foreach(lib objtreelite objtreelite_runtime objtreelite_common)
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
-  target_link_libraries(${lib} PUBLIC Threads::Threads)
   if(MSVC)
     target_compile_options(${lib} PRIVATE /MP)
     target_compile_definitions(${lib} PRIVATE -DNOMINMAX)
     target_compile_options(${lib} PRIVATE /utf-8 -D_CRT_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE)
   else()
     target_compile_options(${lib} PRIVATE -funroll-loops)
+  endif()
+  if(USE_OPENMP)
+    target_link_libraries(${lib} PUBLIC OpenMP::OpenMP_CXX)
+    target_compile_definitions(${lib} PRIVATE -DTREELITE_OPENMP_SUPPORT)
   endif()
   if(TEST_COVERAGE)
     if(MSVC)
@@ -101,6 +113,7 @@ target_sources(objtreelite
     ${PROJECT_SOURCE_DIR}/include/treelite/frontend.h
     ${PROJECT_SOURCE_DIR}/include/treelite/frontend_impl.h
     ${PROJECT_SOURCE_DIR}/include/treelite/gtil.h
+    ${PROJECT_SOURCE_DIR}/include/treelite/omp.h
     ${PROJECT_SOURCE_DIR}/include/treelite/optional.h
     ${PROJECT_SOURCE_DIR}/include/treelite/thread_local.h
     ${PROJECT_SOURCE_DIR}/include/treelite/tree.h

--- a/src/annotator.cc
+++ b/src/annotator.cc
@@ -79,7 +79,7 @@ inline void ComputeBranchLoopImpl(
   bool nan_missing = treelite::math::CheckNAN(missing_value);
   auto sched = treelite::threading_utils::ParallelSchedule::Static();
   treelite::threading_utils::ParallelFor(rbegin, rend, nthread, sched,
-                                         [&](std::size_t rid, std::size_t thread_id) {
+                                         [&](std::size_t rid, int thread_id) {
     const ElementType* row = &dmat->data[rid * num_col];
     const size_t off = dmat->num_col * thread_id;
     const size_t off2 = count_row_ptr[ntree] * thread_id;
@@ -110,7 +110,7 @@ inline void ComputeBranchLoopImpl(
   TREELITE_CHECK_LE(rbegin, rend);
   auto sched = treelite::threading_utils::ParallelSchedule::Static();
   treelite::threading_utils::ParallelFor(rbegin, rend, nthread, sched,
-                                         [&](std::size_t rid, std::size_t thread_id) {
+                                         [&](std::size_t rid, int thread_id) {
     const size_t off = dmat->num_col * thread_id;
     const size_t off2 = count_row_ptr[ntree] * thread_id;
     const size_t ibegin = dmat->row_ptr[rid];

--- a/tests/ci_build/Dockerfile.auditwheel_x86_64
+++ b/tests/ci_build/Dockerfile.auditwheel_x86_64
@@ -1,0 +1,15 @@
+FROM quay.io/pypa/manylinux2014_x86_64
+
+# Install lightweight sudo (not bound to TTY)
+ENV GOSU_VERSION 1.10
+RUN set -ex; \
+    curl -o /usr/local/bin/gosu -L "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" && \
+    chmod +x /usr/local/bin/gosu && \
+    gosu nobody true
+
+# Default entry-point to use if running locally
+# It will preserve attributes of created files
+COPY entrypoint.sh /scripts/
+
+WORKDIR /workspace
+ENTRYPOINT ["/scripts/entrypoint.sh"]

--- a/tests/ci_build/build_python_wheels.sh
+++ b/tests/ci_build/build_python_wheels.sh
@@ -9,7 +9,9 @@ if [[ $# -ne 2 ]]; then
 fi
 
 platform_id=$1
-commit_id=$2
+shift
+commit_id=$1
+shift
 
 # Bundle libomp 11.1.0 when targeting MacOS.
 # This is a workaround in order to prevent segfaults when running inside a Conda environment.

--- a/tests/ci_build/build_python_wheels.sh
+++ b/tests/ci_build/build_python_wheels.sh
@@ -49,7 +49,7 @@ if [[ "$platform_id" == macosx_* ]]; then
     export CIBW_TEST_SKIP='*-macosx_arm64'
     export CIBW_BUILD_VERBOSITY=3
 
-    conda create -n build $OPENMP_URL
+    sudo conda create -n build $OPENMP_URL
     PREFIX="/usr/local/miniconda/envs/build"
 
     # Set up build flags for cibuildwheel

--- a/tests/ci_build/build_python_wheels.sh
+++ b/tests/ci_build/build_python_wheels.sh
@@ -63,6 +63,7 @@ else
     exit 2
 fi
 
+conda activate python3
 python -m pip install cibuildwheel
 python -m cibuildwheel python --output-dir wheelhouse
 python -m cibuildwheel runtime/python --output-dir wheelhouse-runtime

--- a/tests/ci_build/build_python_wheels.sh
+++ b/tests/ci_build/build_python_wheels.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 [platform_id] [commit ID]"
+  exit 1
+fi
+
+platform_id=$1
+commit_id=$2
+
+# Bundle libomp 11.1.0 when targeting MacOS.
+# This is a workaround in order to prevent segfaults when running inside a Conda environment.
+# See https://github.com/dmlc/xgboost/issues/7039#issuecomment-1025125003 for more context.
+# The workaround is also used by the scikit-learn and XGBoost projects.
+if [[ "$platform_id" == macosx_* ]]; then
+    # Make sure to use a libomp version binary compatible with the oldest
+    # supported version of the macos SDK as libomp will be vendored into the
+    # Treelite wheels for MacOS.
+
+    if [[ "$platform_id" == macosx_arm64 ]]; then
+        # MacOS, Apple Silicon
+        # arm64 builds must cross compile because CI is on x64
+        # cibuildwheel will take care of cross-compilation.
+        wheel_tag=macosx_12_0_arm64
+        cpython_ver=38
+        setup_env_var='CIBW_TARGET_OSX_ARM64=1'  # extra flag to be passed to setup.py
+        export PYTHON_CROSSENV=1
+        export MACOSX_DEPLOYMENT_TARGET=12.0
+        OPENMP_URL="https://anaconda.org/conda-forge/llvm-openmp/11.1.0/download/osx-arm64/llvm-openmp-11.1.0-hf3c4609_1.tar.bz2"
+    elif [[ "$platform_id" == macosx_x86_64 ]]; then
+        # MacOS, Intel
+        wheel_tag=macosx_10_15_x86_64.macosx_11_0_x86_64.macosx_12_0_x86_64
+        cpython_ver=37
+        export MACOSX_DEPLOYMENT_TARGET=10.13
+        OPENMP_URL="https://anaconda.org/conda-forge/llvm-openmp/11.1.0/download/osx-64/llvm-openmp-11.1.0-hda6cdc1_1.tar.bz2"
+    else
+        echo "Platform not supported: $platform_id"
+        exit 3
+    fi
+    # Set up environment variables to configure cibuildwheel
+    export CIBW_BUILD=cp${cpython_ver}-${platform_id}
+    export CIBW_ARCHS=all
+    export CIBW_ENVIRONMENT=${setup_env_var}
+    export CIBW_TEST_SKIP='*-macosx_arm64'
+    export CIBW_BUILD_VERBOSITY=3
+
+    conda create -n build $OPENMP_URL
+    PREFIX="/usr/local/miniconda/envs/build"
+
+    # Set up build flags for cibuildwheel
+    # This is needed to bundle libomp lib we downloaded earlier
+    export CC=/usr/bin/clang
+    export CXX=/usr/bin/clang++
+    export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"
+    export CFLAGS="$CFLAGS -I$PREFIX/include"
+    export CXXFLAGS="$CXXFLAGS -I$PREFIX/include"
+    export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib -L$PREFIX/lib -lomp"
+else
+    echo "Platform not supported: $platform_id"
+    exit 2
+fi
+
+python -m pip install cibuildwheel
+python -m cibuildwheel python --output-dir wheelhouse
+python -m cibuildwheel runtime/python --output-dir wheelhouse-runtime
+python tests/ci_build/rename_whl.py wheelhouse/*.whl ${commit_id} ${wheel_tag}
+python tests/ci_build/rename_whl.py wheelhouse-runtime/*.whl ${commit_id} ${wheel_tag}
+mv -v wheelhouse/*.whl .
+mv -v wheelhouse-runtime/*.whl .

--- a/tests/ci_build/build_python_wheels.sh
+++ b/tests/ci_build/build_python_wheels.sh
@@ -3,16 +3,14 @@
 set -e
 set -x
 
-if [[ $# -ne 3 ]]; then
-  echo "Usage: $0 [platform_id] [commit ID] [python package location]"
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 [platform_id] [commit ID]"
   exit 1
 fi
 
 platform_id=$1
 shift
 commit_id=$1
-shift
-python_pkg_root=$1
 shift
 
 # Bundle libomp 11.1.0 when targeting MacOS.
@@ -51,20 +49,18 @@ if [[ "$platform_id" == macosx_* ]]; then
     export CIBW_TEST_SKIP='*-macosx_arm64'
     export CIBW_BUILD_VERBOSITY=3
 
-    if [[ "${NO_OPENMP}" != 1 ]]; then
-        sudo conda create -n build $OPENMP_URL
-        conda info -e
-        PREFIX="$HOME/miniconda/envs/build"
+    sudo conda create -n build $OPENMP_URL
+    conda info -e
+    PREFIX="$HOME/miniconda/envs/build"
 
-        # Set up build flags for cibuildwheel
-        # This is needed to bundle libomp lib we downloaded earlier
-        export CC=/usr/bin/clang
-        export CXX=/usr/bin/clang++
-        export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"
-        export CFLAGS="$CFLAGS -I$PREFIX/include"
-        export CXXFLAGS="$CXXFLAGS -I$PREFIX/include"
-        export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib -L$PREFIX/lib -lomp"
-    fi
+    # Set up build flags for cibuildwheel
+    # This is needed to bundle libomp lib we downloaded earlier
+    export CC=/usr/bin/clang
+    export CXX=/usr/bin/clang++
+    export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"
+    export CFLAGS="$CFLAGS -I$PREFIX/include"
+    export CXXFLAGS="$CXXFLAGS -I$PREFIX/include"
+    export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib -L$PREFIX/lib -lomp"
 else
     echo "Platform not supported: $platform_id"
     exit 2
@@ -73,6 +69,9 @@ fi
 source $HOME/miniconda/bin/activate
 conda activate python3
 python -m pip install cibuildwheel
-python -m cibuildwheel ${python_pkg_root} --output-dir wheelhouse
+python -m cibuildwheel python --output-dir wheelhouse
+python -m cibuildwheel runtime/python --output-dir wheelhouse-runtime
 python tests/ci_build/rename_whl.py wheelhouse/*.whl ${commit_id} ${wheel_tag}
+python tests/ci_build/rename_whl.py wheelhouse-runtime/*.whl ${commit_id} ${wheel_tag}
 mv -v wheelhouse/*.whl .
+mv -v wheelhouse-runtime/*.whl .

--- a/tests/ci_build/build_python_wheels.sh
+++ b/tests/ci_build/build_python_wheels.sh
@@ -63,6 +63,7 @@ else
     exit 2
 fi
 
+source $HOME/miniconda/bin/activate
 conda activate python3
 python -m pip install cibuildwheel
 python -m cibuildwheel python --output-dir wheelhouse

--- a/tests/ci_build/build_python_wheels.sh
+++ b/tests/ci_build/build_python_wheels.sh
@@ -51,7 +51,7 @@ if [[ "$platform_id" == macosx_* ]]; then
 
     sudo conda create -n build $OPENMP_URL
     conda info -e
-    PREFIX="/usr/local/miniconda/envs/build"
+    PREFIX="$HOME/miniconda/envs/build"
 
     # Set up build flags for cibuildwheel
     # This is needed to bundle libomp lib we downloaded earlier

--- a/tests/ci_build/build_python_wheels.sh
+++ b/tests/ci_build/build_python_wheels.sh
@@ -50,6 +50,7 @@ if [[ "$platform_id" == macosx_* ]]; then
     export CIBW_BUILD_VERBOSITY=3
 
     sudo conda create -n build $OPENMP_URL
+    conda info -e
     PREFIX="/usr/local/miniconda/envs/build"
 
     # Set up build flags for cibuildwheel

--- a/tests/cpp/test_threading_utils.cc
+++ b/tests/cpp/test_threading_utils.cc
@@ -58,7 +58,7 @@ TEST(ThreadingUtils, ParallelFor) {
 
   auto sched = treelite::threading_utils::ParallelSchedule::Guided();
 
-  auto dummy_func = [](int, std::size_t) {};
+  auto dummy_func = [](int, int) {};
   EXPECT_THROW(ParallelFor(0, 100, 0, sched, dummy_func), treelite::Error);
   EXPECT_THROW(ParallelFor(200, 100, 3, sched, dummy_func), treelite::Error);
   EXPECT_THROW(ParallelFor(-100, 100, 3, sched, dummy_func), treelite::Error);
@@ -85,7 +85,7 @@ TEST(ThreadingUtils, ParallelFor) {
     std::size_t nthread = static_cast<std::size_t>(rng.DrawInteger(1, max_thread + 1));
     int64_t end = rng.DrawInteger(begin, kVectorLength);
 
-    ParallelFor(begin, end, nthread, sched, [&a, &b, &c](int64_t i, std::size_t) {
+    ParallelFor(begin, end, nthread, sched, [&a, &b, &c](int64_t i, int) {
       c[i] = a[i] + b[i];
     });
 

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -135,7 +135,8 @@ if [ ${TASK} == "python_sdist_test" ]; then
 fi
 
 if [ ${TASK} == "python_wheels" ]; then
-  tests/ci_build/build_python_wheels.sh ${CIBW_PLATFORM_ID} ${TRAVIS_COMMIT}
+  tests/ci_build/build_python_wheels.sh ${CIBW_PLATFORM_ID} ${TRAVIS_COMMIT} python
+  NO_OPENMP=1 tests/ci_build/build_python_wheels.sh ${CIBW_PLATFORM_ID} ${TRAVIS_COMMIT} runtime/python
   # Deploy binary wheels to S3
   conda activate python3
   python --version

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -135,8 +135,7 @@ if [ ${TASK} == "python_sdist_test" ]; then
 fi
 
 if [ ${TASK} == "python_wheels" ]; then
-  tests/ci_build/build_python_wheels.sh ${CIBW_PLATFORM_ID} ${TRAVIS_COMMIT} python
-  NO_OPENMP=1 tests/ci_build/build_python_wheels.sh ${CIBW_PLATFORM_ID} ${TRAVIS_COMMIT} runtime/python
+  tests/ci_build/build_python_wheels.sh ${CIBW_PLATFORM_ID} ${TRAVIS_COMMIT}
   # Deploy binary wheels to S3
   conda activate python3
   python --version

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -9,7 +9,7 @@ then
   conda activate python3
   conda --version
   python --version
-  conda install -c conda-forge numpy scipy pandas pytest pytest-cov scikit-learn coverage ninja lcov cmake
+  conda install -c conda-forge numpy scipy pandas pytest pytest-cov scikit-learn coverage ninja lcov cmake llvm-openmp
 
   # Run coverage test
   set -x
@@ -38,7 +38,7 @@ then
   conda activate python3
   conda --version
   python --version
-  conda install -c conda-forge ninja cmake rapidjson fmt
+  conda install -c conda-forge ninja cmake rapidjson fmt llvm-openmp
 
   # Install Treelite C++ library into the Conda env
   set -x
@@ -64,7 +64,7 @@ then
   conda activate python3
   conda --version
   python --version
-  conda install -c conda-forge numpy scipy pandas pytest scikit-learn coverage ninja cmake
+  conda install -c conda-forge numpy scipy pandas pytest scikit-learn coverage ninja cmake llvm-openmp
 
   # Build binary wheel
   set -x


### PR DESCRIPTION
- [x] Rewrite `ParallelFor` using OpenMP constructs.
- [x] Link Treelite libs with OpenMP runtime lib.
- [x] On MacOS, bundle libomp (OpenMP runtime) with Treelite. This is to ensure that Treelite does not randomly crash. https://github.com/dmlc/xgboost/pull/7621 for full explanation.
- [x] Build PyPI wheel targeting Apple Silicon. Closes #350
- [x] On Linux, run `auditwheel repair` command to vendor (bundle) `libgomp.so` inside the Python wheel. This is required by the Python packaging standard.