### PR TITLE
docs: add missing supported sklearn models

### DIFF
--- a/docs/tutorials/builder.rst
+++ b/docs/tutorials/builder.rst
@@ -350,8 +350,11 @@ by scikit-learn. In particular, it will be able to work with
 
 * :py:class:`sklearn.ensemble.RandomForestRegressor`
 * :py:class:`sklearn.ensemble.RandomForestClassifier`
+* :py:class:`sklearn.ensemble.ExtraTreesRegressor`
+* :py:class:`sklearn.ensemble.ExtraTreesClassifier`
 * :py:class:`sklearn.ensemble.GradientBoostingRegressor`
 * :py:class:`sklearn.ensemble.GradientBoostingClassifier`
+* :py:class:`sklearn.ensemble.IsolationForest`
 
 .. note:: Why scikit-learn? How about other packages?
 

--- a/docs/tutorials/import.rst
+++ b/docs/tutorials/import.rst
@@ -60,8 +60,11 @@ Treelite.
 
 * :py:class:`sklearn.ensemble.RandomForestRegressor`
 * :py:class:`sklearn.ensemble.RandomForestClassifier`
+* :py:class:`sklearn.ensemble.ExtraTreesRegressor`
+* :py:class:`sklearn.ensemble.ExtraTreesClassifier`
 * :py:class:`sklearn.ensemble.GradientBoostingRegressor`
 * :py:class:`sklearn.ensemble.GradientBoostingClassifier`
+* :py:class:`sklearn.ensemble.IsolationForest`
 
 To import scikit-learn models, use
 :py:meth:`treelite.sklearn.import_model`:

--- a/python/.pylintrc
+++ b/python/.pylintrc
@@ -1,6 +1,8 @@
 [MASTER]
 extension-pkg-whitelist=numpy
 
+load-plugins=pylint.extensions.no_self_use
+
 disable=unexpected-special-method-signature,too-many-nested-blocks,useless-object-inheritance,import-outside-toplevel,unsubscriptable-object,attribute-defined-outside-init,unbalanced-tuple-unpacking,consider-using-f-string,too-many-lines
 
 dummy-variables-rgx=(unused|)_.*

--- a/python/treelite/sklearn/importer.py
+++ b/python/treelite/sklearn/importer.py
@@ -121,9 +121,9 @@ def import_model(sklearn_model):
 
     if isinstance(sklearn_model,
             (RandomForestR, ExtraTreesR, GradientBoostingR, GradientBoostingC, IsolationForest)):
-        leaf_value_expected_shape = lambda node_count: (node_count, 1, 1)
+        leaf_value_expected_shape = lambda node_count: (node_count, 1, 1)  # pylint: disable=C3001
     elif isinstance(sklearn_model, (RandomForestC, ExtraTreesC)):
-        leaf_value_expected_shape = lambda node_count: (node_count, 1, sklearn_model.n_classes_)
+        leaf_value_expected_shape = lambda node_count: (node_count, 1, sklearn_model.n_classes_)  # pylint: disable=C3001
     else:
         raise TreeliteError(f'Not supported model type: {sklearn_model.__class__.__name__}')
 


### PR DESCRIPTION
We have
- ExtraTreesRegressor
- ExtraTreesClassifier
- IsolationForest

in API and tests.

This PR amended the docs