### PR TITLE
Robust handling of nthread

### DIFF
--- a/include/treelite/omp.h
+++ b/include/treelite/omp.h
@@ -9,7 +9,23 @@
 
 #ifdef TREELITE_OPENMP_SUPPORT
 #include <omp.h>
-#else
+#include <limits>
+
+// MSVC doesn't implement the thread limit.
+#if defined(_MSC_VER)
+inline int omp_get_thread_limit() {
+  return std::numeric_limits<int>::max();
+}
+#endif  // defined(_MSC_VER)
+
+#else  // TREELITE_OPENMP_SUPPORT
+
+// Stubs for OpenMP functions, to be used when OpenMP is not available.
+
+inline int omp_get_thread_limit() {
+  return 1;
+}
+
 inline int omp_get_thread_num() {
   return 0;
 }
@@ -17,6 +33,11 @@ inline int omp_get_thread_num() {
 inline int omp_get_max_threads() {
   return 1;
 }
+
+inline int omp_get_num_procs() {
+  return 1;
+}
+
 #endif  // TREELITE_OPENMP_SUPPORT
 
 #endif  // TREELITE_OMP_H_

--- a/src/annotator.cc
+++ b/src/annotator.cc
@@ -218,7 +218,7 @@ AnnotateImpl(
   }
 
   // perform reduction on counts
-  for (int tid = 0; tid < thread_config.nthread; ++tid) {
+  for (std::uint32_t tid = 0; tid < thread_config.nthread; ++tid) {
     const size_t off = count_row_ptr[ntree] * tid;
     for (size_t i = 0; i < count_row_ptr[ntree]; ++i) {
       new_counts[i] += counts_tloc[off + i];

--- a/src/annotator.cc
+++ b/src/annotator.cc
@@ -72,7 +72,7 @@ template <typename ElementType, typename ThresholdType, typename LeafOutputType>
 inline void ComputeBranchLoopImpl(
     const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
     const treelite::DenseDMatrixImpl<ElementType>* dmat, size_t rbegin, size_t rend,
-    ThreadConfig thread_config, const size_t* count_row_ptr, uint64_t* counts_tloc) {
+    const ThreadConfig& thread_config, const size_t* count_row_ptr, uint64_t* counts_tloc) {
   std::vector<Entry<ElementType>> inst(thread_config.nthread * dmat->num_col, {-1});
   size_t ntree = model.trees.size();
   TREELITE_CHECK_LE(rbegin, rend);
@@ -106,7 +106,7 @@ template <typename ElementType, typename ThresholdType, typename LeafOutputType>
 inline void ComputeBranchLoopImpl(
     const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
     const treelite::CSRDMatrixImpl<ElementType>* dmat, size_t rbegin, size_t rend,
-    ThreadConfig thread_config, const size_t* count_row_ptr, uint64_t* counts_tloc) {
+    const ThreadConfig& thread_config, const size_t* count_row_ptr, uint64_t* counts_tloc) {
   std::vector<Entry<ElementType>> inst(thread_config.nthread * dmat->num_col, {-1});
   size_t ntree = model.trees.size();
   TREELITE_CHECK_LE(rbegin, rend);
@@ -135,7 +135,7 @@ class ComputeBranchLoopDispatcherWithDenseDMatrix {
   template <typename ThresholdType, typename LeafOutputType>
   inline static void Dispatch(
       const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
-      const treelite::DMatrix* dmat, size_t rbegin, size_t rend, ThreadConfig thread_config,
+      const treelite::DMatrix* dmat, size_t rbegin, size_t rend, const ThreadConfig& thread_config,
       const size_t* count_row_ptr, uint64_t* counts_tloc) {
     const auto* dmat_ = static_cast<const treelite::DenseDMatrixImpl<ElementType>*>(dmat);
     TREELITE_CHECK(dmat_) << "Dangling data matrix reference detected";
@@ -149,7 +149,7 @@ class ComputeBranchLoopDispatcherWithCSRDMatrix {
   template <typename ThresholdType, typename LeafOutputType>
   inline static void Dispatch(
       const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
-      const treelite::DMatrix* dmat, size_t rbegin, size_t rend, ThreadConfig thread_config,
+      const treelite::DMatrix* dmat, size_t rbegin, size_t rend, const ThreadConfig& thread_config,
       const size_t* count_row_ptr, uint64_t* counts_tloc) {
     const auto* dmat_ = static_cast<const treelite::CSRDMatrixImpl<ElementType>*>(dmat);
     TREELITE_CHECK(dmat_) << "Dangling data matrix reference detected";
@@ -160,8 +160,8 @@ class ComputeBranchLoopDispatcherWithCSRDMatrix {
 template <typename ThresholdType, typename LeafOutputType>
 inline void ComputeBranchLoop(const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
                               const treelite::DMatrix* dmat, size_t rbegin,
-                              size_t rend, ThreadConfig thread_config, const size_t* count_row_ptr,
-                              uint64_t* counts_tloc) {
+                              size_t rend, const ThreadConfig& thread_config,
+                              const size_t* count_row_ptr, uint64_t* counts_tloc) {
   switch (dmat->GetType()) {
   case treelite::DMatrixType::kDense: {
     treelite::DispatchWithTypeInfo<ComputeBranchLoopDispatcherWithDenseDMatrix>(

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -73,7 +73,7 @@ template <typename ThresholdType, typename LeafOutputType, typename DMatrixType,
           typename OutputFunc>
 inline std::size_t PredictImplInner(const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
                                     const DMatrixType* input, float* output,
-                                    ThreadConfig thread_config, bool pred_transform,
+                                    const ThreadConfig& thread_config, bool pred_transform,
                                     OutputFunc output_func) {
   using TreeType = treelite::Tree<ThresholdType, LeafOutputType>;
   const size_t num_row = input->GetNumRow();
@@ -169,8 +169,8 @@ inline std::size_t PredictImplInner(const treelite::ModelImpl<ThresholdType, Lea
 
 template <typename ThresholdType, typename LeafOutputType, typename DMatrixType>
 inline std::size_t PredictImpl(const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
-                               const DMatrixType* input, float* output, ThreadConfig thread_config,
-                               bool pred_transform) {
+                               const DMatrixType* input, float* output,
+                               const ThreadConfig& thread_config, bool pred_transform) {
   using TreeType = treelite::Tree<ThresholdType, LeafOutputType>;
   const treelite::TaskParam task_param = model.task_param;
   if (task_param.num_class > 1) {

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -13,6 +13,7 @@
 #include <limits>
 #include <vector>
 #include <cmath>
+#include <cstdint>
 #include <cstddef>
 #include <cfloat>
 #include "../threading_utils/parallel_for.h"
@@ -124,7 +125,7 @@ inline std::size_t PredictImplInner(const treelite::ModelImpl<ThresholdType, Lea
       }
       output_func(tree, tree_id, node_id, sum);
     });
-    for (int thread_id = 0; thread_id < thread_config.nthread; ++thread_id) {
+    for (std::uint32_t thread_id = 0; thread_id < thread_config.nthread; ++thread_id) {
       for (unsigned i = 0; i < task_param.num_class; ++i) {
         sum_tot[i] += sum_tloc[thread_id * task_param.num_class + i];
       }

--- a/src/threading_utils/parallel_for.h
+++ b/src/threading_utils/parallel_for.h
@@ -10,6 +10,7 @@
 #include <treelite/omp.h>
 #include <treelite/logging.h>
 #include <type_traits>
+#include <algorithm>
 #include <exception>
 #include <mutex>
 #include <cstddef>
@@ -53,8 +54,38 @@ class OMPException {
   }
 };
 
+inline int OmpGetThreadLimit() {
+  int limit = omp_get_thread_limit();
+  TREELITE_CHECK_GE(limit, 1) << "Invalid thread limit for OpenMP.";
+  return limit;
+}
+
 inline int MaxNumThread() {
-  return omp_get_max_threads();
+  return std::min(std::min(omp_get_num_procs(), omp_get_max_threads()), OmpGetThreadLimit());
+}
+
+/*!
+ * \brief Represent thread configuration, to be used with parallel loops.
+ */
+struct ThreadConfig {
+  int nthread;
+};
+
+/*!
+ * \brief Create therad configuration.
+ * @param nthread Number of threads to use. If \<= 0, use all available threads. This value is
+ *                validated to ensure that it's in a valid range.
+ * @return Thread configuration
+ */
+inline ThreadConfig ConfigureThreadConfig(int nthread) {
+  if (nthread <= 0) {
+    nthread = MaxNumThread();
+    TREELITE_CHECK_GE(nthread, 1) << "Invalid number of threads configured in OpenMP";
+  } else {
+    TREELITE_CHECK_LE(nthread, MaxNumThread())
+      << "nthread cannot exceed " << MaxNumThread() << " (configured by OpenMP).";
+  }
+  return ThreadConfig{nthread};
 }
 
 // OpenMP schedule
@@ -74,10 +105,8 @@ struct ParallelSchedule {
 };
 
 template <typename IndexType, typename FuncType>
-inline void ParallelFor(IndexType begin, IndexType end, int nthread, ParallelSchedule sched,
-                        FuncType func) {
-  TREELITE_CHECK_GT(nthread, 0) << "nthread must be positive";
-  TREELITE_CHECK_LE(nthread, MaxNumThread()) << "nthread cannot exceed " << MaxNumThread();
+inline void ParallelFor(IndexType begin, IndexType end, ThreadConfig thread_config,
+                        ParallelSchedule sched, FuncType func) {
   if (begin == end) {
     return;
   }
@@ -92,7 +121,7 @@ inline void ParallelFor(IndexType begin, IndexType end, int nthread, ParallelSch
   OMPException exc;
   switch (sched.sched) {
   case ParallelSchedule::kAuto: {
-#pragma omp parallel for num_threads(nthread)
+#pragma omp parallel for num_threads(thread_config.nthread)
     for (OmpInd i = begin; i < end; ++i) {
       exc.Run(func, static_cast<IndexType>(i), omp_get_thread_num());
     }
@@ -100,12 +129,12 @@ inline void ParallelFor(IndexType begin, IndexType end, int nthread, ParallelSch
   }
   case ParallelSchedule::kDynamic: {
     if (sched.chunk == 0) {
-#pragma omp parallel for num_threads(nthread) schedule(dynamic)
+#pragma omp parallel for num_threads(thread_config.nthread) schedule(dynamic)
       for (OmpInd i = begin; i < end; ++i) {
         exc.Run(func, static_cast<IndexType>(i), omp_get_thread_num());
       }
     } else {
-#pragma omp parallel for num_threads(nthread) schedule(dynamic, sched.chunk)
+#pragma omp parallel for num_threads(thread_config.nthread) schedule(dynamic, sched.chunk)
       for (OmpInd i = begin; i < end; ++i) {
         exc.Run(func, static_cast<IndexType>(i), omp_get_thread_num());
       }
@@ -114,12 +143,12 @@ inline void ParallelFor(IndexType begin, IndexType end, int nthread, ParallelSch
   }
   case ParallelSchedule::kStatic: {
     if (sched.chunk == 0) {
-#pragma omp parallel for num_threads(nthread) schedule(static)
+#pragma omp parallel for num_threads(thread_config.nthread) schedule(static)
       for (OmpInd i = begin; i < end; ++i) {
         exc.Run(func, static_cast<IndexType>(i), omp_get_thread_num());
       }
     } else {
-#pragma omp parallel for num_threads(nthread) schedule(static, sched.chunk)
+#pragma omp parallel for num_threads(thread_config.nthread) schedule(static, sched.chunk)
       for (OmpInd i = begin; i < end; ++i) {
         exc.Run(func, static_cast<IndexType>(i), omp_get_thread_num());
       }
@@ -127,7 +156,7 @@ inline void ParallelFor(IndexType begin, IndexType end, int nthread, ParallelSch
     break;
   }
   case ParallelSchedule::kGuided: {
-#pragma omp parallel for num_threads(nthread) schedule(guided)
+#pragma omp parallel for num_threads(thread_config.nthread) schedule(guided)
     for (OmpInd i = begin; i < end; ++i) {
       exc.Run(func, static_cast<IndexType>(i), omp_get_thread_num());
     }

--- a/src/threading_utils/parallel_for.h
+++ b/src/threading_utils/parallel_for.h
@@ -14,6 +14,7 @@
 #include <exception>
 #include <mutex>
 #include <cstddef>
+#include <cstdint>
 
 namespace treelite {
 namespace threading_utils {
@@ -68,7 +69,7 @@ inline int MaxNumThread() {
  * \brief Represent thread configuration, to be used with parallel loops.
  */
 struct ThreadConfig {
-  int nthread;
+  std::uint32_t nthread;
 };
 
 /*!
@@ -85,7 +86,7 @@ inline ThreadConfig ConfigureThreadConfig(int nthread) {
     TREELITE_CHECK_LE(nthread, MaxNumThread())
       << "nthread cannot exceed " << MaxNumThread() << " (configured by OpenMP).";
   }
-  return ThreadConfig{nthread};
+  return ThreadConfig{static_cast<std::uint32_t>(nthread)};
 }
 
 // OpenMP schedule

--- a/src/threading_utils/parallel_for.h
+++ b/src/threading_utils/parallel_for.h
@@ -105,7 +105,7 @@ struct ParallelSchedule {
 };
 
 template <typename IndexType, typename FuncType>
-inline void ParallelFor(IndexType begin, IndexType end, ThreadConfig thread_config,
+inline void ParallelFor(IndexType begin, IndexType end, const ThreadConfig& thread_config,
                         ParallelSchedule sched, FuncType func) {
   if (begin == end) {
     return;

--- a/tests/cpp/test_threading_utils.cc
+++ b/tests/cpp/test_threading_utils.cc
@@ -58,9 +58,7 @@ TEST(ThreadingUtils, ParallelFor) {
 
   auto sched = treelite::threading_utils::ParallelSchedule::Guided();
 
-  auto dummy_func = [](int, int) {};
-  EXPECT_THROW(ParallelFor(0, 100, 0, sched, dummy_func), treelite::Error);
-  EXPECT_THROW(ParallelFor(10, 20, 3 * max_thread, sched, dummy_func), treelite::Error);
+  EXPECT_THROW(threading_utils::ConfigureThreadConfig(max_thread * 3), treelite::Error);
 
   /* Property-based testing with randomly generated parameters */
   constexpr int kVectorLength = 10000;
@@ -78,10 +76,11 @@ TEST(ThreadingUtils, ParallelFor) {
 
     // Compute c := a + b on range [begin, end)
     int64_t begin = rng.DrawInteger(0, kVectorLength);
-    std::size_t nthread = static_cast<std::size_t>(rng.DrawInteger(1, max_thread + 1));
+    auto thread_config = threading_utils::ConfigureThreadConfig(
+        static_cast<int>(rng.DrawInteger(1, max_thread + 1)));
     int64_t end = rng.DrawInteger(begin, kVectorLength);
 
-    ParallelFor(begin, end, nthread, sched, [&a, &b, &c](int64_t i, int) {
+    ParallelFor(begin, end, thread_config, sched, [&a, &b, &c](int64_t i, int) {
       c[i] = a[i] + b[i];
     });
 


### PR DESCRIPTION
* Recognize `OMP_THREAD_LIMIT` environment variable. See https://github.com/dmlc/xgboost/pull/7390
* Define `ConfigureThreadConfig()` utility function to robustly sanitize user-provided `nthread` argument.
* Wrap sanitized `nthread` into `ThreadConfig`, to make it clear whether the value is sanitized. Now `ParallelFor()` construct takes in `ThreadConfig` instead of a raw integer `nthread`.