### PR TITLE
[CI] Trigger CI daily

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,13 @@ trigger:
 - mainline
 - release_*
 
+schedules:
+- cron: 0 3 * * *
+  displayName: Daily Build
+  branches:
+    include: [ mainline ]
+  always: true
+
 jobs:
 - job: formatting_check
   pool:


### PR DESCRIPTION
Currently, our CI pipelines (hosted on Azure Pipelines) trigger only when updates are made. When Treelite is not updated for an extended duration of time, we will not catch the breakage caused by other packages. For example, Treelite did not work with XGBoost 1.7.0 but we didn't notice it until #412 was submitted.

Fix: Trigger the CI once each day.