### PR TITLE
[CI] Fix the script that names wheels

### DIFF
--- a/ops/build-linux.sh
+++ b/ops/build-linux.sh
@@ -12,11 +12,11 @@ tests/ci_build/ci_build.sh cpu bash -c "cd python/ && python setup.py bdist_whee
 tests/ci_build/ci_build.sh auditwheel_x86_64 auditwheel repair --only-plat --plat ${TAG} python/dist/*.whl
 rm -v python/dist/*.whl
 mv -v wheelhouse/*.whl python/dist/
-tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py python/dist/*.whl ${COMMIT_ID} ${TAG}
+tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py python/dist ${COMMIT_ID} ${TAG}
 
 echo "##[section]Packaging Python wheel for Treelite runtime..."
 tests/ci_build/ci_build.sh cpu bash -c "cd runtime/python/ && python setup.py bdist_wheel --universal"
 tests/ci_build/ci_build.sh auditwheel_x86_64 auditwheel repair --only-plat --plat ${TAG} runtime/python/dist/*.whl
 rm -v runtime/python/dist/*.whl
 mv -v wheelhouse/*.whl runtime/python/dist/
-tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py runtime/python/dist/*.whl ${COMMIT_ID} ${TAG}
+tests/ci_build/ci_build.sh cpu python tests/ci_build/rename_whl.py runtime/python/dist ${COMMIT_ID} ${TAG}

--- a/ops/test-win-python-wheel.bat
+++ b/ops/test-win-python-wheel.bat
@@ -3,14 +3,10 @@ call micromamba activate dev
 
 echo ##[section]Installing Treelite into Python environment...
 setlocal enabledelayedexpansion
-for /R %%i in (python\\dist\\*.whl) DO (
-  python tests\ci_build\rename_whl.py "%%i" %COMMIT_ID% win_amd64
-  if !errorlevel! neq 0 exit /b !errorlevel!
-)
-for /R %%i in (runtime\\python\\dist\\*.whl) DO (
-  python tests\ci_build\rename_whl.py "%%i" %COMMIT_ID% win_amd64
-  if !errorlevel! neq 0 exit /b !errorlevel!
-)
+python tests\ci_build\rename_whl.py python\dist %COMMIT_ID% win_amd64
+if %errorlevel% neq 0 exit /b %errorlevel%
+python tests\ci_build\rename_whl.py runtime\python\dist %COMMIT_ID% win_amd64
+if %errorlevel% neq 0 exit /b %errorlevel%
 for /R %%i in (python\\dist\\*.whl) DO (
   python -m pip install "%%i"
   if !errorlevel! neq 0 exit /b !errorlevel!

--- a/tests/ci_build/build_macos_python_wheels.sh
+++ b/tests/ci_build/build_macos_python_wheels.sh
@@ -68,7 +68,7 @@ fi
 
 python -m cibuildwheel python --output-dir wheelhouse
 python -m cibuildwheel runtime/python --output-dir wheelhouse-runtime
-python tests/ci_build/rename_whl.py wheelhouse/*.whl ${commit_id} ${wheel_tag}
-python tests/ci_build/rename_whl.py wheelhouse-runtime/*.whl ${commit_id} ${wheel_tag}
+python tests/ci_build/rename_whl.py wheelhouse ${commit_id} ${wheel_tag}
+python tests/ci_build/rename_whl.py wheelhouse-runtime ${commit_id} ${wheel_tag}
 mv -v wheelhouse-runtime/*.whl wheelhouse/
 rmdir wheelhouse-runtime/

--- a/tests/ci_build/rename_whl.py
+++ b/tests/ci_build/rename_whl.py
@@ -1,35 +1,57 @@
-import sys
+import argparse
+import glob
 import os
+import sys
 from contextlib import contextmanager
+
 
 @contextmanager
 def cd(path):
     path = os.path.normpath(path)
     cwd = os.getcwd()
     os.chdir(path)
-    print("cd " + path)
+    print(f"cd {path}")
     try:
         yield path
     finally:
         os.chdir(cwd)
 
-if len(sys.argv) != 4:
-    print('Usage: {} [wheel to rename] [commit id] [platform tag]'.format(sys.argv[0]))
-    sys.exit(1)
 
-whl_path = sys.argv[1]
-commit_id = sys.argv[2]
-platform_tag = sys.argv[3]
+def main(args):
+    if not os.path.isdir(args.wheel_dir):
+        raise ValueError("wheel_dir argument must be a directory")
 
-dirname, basename = os.path.dirname(whl_path), os.path.basename(whl_path)
+    with cd(args.wheel_dir):
+        whl_list = list(glob.glob("*.whl"))
+        for whl_path in whl_list:
+            basename = os.path.basename(whl_path)
+            tokens = basename.split("-")
+            assert len(tokens) == 5
+            keywords = {
+                "pkg_name": tokens[0],
+                "version": tokens[1],
+                "commit_id": args.commit_id,
+                "platform_tag": args.platform_tag,
+            }
+            new_name = (
+                "{pkg_name}-{version}+{commit_id}-py3-none-{platform_tag}.whl".format(
+                    **keywords
+                )
+            )
+            print(f"Renaming {basename} to {new_name}...")
+            os.rename(basename, new_name)
 
-with cd(dirname):
-    tokens = basename.split('-')
-    assert len(tokens) == 5
-    keywords = {'pkg_name': tokens[0],
-                'version': tokens[1],
-                'commit_id': commit_id,
-                'platform_tag': platform_tag}
-    new_name = '{pkg_name}-{version}+{commit_id}-py3-none-{platform_tag}.whl'.format(**keywords)
-    print('Renaming {} to {}...'.format(basename, new_name))
-    os.rename(basename, new_name)
+
+if __name__ == "__main__":
+    description = (
+        "Script to rename wheel(s) using a commit ID and platform tag."
+        "Note: This script will not recurse into subdirectories."
+    )
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("wheel_dir", type=str, help="Directory containing wheels")
+    parser.add_argument("commit_id", type=str, help="Hash of current git commit")
+    parser.add_argument(
+        "platform_tag", type=str, help="Platform tag, PEP 425 compliant"
+    )
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
Currently, the CI pipeline is producing wheels with such funny name as 

> treelite_runtime-3.1.0.dev0+d2c6aeee6700ecb812f025219fe2c75f11ecaffa+d2c6aeee6700ecb812f025219fe2c75f11ecaffa-py3-none-win_amd64.whl

where the commit ID is repeated twice.

Update the script `rename_whl.py` so that we get correct names.