### PR TITLE
Prototype for multithreaded GTIL: tree parallel

### DIFF
--- a/include/treelite/c_api.h
+++ b/include/treelite/c_api.h
@@ -413,7 +413,8 @@ TREELITE_DLL int TreeliteFreeModel(ModelHandle handle);
 TREELITE_DLL int TreeliteGTILGetPredictOutputSize(ModelHandle handle, size_t num_row, size_t* out);
 
 TREELITE_DLL int TreeliteGTILPredict(ModelHandle handle, const float* input, size_t num_row,
-                                     float* output, int pred_transform, size_t* out_result_size);
+                                     float* output, int nthread, int pred_transform,
+                                     size_t* out_result_size);
 
 /*! \} */
 

--- a/include/treelite/gtil.h
+++ b/include/treelite/gtil.h
@@ -19,12 +19,32 @@ class DMatrix;
 
 namespace gtil {
 
-// Predict with a DMatrix (can be sparse or dense)
-std::size_t Predict(const Model* model, const DMatrix* input, float* output,
-                    bool pred_transform = true);
-// Predict with 2D dense matrix
+/*!
+ * \brief Predict with a DMatrix
+ * \param model The model object
+ * \param input The data matrix (sparse or dense)
+ * \param output Pointer to buffer to store the output. Call GetPredictOutputSize() to get the
+ *               amount of buffer you should allocate for this parameter.
+ * \param nthread number of CPU threads to use. Set <= 0 to use all CPU cores.
+ * \param pred_transform After computing the prediction score, whether to transform it.
+ * \return Size of output. This could be smaller than GetPredictOutputSize() but could never be
+ *         larger than GetPredictOutputSize().
+ */
+std::size_t Predict(const Model* model, const DMatrix* input, float* output, int nthread,
+                    bool pred_transform);
+/*!
+ * \brief Predict with a 2D dense matrix
+ * \param model The model object
+ * \param input The data matrix, laid out in row-major layout
+ * \param output Pointer to buffer to store the output. Call GetPredictOutputSize() to get the
+ *               amount of buffer you should allocate for this parameter.
+ * \param nthread number of CPU threads to use. Set <= 0 to use all CPU cores.
+ * \param pred_transform After computing the prediction score, whether to transform it.
+ * \return Size of output. This could be smaller than GetPredictOutputSize() but could never be
+ *         larger than GetPredictOutputSize().
+ */
 std::size_t Predict(const Model* model, const float* input, std::size_t num_row, float* output,
-                    bool pred_transform = true);
+                    int nthread, bool pred_transform);
 
 // Query functions to allocate correct amount of memory for the output
 std::size_t GetPredictOutputSize(const Model* model, std::size_t num_row);

--- a/python/treelite/gtil/gtil.py
+++ b/python/treelite/gtil/gtil.py
@@ -7,7 +7,7 @@ from ..frontend import Model
 from ..core import _LIB, _check_call
 
 
-def predict(model: Model, data: np.ndarray, pred_margin: bool = False):
+def predict(model: Model, data: np.ndarray, nthread: int = -1, pred_margin: bool = False):
     """
     Predict with a Treelite model using General Tree Inference Library (GTIL). GTIL is intended to
     be a reference implementation. GTIL is also useful in situations where using a C compiler is
@@ -24,6 +24,8 @@ def predict(model: Model, data: np.ndarray, pred_margin: bool = False):
         Treelite model object
     data : :py:class:`numpy.ndarray` array
         2D NumPy array, with which to run prediction
+    nthread : :py:class:`int <python:int>`, optional
+        Number of CPU cores to use in prediction. If <= 0, use all CPU cores.
     pred_margin : :py:class:`bool <python:bool>`, optional
         Whether to produce raw margin scores
 
@@ -46,6 +48,7 @@ def predict(model: Model, data: np.ndarray, pred_margin: bool = False):
         data.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
         ctypes.c_size_t(data.shape[0]),
         out_result.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+        ctypes.c_int(nthread),
         ctypes.c_int(0 if pred_margin else 1),
         ctypes.byref(out_result_size)
     ))

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -263,11 +263,11 @@ int TreeliteGTILGetPredictOutputSize(ModelHandle handle, size_t num_row, size_t*
 }
 
 int TreeliteGTILPredict(ModelHandle handle, const float* input, size_t num_row, float* output,
-                        int pred_transform, size_t* out_result_size) {
+                        int nthread, int pred_transform, size_t* out_result_size) {
   API_BEGIN();
   const auto* model_ = static_cast<const Model*>(handle);
   *out_result_size =
-      gtil::Predict(model_, input, num_row, output, (pred_transform == 1));
+      gtil::Predict(model_, input, num_row, output, nthread, (pred_transform == 1));
   API_END();
 }
 

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -15,6 +15,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cfloat>
+#include "../threading_utils/parallel_for.h"
 #include "./pred_transform.h"
 
 namespace {
@@ -70,22 +71,37 @@ inline int NextNodeCategorical(float fvalue, const std::vector<uint32_t>& matchi
 template <typename ThresholdType, typename LeafOutputType, typename DMatrixType,
           typename OutputFunc>
 inline std::size_t PredictImplInner(const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
-                                    const DMatrixType* input, float* output, bool pred_transform,
-                                    OutputFunc output_func) {
+                                    const DMatrixType* input, float* output, int nthread,
+                                    bool pred_transform, OutputFunc output_func) {
   using TreeType = treelite::Tree<ThresholdType, LeafOutputType>;
   const size_t num_row = input->GetNumRow();
   const size_t num_col = input->GetNumCol();
   std::vector<ThresholdType> row(num_col);
   const treelite::TaskParam task_param = model.task_param;
-  std::vector<float> sum(task_param.num_class);
+  std::vector<float> sum_tloc(task_param.num_class * nthread);
+  std::vector<float> sum_tot(task_param.num_class);
 
-  // TODO(phcho): Use parallelism
-  std::size_t output_offset = 0;
-  for (size_t row_id = 0; row_id < num_row; ++row_id) {
+  // Query the size of output per input row.
+  // This is guaranteed to be at most GetPredictOutputSize(num_row=1).
+  std::size_t output_size_per_row;
+  if (pred_transform) {
+    std::vector<float> temp(treelite::gtil::GetPredictOutputSize(&model, 1));
+    PredTransformFuncType pred_transform_func
+        = treelite::gtil::LookupPredTransform(model.param.pred_transform);
+    output_size_per_row = pred_transform_func(model, sum_tloc.data(), temp.data());
+  } else {
+    output_size_per_row = task_param.num_class;
+  }
+
+  auto sched = treelite::threading_utils::ParallelSchedule::Static();
+  for (std::size_t row_id = 0; row_id < num_row; ++row_id) {
     input->FillRow(row_id, row.data());
-    std::fill(sum.begin(), sum.end(), 0.0f);
+    std::fill(sum_tloc.begin(), sum_tloc.end(), 0.0f);
+    std::fill(sum_tot.begin(), sum_tot.end(), 0.0f);
     const std::size_t num_tree = model.trees.size();
-    for (std::size_t tree_id = 0; tree_id < num_tree; ++tree_id) {
+    treelite::threading_utils::ParallelFor(std::size_t(0), num_tree, nthread, sched,
+                                           [&](std::size_t tree_id, int thread_id) {
+      float* sum = &sum_tloc[thread_id * task_param.num_class];
       const TreeType& tree = model.trees[tree_id];
       int node_id = 0;
       while (!tree.IsLeaf(node_id)) {
@@ -104,7 +120,12 @@ inline std::size_t PredictImplInner(const treelite::ModelImpl<ThresholdType, Lea
           TREELITE_CHECK(false) << "Unrecognized split type: " << static_cast<int>(split_type);
         }
       }
-      output_func(tree, tree_id, node_id, sum.data());
+      output_func(tree, tree_id, node_id, sum);
+    });
+    for (int thread_id = 0; thread_id < nthread; ++thread_id) {
+      for (unsigned i = 0; i < task_param.num_class; ++i) {
+        sum_tot[i] += sum_tloc[thread_id * task_param.num_class + i];
+      }
     }
     if (model.average_tree_output) {
       float average_factor;
@@ -124,30 +145,29 @@ inline std::size_t PredictImplInner(const treelite::ModelImpl<ThresholdType, Lea
         average_factor = static_cast<float>(num_tree);
       }
       for (unsigned int i = 0; i < task_param.num_class; ++i) {
-        sum[i] /= average_factor;
+        sum_tot[i] /= average_factor;
       }
     }
     for (unsigned int i = 0; i < task_param.num_class; ++i) {
-      sum[i] += model.param.global_bias;
+      sum_tot[i] += model.param.global_bias;
     }
     if (pred_transform) {
       PredTransformFuncType pred_transform_func
         = treelite::gtil::LookupPredTransform(model.param.pred_transform);
-      output_offset += pred_transform_func(model, sum.data(), &output[output_offset]);
+      pred_transform_func(model, sum_tot.data(), &output[row_id * output_size_per_row]);
     } else {
       for (unsigned int i = 0; i < task_param.num_class; ++i) {
-        output[output_offset + i] = sum[i];
+        output[row_id * output_size_per_row + i] = sum_tot[i];
       }
-      output_offset += task_param.num_class;
     }
     input->ClearRow(row_id, row.data());
   }
-  return output_offset;
+  return output_size_per_row * num_row;
 }
 
 template <typename ThresholdType, typename LeafOutputType, typename DMatrixType>
 inline std::size_t PredictImpl(const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
-                               const DMatrixType* input, float* output,
+                               const DMatrixType* input, float* output, int nthread,
                                bool pred_transform) {
   using TreeType = treelite::Tree<ThresholdType, LeafOutputType>;
   const treelite::TaskParam task_param = model.task_param;
@@ -161,21 +181,21 @@ inline std::size_t PredictImpl(const treelite::ModelImpl<ThresholdType, LeafOutp
           sum[i] += leaf_vector[i];
         }
       };
-      return PredictImplInner(model, input, output, pred_transform, output_logic);
+      return PredictImplInner(model, input, output, nthread, pred_transform, output_logic);
     } else {
       // multi-class classification with gradient boosted trees
       auto output_logic = [task_param](
           const TreeType& tree, int tree_id, int node_id, float* sum) {
         sum[tree_id % task_param.num_class] += tree.LeafValue(node_id);
       };
-      return PredictImplInner(model, input, output, pred_transform, output_logic);
+      return PredictImplInner(model, input, output, nthread, pred_transform, output_logic);
     }
   } else {
     auto output_logic = [task_param](
         const TreeType& tree, int tree_id, int node_id, float* sum) {
       sum[0] += tree.LeafValue(node_id);
     };
-    return PredictImplInner(model, input, output, pred_transform, output_logic);
+    return PredictImplInner(model, input, output, nthread, pred_transform, output_logic);
   }
 }
 
@@ -184,17 +204,22 @@ inline std::size_t PredictImpl(const treelite::ModelImpl<ThresholdType, LeafOutp
 namespace treelite {
 namespace gtil {
 
-std::size_t Predict(const Model* model, const DMatrix* input, float* output, bool pred_transform) {
+std::size_t Predict(const Model* model, const DMatrix* input, float* output, int nthread,
+                    bool pred_transform) {
+  // If nthread <= 0, then use all CPU cores in the system
+  if (nthread <= 0) {
+    nthread = threading_utils::MaxNumThread();
+  }
   // Check type of DMatrix
   const auto* d1 = dynamic_cast<const DenseDMatrixImpl<float>*>(input);
   const auto* d2 = dynamic_cast<const CSRDMatrixImpl<float>*>(input);
   if (d1) {
-    return model->Dispatch([d1, output, pred_transform](const auto& model) {
-      return PredictImpl(model, d1, output, pred_transform);
+    return model->Dispatch([d1, output, nthread, pred_transform](const auto& model) {
+      return PredictImpl(model, d1, output, nthread, pred_transform);
     });
   } else if (d2) {
-    return model->Dispatch([d2, output, pred_transform](const auto& model) {
-      return PredictImpl(model, d2, output, pred_transform);
+    return model->Dispatch([d2, output, nthread, pred_transform](const auto& model) {
+      return PredictImpl(model, d2, output, nthread, pred_transform);
     });
   } else {
     TREELITE_LOG(FATAL) << "DMatrix with float64 data is not supported";
@@ -203,14 +228,14 @@ std::size_t Predict(const Model* model, const DMatrix* input, float* output, boo
 }
 
 std::size_t Predict(const Model* model, const float* input, std::size_t num_row, float* output,
-                    bool pred_transform) {
+                    int nthread, bool pred_transform) {
   std::unique_ptr<DenseDMatrixImpl<float>> dmat =
       std::make_unique<DenseDMatrixImpl<float>>(
           std::vector<float>(input, input + num_row * model->num_feature),
           std::numeric_limits<float>::quiet_NaN(),
           num_row,
           model->num_feature);
-  return Predict(model, dmat.get(), output, pred_transform);
+  return Predict(model, dmat.get(), output, nthread, pred_transform);
 }
 
 std::size_t GetPredictOutputSize(const Model* model, std::size_t num_row) {

--- a/src/threading_utils/parallel_for.h
+++ b/src/threading_utils/parallel_for.h
@@ -94,7 +94,7 @@ inline void ParallelFor(IndexType begin, IndexType end, int nthread, ParallelSch
   case ParallelSchedule::kAuto: {
 #pragma omp parallel for num_threads(nthread)
     for (OmpInd i = begin; i < end; ++i) {
-      exc.Run(func, i, omp_get_thread_num());
+      exc.Run(func, static_cast<IndexType>(i), omp_get_thread_num());
     }
     break;
   }
@@ -102,12 +102,12 @@ inline void ParallelFor(IndexType begin, IndexType end, int nthread, ParallelSch
     if (sched.chunk == 0) {
 #pragma omp parallel for num_threads(nthread) schedule(dynamic)
       for (OmpInd i = begin; i < end; ++i) {
-        exc.Run(func, i, omp_get_thread_num());
+        exc.Run(func, static_cast<IndexType>(i), omp_get_thread_num());
       }
     } else {
 #pragma omp parallel for num_threads(nthread) schedule(dynamic, sched.chunk)
       for (OmpInd i = begin; i < end; ++i) {
-        exc.Run(func, i, omp_get_thread_num());
+        exc.Run(func, static_cast<IndexType>(i), omp_get_thread_num());
       }
     }
     break;
@@ -116,12 +116,12 @@ inline void ParallelFor(IndexType begin, IndexType end, int nthread, ParallelSch
     if (sched.chunk == 0) {
 #pragma omp parallel for num_threads(nthread) schedule(static)
       for (OmpInd i = begin; i < end; ++i) {
-        exc.Run(func, i, omp_get_thread_num());
+        exc.Run(func, static_cast<IndexType>(i), omp_get_thread_num());
       }
     } else {
 #pragma omp parallel for num_threads(nthread) schedule(static, sched.chunk)
       for (OmpInd i = begin; i < end; ++i) {
-        exc.Run(func, i, omp_get_thread_num());
+        exc.Run(func, static_cast<IndexType>(i), omp_get_thread_num());
       }
     }
     break;
@@ -129,7 +129,7 @@ inline void ParallelFor(IndexType begin, IndexType end, int nthread, ParallelSch
   case ParallelSchedule::kGuided: {
 #pragma omp parallel for num_threads(nthread) schedule(guided)
     for (OmpInd i = begin; i < end; ++i) {
-      exc.Run(func, i, omp_get_thread_num());
+      exc.Run(func, static_cast<IndexType>(i), omp_get_thread_num());
     }
     break;
   }

--- a/tests/example_app/example.c
+++ b/tests/example_app/example.c
@@ -60,9 +60,10 @@ int main() {
                       2.0f, 0.0f};
   float* output;
   size_t out_result_size;
+  int nthread = 2;
   safe_treelite(TreeliteGTILGetPredictOutputSize(model, num_row, &output_alloc_size));
   output = (float*)malloc(output_alloc_size * sizeof(float));
-  safe_treelite(TreeliteGTILPredict(model, input, num_row, output, 0, &out_result_size));
+  safe_treelite(TreeliteGTILPredict(model, input, num_row, output, nthread, 0, &out_result_size));
 
   printf("TREELITE_VERSION = %s\n", TREELITE_VERSION);
 


### PR DESCRIPTION
Speed up GTIL prediction by running prediction for multiple trees in parallel. This PR exposes the nthread parameter to allow the user to control the number of CPU threads to use.

Using https://github.com/triton-inference-server/fil_backend/blob/main/notebooks/categorical-fraud-detection/Fraud_Detection_Example.ipynb:
![comparison (1)](https://user-images.githubusercontent.com/2532981/152331476-d64b71e3-0877-4624-98d8-c35614cc39cb.png)

Overall, tree-parallel strategy yields lower throughput than the row-parallel strategy (#344)