### PR TITLE
Support XGBoost classifiers with num_class > 2, num_parallel_tree > 1

### DIFF
--- a/src/frontend/xgboost.cc
+++ b/src/frontend/xgboost.cc
@@ -380,7 +380,9 @@ inline std::unique_ptr<treelite::Model> ParseStream(std::istream& fi) {
     xgb_trees_.emplace_back();
     xgb_trees_.back().Load(fp.get());
   }
-  TREELITE_CHECK_EQ(gbm_param_.num_roots, 1) << "multi-root trees not supported";
+  if (mparam_.major_version < 1 || (mparam_.major_version == 1 && mparam_.minor_version < 6)) {
+    TREELITE_CHECK_EQ(gbm_param_.num_roots, 1) << "multi-root trees not supported";
+  }
   std::vector<int> tree_info;
   tree_info.resize(gbm_param_.num_trees);
   if (gbm_param_.num_trees > 0) {

--- a/src/frontend/xgboost.cc
+++ b/src/frontend/xgboost.cc
@@ -381,6 +381,7 @@ inline std::unique_ptr<treelite::Model> ParseStream(std::istream& fi) {
     xgb_trees_.back().Load(fp.get());
   }
   if (mparam_.major_version < 1 || (mparam_.major_version == 1 && mparam_.minor_version < 6)) {
+    // In XGBoost 1.6, num_roots is used as num_parallel_tree, so don't check
     TREELITE_CHECK_EQ(gbm_param_.num_roots, 1) << "multi-root trees not supported";
   }
   std::vector<int> tree_info;

--- a/tests/python/test_gtil.py
+++ b/tests/python/test_gtil.py
@@ -113,11 +113,12 @@ def test_xgb_boston(tmpdir, objective, model_format, num_parallel_tree):
         model_name = 'boston.json'
         model_path = os.path.join(tmpdir, model_name)
         xgb_model.save_model(model_path)
-        with open(model_path, "r") as f:
-            print(f.read())
         tl_model = treelite.Model.load(filename=model_path, model_format='xgboost_json')
     else:
-        tl_model = treelite.Model.from_xgboost(xgb_model)
+        model_name = 'boston.model'
+        model_path = os.path.join(tmpdir, model_name)
+        xgb_model.save_model(model_path)
+        tl_model = treelite.Model.load(filename=model_path, model_format='xgboost')
     assert len(json.loads(tl_model.dump_as_json())["trees"]) == num_round * num_parallel_tree
 
     out_pred = treelite.gtil.predict(tl_model, X_test)
@@ -147,12 +148,12 @@ def test_xgb_iris(tmpdir, objective, model_format, num_parallel_tree):
         model_name = 'iris.json'
         model_path = os.path.join(tmpdir, model_name)
         xgb_model.save_model(model_path)
-        with open(model_path, "r") as f:
-            print(f.read())
         tl_model = treelite.Model.load(filename=model_path, model_format='xgboost_json')
     else:
-        tl_model = treelite.Model.from_xgboost(xgb_model)
-    print(tl_model.dump_as_json())
+        model_name = 'iris.model'
+        model_path = os.path.join(tmpdir, model_name)
+        xgb_model.save_model(model_path)
+        tl_model = treelite.Model.load(filename=model_path, model_format='xgboost')
     expected_num_tree = num_class * num_round * num_parallel_tree
     assert len(json.loads(tl_model.dump_as_json())["trees"]) == expected_num_tree
 

--- a/tests/python/test_gtil.py
+++ b/tests/python/test_gtil.py
@@ -3,6 +3,7 @@ Tests for General Tree Inference Library (GTIL). The tests ensure that GTIL prod
 prediction results for a variety of tree models.
 """
 import os
+import json
 import pytest
 import treelite
 import numpy as np
@@ -92,17 +93,19 @@ def test_skl_converter_iforest():
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=2)
 
 
+@pytest.mark.parametrize('num_parallel_tree', [1, 3, 5])
+@pytest.mark.parametrize('model_format', ['binary', 'json'])
 @pytest.mark.parametrize('objective', ['reg:linear', 'reg:squarederror', 'reg:squaredlogerror',
                                        'reg:pseudohubererror'])
-@pytest.mark.parametrize('model_format', ['binary', 'json'])
-def test_xgb_boston(tmpdir, model_format, objective):
+def test_xgb_boston(tmpdir, objective, model_format, num_parallel_tree):
     # pylint: disable=too-many-locals
     """Test XGBoost with Boston data (regression)"""
     X, y = load_boston(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
     dtrain = xgb.DMatrix(X_train, label=y_train)
     dtest = xgb.DMatrix(X_test, label=y_test)
-    param = {'max_depth': 8, 'eta': 1, 'silent': 1, 'objective': objective}
+    param = {'max_depth': 8, 'eta': 1, 'verbosity': 0, 'objective': objective,
+             'num_parallel_tree': num_parallel_tree}
     num_round = 10
     xgb_model = xgb.train(param, dtrain, num_boost_round=num_round,
                           evals=[(dtrain, 'train'), (dtest, 'test')])
@@ -110,36 +113,48 @@ def test_xgb_boston(tmpdir, model_format, objective):
         model_name = 'boston.json'
         model_path = os.path.join(tmpdir, model_name)
         xgb_model.save_model(model_path)
+        with open(model_path, "r") as f:
+            print(f.read())
         tl_model = treelite.Model.load(filename=model_path, model_format='xgboost_json')
     else:
         tl_model = treelite.Model.from_xgboost(xgb_model)
+    assert len(json.loads(tl_model.dump_as_json())["trees"]) == num_round * num_parallel_tree
 
     out_pred = treelite.gtil.predict(tl_model, X_test)
     expected_pred = xgb_model.predict(dtest)
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
+@pytest.mark.parametrize('num_parallel_tree', [1, 3, 5])
 @pytest.mark.parametrize('model_format', ['binary', 'json'])
 @pytest.mark.parametrize('objective', ['multi:softmax', 'multi:softprob'])
-def test_xgb_iris(tmpdir, objective, model_format):
+def test_xgb_iris(tmpdir, objective, model_format, num_parallel_tree):
     # pylint: disable=too-many-locals
     """Test XGBoost with Iris data (multi-class classification)"""
     X, y = load_iris(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
     dtrain = xgb.DMatrix(X_train, label=y_train)
     dtest = xgb.DMatrix(X_test, label=y_test)
-    param = {'max_depth': 6, 'eta': 0.05, 'num_class': 3, 'verbosity': 0,
-             'objective': objective, 'metric': 'mlogloss'}
-    xgb_model = xgb.train(param, dtrain, num_boost_round=10,
+    num_class = 3
+    param = {'max_depth': 6, 'eta': 0.05, 'num_class': num_class, 'verbosity': 0,
+             'objective': objective, 'metric': 'mlogloss',
+             'num_parallel_tree': num_parallel_tree}
+    num_round = 3
+    xgb_model = xgb.train(param, dtrain, num_boost_round=num_round,
                           evals=[(dtrain, 'train'), (dtest, 'test')])
 
     if model_format == 'json':
         model_name = 'iris.json'
         model_path = os.path.join(tmpdir, model_name)
         xgb_model.save_model(model_path)
+        with open(model_path, "r") as f:
+            print(f.read())
         tl_model = treelite.Model.load(filename=model_path, model_format='xgboost_json')
     else:
         tl_model = treelite.Model.from_xgboost(xgb_model)
+    print(tl_model.dump_as_json())
+    expected_num_tree = num_class * num_round * num_parallel_tree
+    assert len(json.loads(tl_model.dump_as_json())["trees"]) == expected_num_tree
 
     out_pred = treelite.gtil.predict(tl_model, X_test)
     expected_pred = xgb_model.predict(dtest)

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -33,7 +33,8 @@ def test_xgb_boston(tmpdir, toolchain, objective, model_format, num_parallel_tre
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
     dtrain = xgboost.DMatrix(X_train, label=y_train)
     dtest = xgboost.DMatrix(X_test, label=y_test)
-    param = {'max_depth': 8, 'eta': 1, 'silent': 1, 'objective': objective}
+    param = {'max_depth': 8, 'eta': 1, 'silent': 1, 'objective': objective,
+             'num_parallel_tree': num_parallel_tree}
     num_round = 10
     bst = xgboost.train(param, dtrain, num_boost_round=num_round,
                         evals=[(dtrain, 'train'), (dtest, 'test')])
@@ -75,7 +76,7 @@ def test_xgb_boston(tmpdir, toolchain, objective, model_format, num_parallel_tre
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())
 def test_xgb_iris(tmpdir, toolchain, objective, model_format, expected_pred_transform,
                   num_parallel_tree):
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals, too-many-arguments
     """Test Iris data (multi-class classification)"""
     X, y = load_iris(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -21,11 +21,12 @@ except ImportError:
     pytest.skip('XGBoost not installed; skipping', allow_module_level=True)
 
 
+@pytest.mark.parametrize('num_parallel_tree', [1, 3, 5])
 @pytest.mark.parametrize('model_format', ['binary', 'json'])
 @pytest.mark.parametrize('objective', ['reg:linear', 'reg:squarederror', 'reg:squaredlogerror',
                                        'reg:pseudohubererror'])
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-def test_xgb_boston(tmpdir, toolchain, objective, model_format):
+def test_xgb_boston(tmpdir, toolchain, objective, model_format, num_parallel_tree):
     # pylint: disable=too-many-locals
     """Test Boston data (regression)"""
     X, y = load_boston(return_X_y=True)
@@ -42,7 +43,10 @@ def test_xgb_boston(tmpdir, toolchain, objective, model_format):
         bst.save_model(model_path)
         model = treelite.Model.load(filename=model_path, model_format='xgboost_json')
     else:
-        model = treelite.Model.from_xgboost(bst)
+        model_name = 'boston.model'
+        model_path = os.path.join(tmpdir, model_name)
+        bst.save_model(model_path)
+        model = treelite.Model.load(filename=model_path, model_format='xgboost')
 
     assert model.num_feature == dtrain.num_col()
     assert model.num_class == 1
@@ -63,12 +67,14 @@ def test_xgb_boston(tmpdir, toolchain, objective, model_format):
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
+@pytest.mark.parametrize('num_parallel_tree', [1, 3, 5])
 @pytest.mark.parametrize('model_format', ['binary', 'json'])
 @pytest.mark.parametrize('objective,expected_pred_transform',
                          [('multi:softmax', 'max_index'), ('multi:softprob', 'softmax')],
                          ids=['multi:softmax', 'multi:softprob'])
 @pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-def test_xgb_iris(tmpdir, toolchain, objective, model_format, expected_pred_transform):
+def test_xgb_iris(tmpdir, toolchain, objective, model_format, expected_pred_transform,
+                  num_parallel_tree):
     # pylint: disable=too-many-locals
     """Test Iris data (multi-class classification)"""
     X, y = load_iris(return_X_y=True)
@@ -78,7 +84,8 @@ def test_xgb_iris(tmpdir, toolchain, objective, model_format, expected_pred_tran
     num_class = 3
     num_round = 10
     param = {'max_depth': 6, 'eta': 0.05, 'num_class': num_class, 'verbosity': 0,
-             'objective': objective, 'metric': 'mlogloss'}
+             'objective': objective, 'metric': 'mlogloss',
+             'num_parallel_tree': num_parallel_tree}
     bst = xgboost.train(param, dtrain, num_boost_round=num_round,
                         evals=[(dtrain, 'train'), (dtest, 'test')])
 
@@ -88,10 +95,13 @@ def test_xgb_iris(tmpdir, toolchain, objective, model_format, expected_pred_tran
         bst.save_model(model_path)
         model = treelite.Model.load(filename=model_path, model_format='xgboost_json')
     else:
-        model = treelite.Model.from_xgboost(bst)
+        model_name = 'iris.model'
+        model_path = os.path.join(tmpdir, model_name)
+        bst.save_model(model_path)
+        model = treelite.Model.load(filename=model_path, model_format='xgboost')
     assert model.num_feature == dtrain.num_col()
     assert model.num_class == num_class
-    assert model.num_tree == num_round * num_class
+    assert model.num_tree == num_round * num_class * num_parallel_tree
     libpath = os.path.join(tmpdir, 'iris' + _libext())
     model.export_lib(toolchain=toolchain, libpath=libpath, params={}, verbose=True)
 

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -51,7 +51,7 @@ def test_xgb_boston(tmpdir, toolchain, objective, model_format, num_parallel_tre
 
     assert model.num_feature == dtrain.num_col()
     assert model.num_class == 1
-    assert model.num_tree == num_round
+    assert model.num_tree == num_round * num_parallel_tree
     libpath = os.path.join(tmpdir, 'boston' + _libext())
     model.export_lib(toolchain=toolchain, libpath=libpath, params={'parallel_comp': model.num_tree},
                      verbose=True)


### PR DESCRIPTION
FYI @trivialfis 

This PR uses `tree_info` field to deduce `num_parallel_tree`. XGBoost 1.6+ also saves `num_parallel_tree` in the model, but we would like to support older XGBoost models too.