### PR TITLE
Speed up multithreaded GTIL prediction using tiles

### DIFF
--- a/include/treelite/c_api.h
+++ b/include/treelite/c_api.h
@@ -410,9 +410,31 @@ TREELITE_DLL int TreeliteFreeModel(ModelHandle handle);
  * \{
  */
 
-TREELITE_DLL int TreeliteGTILGetPredictOutputSize(ModelHandle handle, size_t num_row, size_t* out);
+/*!
+ * \brief Given a batch of data rows, query the necessary size of array to hold predictions for all
+ *        data points.
+ * \param model Treelite Model object
+ * \param num_row Number of rows in the input
+ * \param out Size of output buffer that should be allocated
+ * \return 0 for success; -1 for failure
+ */
+TREELITE_DLL int TreeliteGTILGetPredictOutputSize(ModelHandle model, size_t num_row, size_t* out);
 
-TREELITE_DLL int TreeliteGTILPredict(ModelHandle handle, const float* input, size_t num_row,
+/*!
+ * \brief Predict with a 2D dense array
+ * \param model Treelite Model object
+ * \param input The 2D data array, laid out in row-major layout
+ * \param num_row Number of rows in the data matrix.
+ * \param output Pointer to buffer to store the output. Call TreeliteGTILGetPredictOutputSize()
+ *               to get the amount of buffer you should allocate for this parameter.
+ * \param nthread number of CPU threads to use. Set <= 0 to use all CPU cores.
+ * \param pred_transform After computing the prediction score, whether to transform it.
+ * \param out_result_size Size of output. This could be smaller than
+ *                        TreeliteGTILGetPredictOutputSize() but could never be larger than
+ *                        TreeliteGTILGetPredictOutputSize().
+ * \return 0 for success; -1 for failure
+ */
+TREELITE_DLL int TreeliteGTILPredict(ModelHandle model, const float* input, size_t num_row,
                                      float* output, int nthread, int pred_transform,
                                      size_t* out_result_size);
 

--- a/include/treelite/gtil.h
+++ b/include/treelite/gtil.h
@@ -33,9 +33,10 @@ namespace gtil {
 std::size_t Predict(const Model* model, const DMatrix* input, float* output, int nthread,
                     bool pred_transform);
 /*!
- * \brief Predict with a 2D dense matrix
+ * \brief Predict with a 2D dense array
  * \param model The model object
- * \param input The data matrix, laid out in row-major layout
+ * \param input The 2D data array, laid out in row-major layout
+ * \param num_row Number of rows in the data matrix.
  * \param output Pointer to buffer to store the output. Call GetPredictOutputSize() to get the
  *               amount of buffer you should allocate for this parameter.
  * \param nthread number of CPU threads to use. Set <= 0 to use all CPU cores.
@@ -45,9 +46,21 @@ std::size_t Predict(const Model* model, const DMatrix* input, float* output, int
  */
 std::size_t Predict(const Model* model, const float* input, std::size_t num_row, float* output,
                     int nthread, bool pred_transform);
-
-// Query functions to allocate correct amount of memory for the output
+/*!
+ * \brief Given a batch of data rows, query the necessary size of array to hold predictions for all
+ *        data points.
+ * \param model Treelite Model object
+ * \param num_row Number of rows in the input
+ * \return Size of output buffer that should be allocated
+ */
 std::size_t GetPredictOutputSize(const Model* model, std::size_t num_row);
+/*!
+ * \brief Given a batch of data rows, query the necessary size of array to hold predictions for all
+ *        data points.
+ * \param model Treelite Model object
+ * \param input The input matrix
+ * \return Size of output buffer that should be allocated
+ */
 std::size_t GetPredictOutputSize(const Model* model, const DMatrix* input);
 
 }  // namespace gtil

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -275,12 +275,15 @@ class Tree {
       return cright_;
     }
     inline bool DefaultLeft() const {
+      // Extract the most significant bit (MSB) of sindex_, which encodes the default_left field
       return (sindex_ >> 31U) != 0;
     }
     inline int DefaultChild() const {
+      // Extract the most significant bit (MSB) of sindex_, which encodes the default_left field
       return ((sindex_ >> 31U) != 0) ? cleft_ : cright_;
     }
     inline std::uint32_t SplitIndex() const {
+      // Extract all bits except the most significant bit (MSB) from sindex_.
       return (sindex_ & ((1U << 31U) - 1U));
     }
     inline bool IsLeaf() const {

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -349,14 +349,14 @@ class Tree {
    * \param nid ID of node being queried
    */
   inline int LeftChild(int nid) const {
-    return nodes_.at(nid).cleft_;
+    return nodes_[nid].cleft_;
   }
   /*!
    * \brief index of the node's right child
    * \param nid ID of node being queried
    */
   inline int RightChild(int nid) const {
-    return nodes_.at(nid).cright_;
+    return nodes_[nid].cright_;
   }
   /*!
    * \brief index of the node's "default" child, used when feature is missing
@@ -370,36 +370,36 @@ class Tree {
    * \param nid ID of node being queried
    */
   inline uint32_t SplitIndex(int nid) const {
-    return (nodes_.at(nid).sindex_ & ((1U << 31U) - 1U));
+    return (nodes_[nid].sindex_ & ((1U << 31U) - 1U));
   }
   /*!
    * \brief whether to use the left child node, when the feature in the split condition is missing
    * \param nid ID of node being queried
    */
   inline bool DefaultLeft(int nid) const {
-    return (nodes_.at(nid).sindex_ >> 31U) != 0;
+    return (nodes_[nid].sindex_ >> 31U) != 0;
   }
   /*!
    * \brief whether the node is leaf node
    * \param nid ID of node being queried
    */
   inline bool IsLeaf(int nid) const {
-    return nodes_.at(nid).cleft_ == -1;
+    return nodes_[nid].cleft_ == -1;
   }
   /*!
    * \brief get leaf value of the leaf node
    * \param nid ID of node being queried
    */
   inline LeafOutputType LeafValue(int nid) const {
-    return (nodes_.at(nid).info_).leaf_value;
+    return (nodes_[nid].info_).leaf_value;
   }
   /*!
    * \brief get leaf vector of the leaf node; useful for multi-class random forest classifier
    * \param nid ID of node being queried
    */
   inline std::vector<LeafOutputType> LeafVector(int nid) const {
-    const std::size_t offset_begin = leaf_vector_begin_.at(nid);
-    const std::size_t offset_end = leaf_vector_end_.at(nid);
+    const std::size_t offset_begin = leaf_vector_begin_[nid];
+    const std::size_t offset_end = leaf_vector_end_[nid];
     if (offset_begin >= leaf_vector_.Size() || offset_end > leaf_vector_.Size()) {
       // Return empty vector, to indicate the lack of leaf vector
       return std::vector<LeafOutputType>();
@@ -414,21 +414,21 @@ class Tree {
    * \param nid ID of node being queried
    */
   inline bool HasLeafVector(int nid) const {
-    return leaf_vector_begin_.at(nid) != leaf_vector_end_.at(nid);
+    return leaf_vector_begin_[nid] != leaf_vector_end_[nid];
   }
   /*!
    * \brief get threshold of the node
    * \param nid ID of node being queried
    */
   inline ThresholdType Threshold(int nid) const {
-    return (nodes_.at(nid).info_).threshold;
+    return (nodes_[nid].info_).threshold;
   }
   /*!
    * \brief get comparison operator
    * \param nid ID of node being queried
    */
   inline Operator ComparisonOp(int nid) const {
-    return nodes_.at(nid).cmp_;
+    return nodes_[nid].cmp_;
   }
   /*!
    * \brief Get list of all categories belonging to the left/right child node. See the
@@ -439,8 +439,8 @@ class Tree {
    * \param nid ID of node being queried
    */
   inline std::vector<uint32_t> MatchingCategories(int nid) const {
-    const std::size_t offset_begin = matching_categories_offset_.at(nid);
-    const std::size_t offset_end = matching_categories_offset_.at(nid + 1);
+    const std::size_t offset_begin = matching_categories_offset_[nid];
+    const std::size_t offset_end = matching_categories_offset_[nid + 1];
     if (offset_begin >= matching_categories_.Size() || offset_end > matching_categories_.Size()) {
       // Return empty vector, to indicate the lack of any matching categories
       // The node might be a numerical split
@@ -456,21 +456,21 @@ class Tree {
    * \param nid ID of node being queried
    */
   inline SplitFeatureType SplitType(int nid) const {
-    return nodes_.at(nid).split_type_;
+    return nodes_[nid].split_type_;
   }
   /*!
    * \brief test whether this node has data count
    * \param nid ID of node being queried
    */
   inline bool HasDataCount(int nid) const {
-    return nodes_.at(nid).data_count_present_;
+    return nodes_[nid].data_count_present_;
   }
   /*!
    * \brief get data count
    * \param nid ID of node being queried
    */
   inline uint64_t DataCount(int nid) const {
-    return nodes_.at(nid).data_count_;
+    return nodes_[nid].data_count_;
   }
 
   /*!
@@ -478,28 +478,28 @@ class Tree {
    * \param nid ID of node being queried
    */
   inline bool HasSumHess(int nid) const {
-    return nodes_.at(nid).sum_hess_present_;
+    return nodes_[nid].sum_hess_present_;
   }
   /*!
    * \brief get hessian sum
    * \param nid ID of node being queried
    */
   inline double SumHess(int nid) const {
-    return nodes_.at(nid).sum_hess_;
+    return nodes_[nid].sum_hess_;
   }
   /*!
    * \brief test whether this node has gain value
    * \param nid ID of node being queried
    */
   inline bool HasGain(int nid) const {
-    return nodes_.at(nid).gain_present_;
+    return nodes_[nid].gain_present_;
   }
   /*!
    * \brief get gain value
    * \param nid ID of node being queried
    */
   inline double Gain(int nid) const {
-    return nodes_.at(nid).gain_;
+    return nodes_[nid].gain_;
   }
   /*!
    * \brief test whether the list given by MatchingCategories(nid) is associated with the right
@@ -507,7 +507,7 @@ class Tree {
    * \param nid ID of node being queried
    */
   inline bool CategoriesListRightChild(int nid) const {
-    return nodes_.at(nid).categories_list_right_child_;
+    return nodes_[nid].categories_list_right_child_;
   }
 
   /** Setters **/

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -306,8 +306,9 @@ class Tree {
   // here
   ContiguousArray<std::size_t> leaf_vector_begin_;
   ContiguousArray<std::size_t> leaf_vector_end_;
-  ContiguousArray<uint32_t> matching_categories_;
+  ContiguousArray<std::uint32_t> matching_categories_;
   ContiguousArray<std::size_t> matching_categories_offset_;
+  bool has_categorical_split_{false};
 
   template <typename WriterType, typename X, typename Y>
   friend void DumpModelAsJSON(WriterType& writer, const ModelImpl<X, Y>& model);
@@ -336,12 +337,6 @@ class Tree {
    * \param nid node id to add children to
    */
   inline void AddChilds(int nid);
-
-  /*!
-   * \brief get list of all categorical features that have appeared anywhere in tree
-   * \return list of all categorical features used
-   */
-  inline std::vector<unsigned> GetCategoricalFeatures() const;
 
   /** Getters **/
   /*!
@@ -508,6 +503,13 @@ class Tree {
    */
   inline bool CategoriesListRightChild(int nid) const {
     return nodes_[nid].categories_list_right_child_;
+  }
+
+  /*!
+   * \brief Query whether this tree contains any categorical splits
+   */
+  inline bool HasCategoricalSplit() const {
+    return has_categorical_split_;
   }
 
   /** Setters **/

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -278,7 +278,7 @@ class Tree {
       return (sindex_ >> 31U) != 0;
     }
     inline int DefaultChild() const {
-      return DefaultLeft() ? LeftChild() : RightChild();
+      return ((sindex_ >> 31U) != 0) ? cleft_ : cright_;
     }
     inline std::uint32_t SplitIndex() const {
       return (sindex_ & ((1U << 31U) - 1U));

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -31,6 +31,8 @@
 
 namespace treelite {
 
+class GTILBridge;
+
 template <typename ThresholdType, typename LeafOutputType>
 class ModelImpl;
 
@@ -223,19 +225,19 @@ class Tree {
       ThresholdType threshold;   // for non-leaf nodes
     };
     /*! \brief pointer to left and right children */
-    int32_t cleft_, cright_;
+    std::int32_t cleft_, cright_;
     /*!
      * \brief feature index used for the split
      * highest bit indicates default direction for missing values
      */
-    uint32_t sindex_;
+    std::uint32_t sindex_;
     /*! \brief storage for leaf value or decision threshold */
     Info info_;
     /*!
      * \brief number of data points whose traversal paths include this node.
      *        LightGBM models natively store this statistics.
      */
-    uint64_t data_count_;
+    std::uint64_t data_count_;
     /*!
      * \brief sum of hessian values for all data points whose traversal paths
      *        include this node. This value is generally correlated positively
@@ -264,6 +266,59 @@ class Tree {
     /* \brief whether the list given by MatchingCategories(nid) is associated with the right child
      *        node or the left child node. True if the right child, False otherwise */
     bool categories_list_right_child_;
+
+    /** Getters **/
+    inline int LeftChild() const {
+      return cleft_;
+    }
+    inline int RightChild() const {
+      return cright_;
+    }
+    inline bool DefaultLeft() const {
+      return (sindex_ >> 31U) != 0;
+    }
+    inline int DefaultChild() const {
+      return DefaultLeft() ? LeftChild() : RightChild();
+    }
+    inline std::uint32_t SplitIndex() const {
+      return (sindex_ & ((1U << 31U) - 1U));
+    }
+    inline bool IsLeaf() const {
+      return cleft_ == -1;
+    }
+    inline LeafOutputType LeafValue() const {
+      return info_.leaf_value;
+    }
+    inline ThresholdType Threshold() const {
+      return info_.threshold;
+    }
+    inline Operator ComparisonOp() const {
+      return cmp_;
+    }
+    inline SplitFeatureType SplitType() const {
+      return split_type_;
+    }
+    inline bool HasDataCount() const {
+      return data_count_present_;
+    }
+    inline std::uint64_t DataCount() const {
+      return data_count_;
+    }
+    inline bool HasSumHess() const {
+      return sum_hess_present_;
+    }
+    inline double SumHess() const {
+      return sum_hess_;
+    }
+    inline bool HasGain() const {
+      return gain_present_;
+    }
+    inline double Gain() const {
+      return gain_;
+    }
+    inline bool CategoriesListRightChild() const {
+      return categories_list_right_child_;
+    }
   };
 
   static_assert(std::is_pod<Node>::value, "Node must be a POD type");
@@ -327,6 +382,8 @@ class Tree {
   inline void
   DeserializeTemplate(ScalarHandler scalar_handler, ArrayHandler array_handler);
 
+  friend class GTILBridge;  // bridge to enable optimized access to nodes from GTIL
+
  public:
   /*! \brief number of nodes */
   int num_nodes;
@@ -344,49 +401,49 @@ class Tree {
    * \param nid ID of node being queried
    */
   inline int LeftChild(int nid) const {
-    return nodes_[nid].cleft_;
+    return nodes_[nid].LeftChild();
   }
   /*!
    * \brief index of the node's right child
    * \param nid ID of node being queried
    */
   inline int RightChild(int nid) const {
-    return nodes_[nid].cright_;
+    return nodes_[nid].RightChild();
   }
   /*!
    * \brief index of the node's "default" child, used when feature is missing
    * \param nid ID of node being queried
    */
   inline int DefaultChild(int nid) const {
-    return DefaultLeft(nid) ? LeftChild(nid) : RightChild(nid);
+    return nodes_[nid].DefaultChild();
   }
   /*!
    * \brief feature index of the node's split condition
    * \param nid ID of node being queried
    */
-  inline uint32_t SplitIndex(int nid) const {
-    return (nodes_[nid].sindex_ & ((1U << 31U) - 1U));
+  inline std::uint32_t SplitIndex(int nid) const {
+    return nodes_[nid].SplitIndex();
   }
   /*!
    * \brief whether to use the left child node, when the feature in the split condition is missing
    * \param nid ID of node being queried
    */
   inline bool DefaultLeft(int nid) const {
-    return (nodes_[nid].sindex_ >> 31U) != 0;
+    return nodes_[nid].DefaultLeft();
   }
   /*!
    * \brief whether the node is leaf node
    * \param nid ID of node being queried
    */
   inline bool IsLeaf(int nid) const {
-    return nodes_[nid].cleft_ == -1;
+    return nodes_[nid].IsLeaf();
   }
   /*!
    * \brief get leaf value of the leaf node
    * \param nid ID of node being queried
    */
   inline LeafOutputType LeafValue(int nid) const {
-    return (nodes_[nid].info_).leaf_value;
+    return nodes_[nid].LeafValue();
   }
   /*!
    * \brief get leaf vector of the leaf node; useful for multi-class random forest classifier
@@ -416,14 +473,14 @@ class Tree {
    * \param nid ID of node being queried
    */
   inline ThresholdType Threshold(int nid) const {
-    return (nodes_[nid].info_).threshold;
+    return nodes_[nid].Threshold();
   }
   /*!
    * \brief get comparison operator
    * \param nid ID of node being queried
    */
   inline Operator ComparisonOp(int nid) const {
-    return nodes_[nid].cmp_;
+    return nodes_[nid].ComparisonOp();
   }
   /*!
    * \brief Get list of all categories belonging to the left/right child node. See the
@@ -433,16 +490,16 @@ class Tree {
    *        assumed to be in ascending order.
    * \param nid ID of node being queried
    */
-  inline std::vector<uint32_t> MatchingCategories(int nid) const {
+  inline std::vector<std::uint32_t> MatchingCategories(int nid) const {
     const std::size_t offset_begin = matching_categories_offset_[nid];
     const std::size_t offset_end = matching_categories_offset_[nid + 1];
     if (offset_begin >= matching_categories_.Size() || offset_end > matching_categories_.Size()) {
       // Return empty vector, to indicate the lack of any matching categories
       // The node might be a numerical split
-      return std::vector<uint32_t>();
+      return std::vector<std::uint32_t>();
     }
-    return std::vector<uint32_t>(&matching_categories_[offset_begin],
-                                 &matching_categories_[offset_end]);
+    return std::vector<std::uint32_t>(&matching_categories_[offset_begin],
+                                      &matching_categories_[offset_end]);
       // Use unsafe access here, since we may need to take the address of one past the last
       // element, to follow with the range semantic of std::vector<>.
   }
@@ -451,21 +508,21 @@ class Tree {
    * \param nid ID of node being queried
    */
   inline SplitFeatureType SplitType(int nid) const {
-    return nodes_[nid].split_type_;
+    return nodes_[nid].SplitType();
   }
   /*!
    * \brief test whether this node has data count
    * \param nid ID of node being queried
    */
   inline bool HasDataCount(int nid) const {
-    return nodes_[nid].data_count_present_;
+    return nodes_[nid].HasDataCount();
   }
   /*!
    * \brief get data count
    * \param nid ID of node being queried
    */
-  inline uint64_t DataCount(int nid) const {
-    return nodes_[nid].data_count_;
+  inline std::uint64_t DataCount(int nid) const {
+    return nodes_[nid].DataCount();
   }
 
   /*!
@@ -473,28 +530,28 @@ class Tree {
    * \param nid ID of node being queried
    */
   inline bool HasSumHess(int nid) const {
-    return nodes_[nid].sum_hess_present_;
+    return nodes_[nid].HasSumHess();
   }
   /*!
    * \brief get hessian sum
    * \param nid ID of node being queried
    */
   inline double SumHess(int nid) const {
-    return nodes_[nid].sum_hess_;
+    return nodes_[nid].SumHess();
   }
   /*!
    * \brief test whether this node has gain value
    * \param nid ID of node being queried
    */
   inline bool HasGain(int nid) const {
-    return nodes_[nid].gain_present_;
+    return nodes_[nid].HasGain();
   }
   /*!
    * \brief get gain value
    * \param nid ID of node being queried
    */
   inline double Gain(int nid) const {
-    return nodes_[nid].gain_;
+    return nodes_[nid].Gain();
   }
   /*!
    * \brief test whether the list given by MatchingCategories(nid) is associated with the right
@@ -502,7 +559,7 @@ class Tree {
    * \param nid ID of node being queried
    */
   inline bool CategoriesListRightChild(int nid) const {
-    return nodes_[nid].categories_list_right_child_;
+    return nodes_[nid].CategoriesListRightChild();
   }
 
   /*!

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -255,17 +255,17 @@ int TreeliteFreeModel(ModelHandle handle) {
   API_END();
 }
 
-int TreeliteGTILGetPredictOutputSize(ModelHandle handle, size_t num_row, size_t* out) {
+int TreeliteGTILGetPredictOutputSize(ModelHandle model, size_t num_row, size_t* out) {
   API_BEGIN();
-  const auto* model_ = static_cast<const Model*>(handle);
+  const auto* model_ = static_cast<const Model*>(model);
   *out = gtil::GetPredictOutputSize(model_, num_row);
   API_END();
 }
 
-int TreeliteGTILPredict(ModelHandle handle, const float* input, size_t num_row, float* output,
+int TreeliteGTILPredict(ModelHandle model, const float* input, size_t num_row, float* output,
                         int nthread, int pred_transform, size_t* out_result_size) {
   API_BEGIN();
-  const auto* model_ = static_cast<const Model*>(handle);
+  const auto* model_ = static_cast<const Model*>(model);
   *out_result_size =
       gtil::Predict(model_, input, num_row, output, nthread, (pred_transform == 1));
   API_END();

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -87,11 +87,15 @@ class FVec {
 
 template <typename ThresholdType>
 inline int NextNode(float fvalue, ThresholdType threshold, treelite::Operator op, int left_child) {
+  // XGBoost
+  if (op == treelite::Operator::kLT) {
+    return left_child + !(fvalue < threshold);
+  }
+  // LightGBM, sklearn, cuML RF
+  if (op == treelite::Operator::kLE) {
+    return left_child + !(fvalue <= threshold);
+  }
   switch (op) {
-    case treelite::Operator::kLT:
-      return left_child + !(fvalue < threshold);
-    case treelite::Operator::kLE:
-      return left_child + !(fvalue <= threshold);
     case treelite::Operator::kEQ:
       return left_child + !(fvalue == threshold);
     case treelite::Operator::kGT:

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -39,10 +39,7 @@ using PredTransformFuncType = std::size_t (*) (const treelite::Model&, const flo
 
 template <typename ThresholdType>
 inline int NextNode(float fvalue, ThresholdType threshold, treelite::Operator op,
-                    int left_child, int right_child, int default_child) {
-  if (std::isnan(fvalue)) {
-    return default_child;
-  }
+                    int left_child, int right_child) {
   switch (op) {
     case treelite::Operator::kLT:
       return (fvalue < threshold) ? left_child : right_child;
@@ -61,11 +58,7 @@ inline int NextNode(float fvalue, ThresholdType threshold, treelite::Operator op
 }
 
 inline int NextNodeCategorical(float fvalue, const std::vector<std::uint32_t>& matching_categories,
-                               bool categories_list_right_child, int left_child, int right_child,
-                               int default_child) {
-  if (std::isnan(fvalue)) {
-    return default_child;
-  }
+                               bool categories_list_right_child, int left_child, int right_child) {
   bool is_matching_category;
   auto max_representable_int = static_cast<float>(std::uint32_t(1) << FLT_MANT_DIG);
   if (fvalue < 0 || std::fabs(fvalue) > max_representable_int) {
@@ -193,10 +186,10 @@ void PredValueByOneTree(const treelite::Tree<ThresholdType, LeafOutputType>& tre
       if (has_categorical && node->SplitType() == treelite::SplitFeatureType::kCategorical) {
         node_id = NextNodeCategorical(fvalue, tree.MatchingCategories(node_id),
                                       node->CategoriesListRightChild(), node->LeftChild(),
-                                      node->RightChild(), node->DefaultChild());
+                                      node->RightChild());
       } else {
         node_id = NextNode(fvalue, node->Threshold(), node->ComparisonOp(), node->LeftChild(),
-                           node->RightChild(), node->DefaultChild());
+                           node->RightChild());
       }
     }
     node = treelite::GTILBridge::GetNode(tree, node_id);

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -200,7 +200,7 @@ void PredictByAllTrees(const treelite::ModelImpl<ThresholdType, LeafOutputType>&
   const std::size_t num_tree = model.trees.size();
   for (std::size_t tree_id = 0; tree_id < num_tree; ++tree_id) {
     const treelite::Tree<ThresholdType, LeafOutputType>& tree = model.trees[tree_id];
-    auto has_categorical = !tree.GetCategoricalFeatures().empty();
+    auto has_categorical = tree.HasCategoricalSplit();
     if (has_categorical) {
       for (std::size_t i = 0; i < block_size; ++i) {
         PredValueByOneTree<true, OutputLogic>(tree, tree_id,

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -90,15 +90,15 @@ inline int NextNode(float fvalue, ThresholdType threshold, treelite::Operator op
                     int left_child, int right_child) {
   switch (op) {
     case treelite::Operator::kLT:
-      return (fvalue < threshold) ? left_child : right_child;
+      return left_child + !(fvalue < threshold);
     case treelite::Operator::kLE:
-      return (fvalue <= threshold) ? left_child : right_child;
+      return left_child + !(fvalue <= threshold);
     case treelite::Operator::kEQ:
-      return (fvalue == threshold) ? left_child : right_child;
+      return left_child + !(fvalue == threshold);
     case treelite::Operator::kGT:
-      return (fvalue > threshold) ? left_child : right_child;
+      return left_child + !(fvalue > threshold);
     case treelite::Operator::kGE:
-      return (fvalue >= threshold) ? left_child : right_child;
+      return left_child + !(fvalue >= threshold);
     default:
       TREELITE_CHECK(false) << "Unrecognized comparison operator " << static_cast<int>(op);
       return -1;

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -86,8 +86,7 @@ class FVec {
 };
 
 template <typename ThresholdType>
-inline int NextNode(float fvalue, ThresholdType threshold, treelite::Operator op,
-                    int left_child, int right_child) {
+inline int NextNode(float fvalue, ThresholdType threshold, treelite::Operator op, int left_child) {
   switch (op) {
     case treelite::Operator::kLT:
       return left_child + !(fvalue < threshold);
@@ -240,8 +239,7 @@ void PredValueByOneTreeImpl(const treelite::Tree<ThresholdType, LeafOutputType>&
                                       node->CategoriesListRightChild(), node->LeftChild(),
                                       node->RightChild());
       } else {
-        node_id = NextNode(fvalue, node->Threshold(), node->ComparisonOp(), node->LeftChild(),
-                           node->RightChild());
+        node_id = NextNode(fvalue, node->Threshold(), node->ComparisonOp(), node->LeftChild());
       }
     }
     node = treelite::GTILBridge::GetNode(tree, node_id);

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -78,6 +78,7 @@ class FVec {
   bool HasMissing() const {
     return has_missing_;
   }
+
  private:
   std::vector<float> data_;
   std::vector<bool> missing_;

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -24,19 +24,19 @@ namespace {
 using treelite::threading_utils::ThreadConfig;
 using PredTransformFuncType = std::size_t (*) (const treelite::Model&, const float*, float*);
 
-template <typename T>
-inline int NextNode(float fvalue, T threshold, treelite::Operator op,
+template <typename ThresholdType>
+inline int NextNode(float fvalue, ThresholdType threshold, treelite::Operator op,
                     int left_child, int right_child, int default_child) {
   if (std::isnan(fvalue)) {
     return default_child;
   }
   switch (op) {
-    case treelite::Operator::kEQ:
-      return (fvalue == threshold) ? left_child : right_child;
     case treelite::Operator::kLT:
       return (fvalue < threshold) ? left_child : right_child;
     case treelite::Operator::kLE:
       return (fvalue <= threshold) ? left_child : right_child;
+    case treelite::Operator::kEQ:
+      return (fvalue == threshold) ? left_child : right_child;
     case treelite::Operator::kGT:
       return (fvalue > threshold) ? left_child : right_child;
     case treelite::Operator::kGE:
@@ -47,18 +47,18 @@ inline int NextNode(float fvalue, T threshold, treelite::Operator op,
   }
 }
 
-inline int NextNodeCategorical(float fvalue, const std::vector<uint32_t>& matching_categories,
+inline int NextNodeCategorical(float fvalue, const std::vector<std::uint32_t>& matching_categories,
                                bool categories_list_right_child, int left_child, int right_child,
                                int default_child) {
   if (std::isnan(fvalue)) {
     return default_child;
   }
   bool is_matching_category;
-  float max_representable_int = static_cast<float>(uint32_t(1) << FLT_MANT_DIG);
+  auto max_representable_int = static_cast<float>(std::uint32_t(1) << FLT_MANT_DIG);
   if (fvalue < 0 || std::fabs(fvalue) > max_representable_int) {
     is_matching_category = false;
   } else {
-    const auto category_value = static_cast<uint32_t>(fvalue);
+    const auto category_value = static_cast<std::uint32_t>(fvalue);
     is_matching_category = (
         std::find(matching_categories.begin(), matching_categories.end(), category_value)
         != matching_categories.end());
@@ -70,100 +70,237 @@ inline int NextNodeCategorical(float fvalue, const std::vector<uint32_t>& matchi
   }
 }
 
-template <typename ThresholdType, typename LeafOutputType, typename DMatrixType,
-          typename OutputFunc>
-inline std::size_t PredictImplInner(const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
-                                    const DMatrixType* input, float* output,
-                                    const ThreadConfig& thread_config, bool pred_transform,
-                                    OutputFunc output_func) {
-  using TreeType = treelite::Tree<ThresholdType, LeafOutputType>;
-  const size_t num_row = input->GetNumRow();
-  const size_t num_col = input->GetNumCol();
-  std::vector<ThresholdType> row(num_col);
-  const treelite::TaskParam task_param = model.task_param;
-  std::vector<float> sum_tloc(task_param.num_class * thread_config.nthread);
-  std::vector<float> sum_tot(task_param.num_class);
+constexpr std::size_t kBlockOfRowsSize = 64;
 
-  // Query the size of output per input row.
-  // This is guaranteed to be at most GetPredictOutputSize(num_row=1).
+struct BinaryClfRegrOutputLogic {
+  template <typename ThresholdType, typename LeafOutputType>
+  inline static void PushOutput(const treelite::Tree<ThresholdType, LeafOutputType>& tree,
+                                std::size_t, int node_id, float* sum, std::size_t) {
+    sum[0] += tree.LeafValue(node_id);
+  }
+  inline static void ApplyAverageFactor(const treelite::TaskParam& task_param, std::size_t num_tree,
+                                        float* output, std::size_t batch_offset,
+                                        std::size_t block_size) {
+    const auto average_factor = static_cast<float>(num_tree);
+    const unsigned num_class = task_param.num_class;
+    for (std::size_t i = 0; i < block_size; ++i) {
+      for (unsigned k = 0; k < num_class; ++k) {
+        output[(batch_offset + i) * num_class + k] /= average_factor;
+      }
+    }
+  }
+};
+
+struct MultiClfGrovePerClassOutputLogic {
+  template <typename ThresholdType, typename LeafOutputType>
+  inline static void PushOutput(const treelite::Tree<ThresholdType, LeafOutputType>& tree,
+                                std::size_t tree_id, int node_id, float* sum,
+                                std::size_t num_class) {
+    sum[tree_id % num_class] += tree.LeafValue(node_id);
+  }
+  inline static void ApplyAverageFactor(const treelite::TaskParam& task_param, std::size_t num_tree,
+                                        float* output, std::size_t batch_offset,
+                                        std::size_t block_size) {
+    auto num_boosting_round = num_tree / static_cast<std::size_t>(task_param.num_class);
+    const auto average_factor = static_cast<float>(num_boosting_round);
+    const unsigned num_class = task_param.num_class;
+    for (std::size_t i = 0; i < block_size; ++i) {
+      for (unsigned k = 0; k < num_class; ++k) {
+        output[(batch_offset + i) * num_class + k] /= average_factor;
+      }
+    }
+  }
+};
+
+struct MultiClfProbDistLeafOutputLogic {
+  template <typename ThresholdType, typename LeafOutputType>
+  inline static void PushOutput(const treelite::Tree<ThresholdType, LeafOutputType>& tree,
+                                std::size_t tree_id, int node_id, float* sum,
+                                std::size_t num_class) {
+    auto leaf_vector = tree.LeafVector(node_id);
+    for (unsigned int i = 0; i < num_class; ++i) {
+      sum[i] += leaf_vector[i];
+    }
+  }
+  inline static void ApplyAverageFactor(const treelite::TaskParam& task_param, std::size_t num_tree,
+                                        float* output, std::size_t batch_offset,
+                                        std::size_t block_size) {
+    return BinaryClfRegrOutputLogic::ApplyAverageFactor(task_param, num_tree, output, batch_offset,
+                                                        block_size);
+  }
+};
+
+template <typename T1, typename T2>
+inline T1 DivRoundUp(const T1 a, const T2 b) {
+  return static_cast<T1>(std::ceil(static_cast<double>(a) / b));
+}
+
+template <typename ThresholdType, typename DMatrixType>
+void FVecFill(const std::size_t block_size, const std::size_t batch_offset,
+              const DMatrixType* input, const std::size_t fvec_offset, int num_feature,
+              std::vector<ThresholdType>& feats) {
+  for (std::size_t i = 0; i < block_size; ++i) {
+    const std::size_t row_id = batch_offset + i;
+    input->FillRow(row_id, &feats[(fvec_offset + i) * num_feature]);
+  }
+}
+
+template <typename ThresholdType, typename DMatrixType>
+void FVecDrop(const std::size_t block_size, const std::size_t batch_offset,
+              const DMatrixType* input, const std::size_t fvec_offset, int num_feature,
+              std::vector<ThresholdType>& feats) {
+  for (std::size_t i = 0; i < block_size; ++i) {
+    const std::size_t row_id = batch_offset + i;
+    input->ClearRow(row_id, &feats[(fvec_offset + i) * num_feature]);
+  }
+}
+
+template <typename ThresholdType, typename LeafOutputType, typename DMatrixType>
+inline void InitOutPredictions(const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
+                               const DMatrixType* input, float* output) {
+  const std::size_t num_row = input->GetNumRow();
+  const auto num_class = model.task_param.num_class;
+  std::fill(output, output + num_row * num_class, model.param.global_bias);
+}
+
+template <bool has_categorical, typename OutputLogic, typename ThresholdType,
+          typename LeafOutputType>
+void PredValueByOneTree(const treelite::Tree<ThresholdType, LeafOutputType>& tree,
+                        std::size_t tree_id, const ThresholdType* feats, float* output,
+                        std::size_t num_class) {
+  int node_id = 0;
+  while (!tree.IsLeaf(node_id)) {
+    const auto split_index = tree.SplitIndex(node_id);
+    const auto fvalue = feats[split_index];
+    if (std::isnan(fvalue)) {
+      node_id = tree.DefaultChild(node_id);
+    } else {
+      if (has_categorical && tree.SplitType(node_id) == treelite::SplitFeatureType::kCategorical) {
+        node_id = NextNodeCategorical(fvalue, tree.MatchingCategories(node_id),
+                                      tree.CategoriesListRightChild(node_id),
+                                      tree.LeftChild(node_id), tree.RightChild(node_id),
+                                      tree.DefaultChild(node_id));
+      } else {
+        node_id = NextNode(fvalue, tree.Threshold(node_id), tree.ComparisonOp(node_id),
+                           tree.LeftChild(node_id), tree.RightChild(node_id),
+                           tree.DefaultChild(node_id));
+      }
+    }
+  }
+  OutputLogic::PushOutput(tree, tree_id, node_id, output, num_class);
+}
+
+
+template <typename OutputLogic, typename ThresholdType, typename LeafOutputType>
+void PredictByAllTrees(const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
+                       float* output, const std::size_t batch_offset,
+                       const std::size_t num_class, const std::vector<ThresholdType>& feats,
+                       const std::size_t fvec_offset, const std::size_t block_size) {
+  const int num_feature = model.num_feature;
+  const std::size_t num_tree = model.trees.size();
+  for (std::size_t tree_id = 0; tree_id < num_tree; ++tree_id) {
+    const treelite::Tree<ThresholdType, LeafOutputType>& tree = model.trees[tree_id];
+    auto has_categorical = !tree.GetCategoricalFeatures().empty();
+    if (has_categorical) {
+      for (std::size_t i = 0; i < block_size; ++i) {
+        PredValueByOneTree<true, OutputLogic>(tree, tree_id,
+                                              &feats[(fvec_offset + i) * num_feature],
+                                              &output[(batch_offset + i) * num_class], num_class);
+      }
+    } else {
+      for (std::size_t i = 0; i < block_size; ++i) {
+        PredValueByOneTree<false, OutputLogic>(tree, tree_id,
+                                               &feats[(fvec_offset + i) * num_feature],
+                                               &output[(batch_offset + i) * num_class], num_class);
+      }
+    }
+  }
+}
+
+
+template <std::size_t block_of_rows_size, typename OutputLogic, typename ThresholdType,
+          typename LeafOutputType, typename DMatrixType>
+void PredictBatchByBlockOfRowsKernel(
+    const treelite::ModelImpl<ThresholdType, LeafOutputType>& model, const DMatrixType* input,
+    float* output, const ThreadConfig& thread_config) {
+  const std::size_t num_row = input->GetNumRow();
+  const int num_feature = model.num_feature;
+  const auto& task_param = model.task_param;
+  std::size_t n_blocks = DivRoundUp(num_row, block_of_rows_size);
+
+  std::vector<ThresholdType> feats(thread_config.nthread * block_of_rows_size * num_feature);
+  auto sched = treelite::threading_utils::ParallelSchedule::Static();
+  treelite::threading_utils::ParallelFor(std::size_t(0), n_blocks, thread_config, sched,
+                                         [&](std::size_t block_id, int thread_id) {
+    const std::size_t batch_offset = block_id * block_of_rows_size;
+    const std::size_t block_size =
+        std::min(num_row - batch_offset, block_of_rows_size);
+    const std::size_t fvec_offset = thread_id * block_of_rows_size;
+
+    FVecFill(block_size, batch_offset, input, fvec_offset, num_feature, feats);
+    // process block of rows through all trees to keep cache locality
+    PredictByAllTrees<OutputLogic>(model, output, batch_offset,
+                                   static_cast<std::size_t>(task_param.num_class), feats,
+                                   fvec_offset, block_size);
+    FVecDrop(block_size, batch_offset, input, fvec_offset, num_feature, feats);
+    if (model.average_tree_output) {
+      OutputLogic::ApplyAverageFactor(task_param, model.GetNumTree(), output, batch_offset,
+                                      block_size);
+    }
+  });
+}
+
+template <typename ThresholdType, typename LeafOutputType, typename DMatrixType>
+inline void PredictRaw(const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
+                       const DMatrixType* input, float* output, const ThreadConfig& thread_config) {
+  InitOutPredictions(model, input, output);
+
+  switch (model.task_type) {
+    case treelite::TaskType::kBinaryClfRegr:
+      PredictBatchByBlockOfRowsKernel<kBlockOfRowsSize, BinaryClfRegrOutputLogic>(
+          model, input, output, thread_config);
+      break;
+    case treelite::TaskType::kMultiClfGrovePerClass:
+      PredictBatchByBlockOfRowsKernel<kBlockOfRowsSize, MultiClfGrovePerClassOutputLogic>(
+          model, input, output, thread_config);
+      break;
+    case treelite::TaskType::kMultiClfProbDistLeaf:
+      PredictBatchByBlockOfRowsKernel<kBlockOfRowsSize, MultiClfProbDistLeafOutputLogic>(
+          model, input, output, thread_config);
+      break;
+    case treelite::TaskType::kMultiClfCategLeaf:
+    default:
+      TREELITE_LOG(FATAL)
+      << "Unsupported task type of the tree ensemble model: "
+      << static_cast<int>(model.task_type);
+  }
+}
+
+template <typename ThresholdType, typename LeafOutputType, typename DMatrixType>
+inline std::size_t PredTransform(const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
+                                 const DMatrixType* input, float* output,
+                                 const ThreadConfig& thread_config, bool pred_transform) {
   std::size_t output_size_per_row;
+  const auto num_class = model.task_param.num_class;
+  std::size_t num_row = input->GetNumRow();
   if (pred_transform) {
-    std::vector<float> temp(treelite::gtil::GetPredictOutputSize(&model, 1));
+    std::vector<float> temp(treelite::gtil::GetPredictOutputSize(&model, num_row));
     PredTransformFuncType pred_transform_func
         = treelite::gtil::LookupPredTransform(model.param.pred_transform);
-    output_size_per_row = pred_transform_func(model, sum_tloc.data(), temp.data());
-  } else {
-    output_size_per_row = task_param.num_class;
-  }
-
-  auto sched = treelite::threading_utils::ParallelSchedule::Static();
-  for (std::size_t row_id = 0; row_id < num_row; ++row_id) {
-    input->FillRow(row_id, row.data());
-    std::fill(sum_tloc.begin(), sum_tloc.end(), 0.0f);
-    std::fill(sum_tot.begin(), sum_tot.end(), 0.0f);
-    const std::size_t num_tree = model.trees.size();
-    treelite::threading_utils::ParallelFor(std::size_t(0), num_tree, thread_config, sched,
-                                           [&](std::size_t tree_id, int thread_id) {
-      float* sum = &sum_tloc[thread_id * task_param.num_class];
-      const TreeType& tree = model.trees[tree_id];
-      int node_id = 0;
-      while (!tree.IsLeaf(node_id)) {
-        treelite::SplitFeatureType split_type = tree.SplitType(node_id);
-        if (split_type == treelite::SplitFeatureType::kNumerical) {
-          node_id = NextNode(row[tree.SplitIndex(node_id)], tree.Threshold(node_id),
-                             tree.ComparisonOp(node_id), tree.LeftChild(node_id),
-                             tree.RightChild(node_id), tree.DefaultChild(node_id));
-        } else if (split_type == treelite::SplitFeatureType::kCategorical) {
-          node_id = NextNodeCategorical(row[tree.SplitIndex(node_id)],
-                                        tree.MatchingCategories(node_id),
-                                        tree.CategoriesListRightChild(node_id),
-                                        tree.LeftChild(node_id), tree.RightChild(node_id),
-                                        tree.DefaultChild(node_id));
-        } else {
-          TREELITE_CHECK(false) << "Unrecognized split type: " << static_cast<int>(split_type);
-        }
-      }
-      output_func(tree, tree_id, node_id, sum);
+    auto sched = treelite::threading_utils::ParallelSchedule::Static();
+    // Query the size of output per input row.
+    output_size_per_row = pred_transform_func(model, &output[0], &temp[0]);
+    // Now transform predictions in parallel
+    treelite::threading_utils::ParallelFor(std::size_t(0), num_row, thread_config, sched,
+                                           [&](std::size_t row_id, int thread_id) {
+      pred_transform_func(model, &output[row_id * num_class],
+                          &temp[row_id * output_size_per_row]);
     });
-    for (std::uint32_t thread_id = 0; thread_id < thread_config.nthread; ++thread_id) {
-      for (unsigned i = 0; i < task_param.num_class; ++i) {
-        sum_tot[i] += sum_tloc[thread_id * task_param.num_class + i];
-      }
-    }
-    if (model.average_tree_output) {
-      float average_factor;
-      if (model.task_type == treelite::TaskType::kMultiClfGrovePerClass) {
-        TREELITE_CHECK(task_param.grove_per_class);
-        TREELITE_CHECK_EQ(task_param.leaf_vector_size, 1);
-        TREELITE_CHECK_GT(task_param.num_class, 1);
-        TREELITE_CHECK_EQ(num_tree % task_param.num_class, 0)
-          << "Expected the number of trees to be divisible by the number of classes";
-        int num_boosting_round = num_tree / static_cast<int>(task_param.num_class);
-        average_factor = static_cast<float>(num_boosting_round);
-      } else {
-        TREELITE_CHECK(model.task_type == treelite::TaskType::kBinaryClfRegr
-                       || model.task_type == treelite::TaskType::kMultiClfProbDistLeaf);
-        TREELITE_CHECK(task_param.num_class == task_param.leaf_vector_size);
-        TREELITE_CHECK(!task_param.grove_per_class);
-        average_factor = static_cast<float>(num_tree);
-      }
-      for (unsigned int i = 0; i < task_param.num_class; ++i) {
-        sum_tot[i] /= average_factor;
-      }
-    }
-    for (unsigned int i = 0; i < task_param.num_class; ++i) {
-      sum_tot[i] += model.param.global_bias;
-    }
-    if (pred_transform) {
-      PredTransformFuncType pred_transform_func
-        = treelite::gtil::LookupPredTransform(model.param.pred_transform);
-      pred_transform_func(model, sum_tot.data(), &output[row_id * output_size_per_row]);
-    } else {
-      for (unsigned int i = 0; i < task_param.num_class; ++i) {
-        output[row_id * output_size_per_row + i] = sum_tot[i];
-      }
-    }
-    input->ClearRow(row_id, row.data());
+    // Copy transformed score back to output
+    temp.resize(output_size_per_row * num_row);
+    std::copy(temp.begin(), temp.end(), output);
+  } else {
+    output_size_per_row = model.task_param.num_class;
   }
   return output_size_per_row * num_row;
 }
@@ -172,34 +309,8 @@ template <typename ThresholdType, typename LeafOutputType, typename DMatrixType>
 inline std::size_t PredictImpl(const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
                                const DMatrixType* input, float* output,
                                const ThreadConfig& thread_config, bool pred_transform) {
-  using TreeType = treelite::Tree<ThresholdType, LeafOutputType>;
-  const treelite::TaskParam task_param = model.task_param;
-  if (task_param.num_class > 1) {
-    if (task_param.leaf_vector_size > 1) {
-      // multi-class classification with random forest
-      auto output_logic = [task_param](
-          const TreeType& tree, int, int node_id, float* sum) {
-        auto leaf_vector = tree.LeafVector(node_id);
-        for (unsigned int i = 0; i < task_param.leaf_vector_size; ++i) {
-          sum[i] += leaf_vector[i];
-        }
-      };
-      return PredictImplInner(model, input, output, thread_config, pred_transform, output_logic);
-    } else {
-      // multi-class classification with gradient boosted trees
-      auto output_logic = [task_param](
-          const TreeType& tree, int tree_id, int node_id, float* sum) {
-        sum[tree_id % task_param.num_class] += tree.LeafValue(node_id);
-      };
-      return PredictImplInner(model, input, output, thread_config, pred_transform, output_logic);
-    }
-  } else {
-    auto output_logic = [task_param](
-        const TreeType& tree, int tree_id, int node_id, float* sum) {
-      sum[0] += tree.LeafValue(node_id);
-    };
-    return PredictImplInner(model, input, output, thread_config, pred_transform, output_logic);
-  }
+  PredictRaw(model, input, output, thread_config);
+  return PredTransform(model, input, output, thread_config, pred_transform);
 }
 
 }  // anonymous namespace

--- a/src/json_serializer.cc
+++ b/src/json_serializer.cc
@@ -140,6 +140,8 @@ void DumpTreeAsJSON(WriterType& writer, const Tree<ThresholdType, LeafOutputType
 
   writer.Key("num_nodes");
   writer.Int(tree.num_nodes);
+  writer.Key("has_categorical_split");
+  writer.Bool(tree.has_categorical_split_);
   writer.Key("nodes");
   writer.StartArray();
   for (std::size_t i = 0; i < tree.nodes_.Size(); ++i) {

--- a/tests/cpp/test_serializer.cc
+++ b/tests/cpp/test_serializer.cc
@@ -95,6 +95,7 @@ void PyBufferInterfaceRoundTrip_TreeStump() {
     }},
     "trees": [{{
             "num_nodes": 3,
+            "has_categorical_split": false,
             "nodes": [{{
                     "node_id": 0,
                     "split_feature_id": 0,
@@ -183,6 +184,7 @@ void PyBufferInterfaceRoundTrip_TreeStumpLeafVec() {
     }},
     "trees": [{{
             "num_nodes": 3,
+            "has_categorical_split": false,
             "nodes": [{{
                     "node_id": 0,
                     "split_feature_id": 0,
@@ -289,6 +291,7 @@ void PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit(
     }},
     "trees": [{{
             "num_nodes": 3,
+            "has_categorical_split": true,
             "nodes": [{{
                     "node_id": 0,
                     "split_feature_id": 0,
@@ -394,6 +397,7 @@ void PyBufferInterfaceRoundTrip_TreeDepth2() {
     }},
     "trees": [{{
             "num_nodes": 7,
+            "has_categorical_split": true,
             "nodes": [{{
                     "node_id": 0,
                     "split_feature_id": 0,
@@ -436,6 +440,7 @@ void PyBufferInterfaceRoundTrip_TreeDepth2() {
                 }}]
         }}, {{
             "num_nodes": 7,
+            "has_categorical_split": true,
             "nodes": [{{
                     "node_id": 0,
                     "split_feature_id": 0,
@@ -478,6 +483,7 @@ void PyBufferInterfaceRoundTrip_TreeDepth2() {
                 }}]
         }}, {{
             "num_nodes": 7,
+            "has_categorical_split": true,
             "nodes": [{{
                     "node_id": 0,
                     "split_feature_id": 0,


### PR DESCRIPTION
Inspired by XGBoost's CPU predictor. A team of threads now process a tile (block) of data rows. We set the tile size judiciously so that the buffer fits into the smallest CPU cache.

Also:
* Don't use bound-checked `at()` in a tight read loop. Use unsafe `operator[]` instead.
* Remove the use of `std::unordered_map`, as it destroys data locality.
* Specialize for the case where the whole tree consists of only numerical splits.
* Specialize for the case where a data row contains no missing value. (`std::isnan()` is surprisingly costly, as it consists of a floating-point comparison)
* Remove duplicated `std::isnan` check
* Optimize `NextNode()` for the common cases (XGBoost, LightGBM, cuML, sklearn)
* Don't pass right_child to `NextNode()`, taking advantage of the equality `right_child == left_child + 1`.
* In `PredValueByOneTree()`, cache the individual `Node` struct to improve data locality.

These optimizations reduced the number of CPU instructions from 1,286B to 542B in a [microbenchmark](https://github.com/hcho3/gtil_bench).

Using the `large_model` in the [microbenchmark](https://github.com/hcho3/gtil_bench):

|   | Elapsed Time |
| ------------- | ------------- |
| GTIL, status quo (`mainline`)  | 20240 ms  |
| GTIL with tiles  | 5871 ms  |
| **GTIL with tiles + various optimization**  | **2091 ms** |
| XGBoost | 1817 ms |