### PR TITLE
Replace all generic exceptions with treelite::Error

### DIFF
--- a/include/treelite/base.h
+++ b/include/treelite/base.h
@@ -7,12 +7,13 @@
 #ifndef TREELITE_BASE_H_
 #define TREELITE_BASE_H_
 
+#include <treelite/error.h>
+#include <treelite/typeinfo.h>
 #include <cstdint>
 #include <typeinfo>
 #include <string>
 #include <unordered_map>
 #include <stdexcept>
-#include "./typeinfo.h"
 
 namespace treelite {
 
@@ -82,7 +83,7 @@ inline bool CompareWithOp(ElementType lhs, Operator op, ThresholdType rhs) {
     case Operator::kGT: return lhs >  rhs;
     case Operator::kGE: return lhs >= rhs;
     default:
-      throw std::runtime_error("operator undefined");
+      throw Error("operator undefined");
       return false;
   }
 }

--- a/include/treelite/error.h
+++ b/include/treelite/error.h
@@ -21,4 +21,4 @@ struct Error : public std::runtime_error {
 
 }  // namespace treelite
 
-#endif //TREELITE_ERROR_H_
+#endif  // TREELITE_ERROR_H_

--- a/include/treelite/error.h
+++ b/include/treelite/error.h
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) 2022 by Contributors
+ * \file error.h
+ * \brief Exception class used throughout the Treelite codebase
+ * \author Hyunsu Cho
+ */
+#ifndef TREELITE_ERROR_H_
+#define TREELITE_ERROR_H_
+
+#include <string>
+#include <stdexcept>
+
+namespace treelite {
+
+/*!
+ * \brief Exception class that will be thrown by Treelite
+ */
+struct Error : public std::runtime_error {
+  explicit Error(const std::string& s) : std::runtime_error(s) {}
+};
+
+}  // namespace treelite
+
+#endif //TREELITE_ERROR_H_

--- a/include/treelite/frontend_impl.h
+++ b/include/treelite/frontend_impl.h
@@ -8,6 +8,7 @@
 #ifndef TREELITE_FRONTEND_IMPL_H_
 #define TREELITE_FRONTEND_IMPL_H_
 
+#include <treelite/error.h>
 #include <string>
 
 namespace treelite {
@@ -24,8 +25,8 @@ Value::Dispatch(Func func) {
   case TypeInfo::kFloat64:
     return func(Get<double>());
   default:
-    throw std::runtime_error(std::string("Unknown value type detected: ")
-                             + std::to_string(static_cast<int>(type_)));
+    throw Error(std::string("Unknown value type detected: ")
+                + std::to_string(static_cast<int>(type_)));
     return func(Get<double>());  // avoid "missing return" warning
   }
 }
@@ -41,8 +42,8 @@ Value::Dispatch(Func func) const {
   case TypeInfo::kFloat64:
     return func(Get<double>());
   default:
-    throw std::runtime_error(std::string("Unknown value type detected: ")
-                             + std::to_string(static_cast<int>(type_)));
+    throw Error(std::string("Unknown value type detected: ")
+                + std::to_string(static_cast<int>(type_)));
     return func(Get<double>());  // avoid "missing return" warning
   }
 }

--- a/include/treelite/logging.h
+++ b/include/treelite/logging.h
@@ -8,8 +8,8 @@
 #define TREELITE_LOGGING_H_
 
 #include <treelite/thread_local.h>
+#include <treelite/error.h>
 #include <iostream>
-#include <stdexcept>
 #include <string>
 #include <sstream>
 #include <memory>
@@ -17,13 +17,6 @@
 #include <ctime>
 
 namespace treelite {
-
-/*!
- * \brief Exception class that will be thrown by Treelite
- */
-struct Error : public std::runtime_error {
-  explicit Error(const std::string& s) : std::runtime_error(s) {}
-};
 
 template <typename X, typename Y>
 std::unique_ptr<std::string> LogCheckFormat(const X& x, const Y& y) {

--- a/include/treelite/omp_exception.h
+++ b/include/treelite/omp_exception.h
@@ -56,4 +56,4 @@ class OMPException {
 
 }  // namespace treelite
 
-#endif // TREELITE_OMP_EXCEPTION_H_
+#endif  // TREELITE_OMP_EXCEPTION_H_

--- a/include/treelite/omp_exception.h
+++ b/include/treelite/omp_exception.h
@@ -1,0 +1,59 @@
+/*!
+ * Copyright (c) 2022 by Contributors
+ * \file omp_exception.h
+ * \author Hyunsu Cho
+ * \brief Utility to propagate exceptions throws inside an OpenMP block
+ */
+#ifndef TREELITE_OMP_EXCEPTION_H_
+#define TREELITE_OMP_EXCEPTION_H_
+
+#include <treelite/error.h>
+#include <exception>
+#include <mutex>
+
+namespace treelite {
+
+/*!
+ * \brief OMP Exception class catches, saves and rethrows exception from OMP blocks
+ */
+class OMPException {
+ private:
+  // exception_ptr member to store the exception
+  std::exception_ptr omp_exception_;
+  // mutex to be acquired during catch to set the exception_ptr
+  std::mutex mutex_;
+
+ public:
+  /*!
+   * \brief Parallel OMP blocks should be placed within Run to save exception
+   */
+  template <typename Function, typename... Parameters>
+  void Run(Function f, Parameters... params) {
+    try {
+      f(params...);
+    } catch (treelite::Error &ex) {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (!omp_exception_) {
+        omp_exception_ = std::current_exception();
+      }
+    } catch (std::exception &ex) {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (!omp_exception_) {
+        omp_exception_ = std::current_exception();
+      }
+    }
+  }
+
+  /*!
+   * \brief should be called from the main thread to rethrow the exception
+   */
+  void Rethrow() {
+    if (this->omp_exception_) {
+      std::rethrow_exception(this->omp_exception_);
+    }
+  }
+};
+
+}  // namespace treelite
+
+#endif // TREELITE_OMP_EXCEPTION_H_

--- a/include/treelite/predictor.h
+++ b/include/treelite/predictor.h
@@ -8,6 +8,7 @@
 #define TREELITE_PREDICTOR_H_
 
 #include <treelite/error.h>
+#include <treelite/omp_exception.h>
 #include <treelite/logging.h>
 #include <treelite/typeinfo.h>
 #include <treelite/c_api_runtime.h>
@@ -24,45 +25,6 @@
 
 namespace treelite {
 namespace predictor {
-
-/*!
- * \brief OMP Exception class catches, saves and rethrows exception from OMP blocks
- */
-class OMPException {
- private:
-  // exception_ptr member to store the exception
-  std::exception_ptr omp_exception_;
-  // mutex to be acquired during catch to set the exception_ptr
-  std::mutex mutex_;
-
- public:
-  /*!
-   * \brief Parallel OMP blocks should be placed within Run to save exception
-   */
-  template <typename Function, typename... Parameters>
-  void Run(Function f, Parameters... params) {
-    try {
-      f(params...);
-    } catch (treelite::Error &ex) {
-      std::lock_guard<std::mutex> lock(mutex_);
-      if (!omp_exception_) {
-        omp_exception_ = std::current_exception();
-      }
-    } catch (std::exception &ex) {
-      std::lock_guard<std::mutex> lock(mutex_);
-      if (!omp_exception_) {
-        omp_exception_ = std::current_exception();
-      }
-    }
-  }
-
-  /*!
-   * \brief should be called from the main thread to rethrow the exception
-   */
-  void Rethrow() {
-    if (this->omp_exception_) std::rethrow_exception(this->omp_exception_);
-  }
-};
 
 /*! \brief data layout. The value -1 signifies the missing value.
     When the "missing" field is set to -1, the "fvalue" field is set to

--- a/include/treelite/predictor.h
+++ b/include/treelite/predictor.h
@@ -7,6 +7,7 @@
 #ifndef TREELITE_PREDICTOR_H_
 #define TREELITE_PREDICTOR_H_
 
+#include <treelite/error.h>
 #include <treelite/logging.h>
 #include <treelite/typeinfo.h>
 #include <treelite/c_api_runtime.h>

--- a/include/treelite/typeinfo.h
+++ b/include/treelite/typeinfo.h
@@ -8,6 +8,7 @@
 #ifndef TREELITE_TYPEINFO_H_
 #define TREELITE_TYPEINFO_H_
 
+#include <treelite/error.h>
 #include <cstdint>
 #include <typeinfo>
 #include <string>
@@ -47,7 +48,7 @@ inline std::string TypeInfoToString(treelite::TypeInfo type) {
   case treelite::TypeInfo::kFloat64:
     return "float64";
   default:
-    throw std::runtime_error("Unrecognized type");
+    throw Error("Unrecognized type");
     return "";
   }
 }
@@ -66,7 +67,7 @@ inline TypeInfo TypeToInfo() {
   } else if (std::is_same<T, double>::value) {
     return TypeInfo::kFloat64;
   } else {
-    throw std::runtime_error(std::string("Unrecognized Value type") + typeid(T).name());
+    throw Error(std::string("Unrecognized Value type") + typeid(T).name());
     return TypeInfo::kInvalid;
   }
 }
@@ -94,7 +95,7 @@ inline auto DispatchWithTypeInfo(TypeInfo type, Args&& ...args) {
     return Dispatcher<double>::Dispatch(std::forward<Args>(args)...);
   case TypeInfo::kInvalid:
   default:
-    throw std::runtime_error(std::string("Invalid type: ") + TypeInfoToString(type));
+    throw Error(std::string("Invalid type: ") + TypeInfoToString(type));
   }
   return Dispatcher<double>::Dispatch(std::forward<Args>(args)...);  // avoid missing return error
 }
@@ -135,7 +136,7 @@ inline auto DispatchWithModelTypes(
     case treelite::TypeInfo::kFloat32:
       return Dispatcher<float, float>::Dispatch(std::forward<Args>(args)...);
     default:
-      throw std::runtime_error(error_leaf_output_type());
+      throw Error(error_leaf_output_type());
       break;
     }
     break;
@@ -146,12 +147,12 @@ inline auto DispatchWithModelTypes(
     case treelite::TypeInfo::kFloat64:
       return Dispatcher<double, double>::Dispatch(std::forward<Args>(args)...);
     default:
-      throw std::runtime_error(error_leaf_output_type());
+      throw Error(error_leaf_output_type());
       break;
     }
     break;
   default:
-    throw std::runtime_error(error_threshold_type());
+    throw Error(error_threshold_type());
     break;
   }
   return Dispatcher<double, double>::Dispatch(std::forward<Args>(args)...);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,6 +139,7 @@ target_sources(objtreelite_common
     typeinfo.cc
     ${PROJECT_SOURCE_DIR}/include/treelite/c_api_common.h
     ${PROJECT_SOURCE_DIR}/include/treelite/c_api_error.h
+    ${PROJECT_SOURCE_DIR}/include/treelite/error.h
     ${PROJECT_SOURCE_DIR}/include/treelite/logging.h
     ${PROJECT_SOURCE_DIR}/include/treelite/math.h
     ${PROJECT_SOURCE_DIR}/include/treelite/typeinfo.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,6 +142,7 @@ target_sources(objtreelite_common
     ${PROJECT_SOURCE_DIR}/include/treelite/error.h
     ${PROJECT_SOURCE_DIR}/include/treelite/logging.h
     ${PROJECT_SOURCE_DIR}/include/treelite/math.h
+    ${PROJECT_SOURCE_DIR}/include/treelite/omp_exception.h
     ${PROJECT_SOURCE_DIR}/include/treelite/typeinfo.h
     ${PROJECT_SOURCE_DIR}/include/treelite/data.h
 )

--- a/src/compiler/native/typeinfo_ctypes.h
+++ b/src/compiler/native/typeinfo_ctypes.h
@@ -10,6 +10,7 @@
 #define TREELITE_COMPILER_NATIVE_TYPEINFO_CTYPES_H_
 
 #include <treelite/base.h>
+#include <treelite/error.h>
 #include <string>
 
 namespace treelite {
@@ -24,7 +25,7 @@ namespace native {
 inline std::string TypeInfoToCTypeString(TypeInfo type) {
   switch (type) {
   case TypeInfo::kInvalid:
-    throw std::runtime_error("Invalid type");
+    throw Error("Invalid type");
     return "";
   case TypeInfo::kUInt32:
     return "uint32_t";
@@ -33,8 +34,7 @@ inline std::string TypeInfoToCTypeString(TypeInfo type) {
   case TypeInfo::kFloat64:
     return "double";
   default:
-    throw std::runtime_error(std::string("Unrecognized type: ")
-                             + std::to_string(static_cast<int>(type)));
+    throw Error(std::string("Unrecognized type: ") + std::to_string(static_cast<int>(type)));
     return "";
   }
 }
@@ -48,15 +48,14 @@ inline std::string CExpForTypeInfo(TypeInfo type) {
   switch (type) {
   case TypeInfo::kInvalid:
   case TypeInfo::kUInt32:
-    throw std::runtime_error(std::string("Invalid type: ") + TypeInfoToString(type));
+    throw Error(std::string("Invalid type: ") + TypeInfoToString(type));
     return "";
   case TypeInfo::kFloat32:
     return "expf";
   case TypeInfo::kFloat64:
     return "exp";
   default:
-    throw std::runtime_error(std::string("Unrecognized type: ")
-                             + std::to_string(static_cast<int>(type)));
+    throw Error(std::string("Unrecognized type: ") + std::to_string(static_cast<int>(type)));
     return "";
   }
 }
@@ -70,15 +69,14 @@ inline std::string CExp2ForTypeInfo(TypeInfo type) {
   switch (type) {
   case TypeInfo::kInvalid:
   case TypeInfo::kUInt32:
-    throw std::runtime_error(std::string("Invalid type: ") + TypeInfoToString(type));
+    throw Error(std::string("Invalid type: ") + TypeInfoToString(type));
     return "";
   case TypeInfo::kFloat32:
     return "exp2f";
   case TypeInfo::kFloat64:
     return "exp2";
   default:
-    throw std::runtime_error(std::string("Unrecognized type: ")
-                             + std::to_string(static_cast<int>(type)));
+    throw Error(std::string("Unrecognized type: ") + std::to_string(static_cast<int>(type)));
     return "";
   }
 }
@@ -92,15 +90,14 @@ inline std::string CCopySignForTypeInfo(TypeInfo type) {
   switch (type) {
   case TypeInfo::kInvalid:
   case TypeInfo::kUInt32:
-    throw std::runtime_error(std::string("Invalid type: ") + TypeInfoToString(type));
+    throw Error(std::string("Invalid type: ") + TypeInfoToString(type));
     return "";
   case TypeInfo::kFloat32:
     return "copysignf";
   case TypeInfo::kFloat64:
     return "copysign";
   default:
-    throw std::runtime_error(std::string("Unrecognized type: ")
-                             + std::to_string(static_cast<int>(type)));
+    throw Error(std::string("Unrecognized type: ") + std::to_string(static_cast<int>(type)));
     return "";
   }
 }
@@ -114,15 +111,14 @@ inline std::string CLog1PForTypeInfo(TypeInfo type) {
   switch (type) {
   case TypeInfo::kInvalid:
   case TypeInfo::kUInt32:
-    throw std::runtime_error(std::string("Invalid type: ") + TypeInfoToString(type));
+    throw Error(std::string("Invalid type: ") + TypeInfoToString(type));
     return "";
   case TypeInfo::kFloat32:
     return "log1pf";
   case TypeInfo::kFloat64:
     return "log1p";
   default:
-    throw std::runtime_error(std::string("Unrecognized type: ")
-                             + std::to_string(static_cast<int>(type)));
+    throw Error(std::string("Unrecognized type: ") + std::to_string(static_cast<int>(type)));
     return "";
   }
 }

--- a/src/serializer.cc
+++ b/src/serializer.cc
@@ -6,6 +6,7 @@
  */
 
 #include <treelite/tree.h>
+#include <treelite/error.h>
 
 namespace treelite {
 
@@ -25,8 +26,8 @@ Model::CreateFromPyBuffer(std::vector<PyBufferFrame> frames) {
   TypeInfo threshold_type, leaf_output_type;
   constexpr std::size_t kNumFrameInHeader = 5;
   if (frames.size() < kNumFrameInHeader) {
-    throw std::runtime_error(std::string("Insufficient number of frames: there must be at least ")
-                             + std::to_string(kNumFrameInHeader));
+    throw Error(std::string("Insufficient number of frames: there must be at least ")
+                + std::to_string(kNumFrameInHeader));
   }
   int idx = 0;
   auto header_primitive_field_handler = [&idx, &frames](auto* field) {
@@ -34,7 +35,7 @@ Model::CreateFromPyBuffer(std::vector<PyBufferFrame> frames) {
   };
   DeserializeTemplate(header_primitive_field_handler, threshold_type, leaf_output_type);
   if (idx != kNumFrameInHeader) {
-    throw std::runtime_error("Did not read from a sufficient number of frames");
+    throw Error("Did not read from a sufficient number of frames");
   }
 
   std::unique_ptr<Model> model = Model::Create(threshold_type, leaf_output_type);

--- a/src/typeinfo.cc
+++ b/src/typeinfo.cc
@@ -5,9 +5,8 @@
  * \brief Conversion tables to obtain TypeInfo from string
  */
 
-// Do not include other Treelite headers here, to minimize cross-header dependencies
-
 #include <treelite/typeinfo.h>
+#include <treelite/error.h>
 #include <string>
 #include <unordered_map>
 
@@ -21,7 +20,7 @@ TypeInfo GetTypeInfoByName(const std::string& str) {
   } else if (str == "float64") {
     return TypeInfo::kFloat64;
   } else {
-    throw std::runtime_error("Unrecognized type");
+    throw Error("Unrecognized type");
     return TypeInfo::kInvalid;
   }
 }


### PR DESCRIPTION
Related: https://github.com/triton-inference-server/fil_backend/issues/265

Ensure that Treelite only throws `treelite::Error`, not other exceptions like `std::runtime_error`.

Also:
* Move `treelite::Error` into a separate header. This header should be small since this exception will be used everywhere.
* De-duplicate `treelite::OMPException` and move it into a separate header. Previously, it existed in both `predictor.h` and `parallel_for.h`.