### PR TITLE
Remove all uses of distutils

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -5,7 +5,6 @@ import shutil
 import subprocess
 import collections
 import logging
-import shutil
 from platform import system
 from setuptools import setup, find_packages, Extension
 from setuptools.command import build_ext, sdist, install_lib, install

--- a/python/setup.py
+++ b/python/setup.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 import collections
 import logging
-import distutils
+import shutil
 from platform import system
 from setuptools import setup, find_packages, Extension
 from setuptools.command import build_ext, sdist, install_lib, install
@@ -42,12 +42,12 @@ def copy_tree(src_dir, target_dir):
     logger = logging.getLogger('Treelite copy_tree')
     def clean_copy_tree(src, dst):
         logger.info('Copy tree %s -> %s', src, dst)
-        distutils.dir_util.copy_tree(src, dst)
+        shutil.copytree(src, dst)
         NEED_CLEAN_TREE.add(os.path.abspath(dst))
 
     def clean_copy_file(src, dst):
         logger.info('Copy tree %s -> %s', src, dst)
-        distutils.file_util.copy_file(src, dst)
+        shutil.copy(src, dst)
         NEED_CLEAN_FILE.add(os.path.abspath(dst))
 
     cmake = os.path.join(src_dir, 'cmake')

--- a/python/treelite/contrib/msvc.py
+++ b/python/treelite/contrib/msvc.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import as _abs
 import os
 import glob
 import re
-from distutils.version import StrictVersion
+from pkg_resources import parse_version
 from .util import _create_shared_base, _libext
 
 LIBEXT = _libext()
@@ -42,7 +42,7 @@ def _varsall_bat_path():  # pylint: disable=R0912
         while True:
             try:
                 version, vcroot, _ = winreg.EnumValue(key, i)
-                if StrictVersion(version) >= StrictVersion('15.0'):
+                if parse_version(version) >= parse_version('15.0'):
                     # Visual Studio 2017 revamped directory structure
                     candidate_paths.append(
                         os.path.join(vcroot, 'VC\\Auxiliary\\Build\\vcvarsall.bat'))

--- a/runtime/python/setup.py
+++ b/runtime/python/setup.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 import collections
 import logging
-import distutils
+import shutil
 from platform import system
 from setuptools import setup, find_packages, Extension
 from setuptools.command import build_ext, sdist, install_lib, install
@@ -42,12 +42,12 @@ def copy_tree(src_dir, target_dir):
     logger = logging.getLogger('Treelite runtime copy_tree')
     def clean_copy_tree(src, dst):
         logger.info(f'Copy tree {src} -> {dst}')
-        distutils.dir_util.copy_tree(src, dst)
+        shutil.copytree(src, dst)
         NEED_CLEAN_TREE.add(os.path.abspath(dst))
 
     def clean_copy_file(src, dst):
         logger.info(f'Copy file {src} -> {dst}')
-        distutils.file_util.copy_file(src, dst)
+        shutil.copy(src, dst)
         NEED_CLEAN_FILE.add(os.path.abspath(dst))
 
     cmake = os.path.join(src_dir, 'cmake')


### PR DESCRIPTION
The `distutils` package in Python has been deprecated and is scheduled to be removed in Python 3.12.