### PR TITLE
Use `n_features_in_` instead of deprecated `n_features_` attribute

### DIFF
--- a/docs/tutorials/builder.rst
+++ b/docs/tutorials/builder.rst
@@ -430,7 +430,7 @@ The usage of this function is as follows:
 We won't have space here to discuss all internals of scikit-learn objects, but
 a few details should be noted:
 
-* The attribute ``n_features_`` stores the number of features used anywhere
+* The attribute ``n_features_in_`` stores the number of features used anywhere
   in the tree ensemble.
 * The attribute ``n_estimators`` stores the number of member trees.
 * The attribute ``estimators_`` is an array of handles that store the individual

--- a/python/treelite/sklearn/gbm_classifier.py
+++ b/python/treelite/sklearn/gbm_classifier.py
@@ -18,7 +18,7 @@ class SKLGBMClassifierMixin:
         # Set average_tree_output=False for gradient boosted trees
         # Set pred_transform='sigmoid' to obtain probability predictions
         builder = treelite.ModelBuilder(
-            num_feature=sklearn_model.n_features_, average_tree_output=False,
+            num_feature=sklearn_model.n_features_in_, average_tree_output=False,
             pred_transform='sigmoid', threshold_type='float64', leaf_output_type='float64')
         for i in range(sklearn_model.n_estimators):
             # Process i-th tree and add to the builder

--- a/python/treelite/sklearn/gbm_multi_classifier.py
+++ b/python/treelite/sklearn/gbm_multi_classifier.py
@@ -20,7 +20,7 @@ class SKLGBMMultiClassifierMixin:
         # Set num_class for multi-class classification
         # Set pred_transform='softmax' to obtain probability predictions
         builder = treelite.ModelBuilder(
-            num_feature=sklearn_model.n_features_, num_class=sklearn_model.n_classes_,
+            num_feature=sklearn_model.n_features_in_, num_class=sklearn_model.n_classes_,
             average_tree_output=False, pred_transform='softmax',
             threshold_type='float64', leaf_output_type='float64')
         # Process [number of iterations] * [number of classes] trees

--- a/python/treelite/sklearn/gbm_regressor.py
+++ b/python/treelite/sklearn/gbm_regressor.py
@@ -16,7 +16,7 @@ class SKLGBMRegressorMixin:
         # Initialize Treelite model builder
         # Set average_tree_output=False for gradient boosted trees
         builder = treelite.ModelBuilder(
-            num_feature=sklearn_model.n_features_, average_tree_output=False,
+            num_feature=sklearn_model.n_features_in_, average_tree_output=False,
             threshold_type='float64', leaf_output_type='float64')
         for i in range(sklearn_model.n_estimators):
             # Process i-th tree and add to the builder

--- a/python/treelite/sklearn/importer.py
+++ b/python/treelite/sklearn/importer.py
@@ -178,35 +178,35 @@ def import_model(sklearn_model):
     handle = ctypes.c_void_p()
     if isinstance(sklearn_model, (RandomForestR, ExtraTreesR)):
         _check_call(_LIB.TreeliteLoadSKLearnRandomForestRegressor(
-            ctypes.c_int(sklearn_model.n_estimators), ctypes.c_int(sklearn_model.n_features_),
+            ctypes.c_int(sklearn_model.n_estimators), ctypes.c_int(sklearn_model.n_features_in_),
             c_array(ctypes.c_int64, node_count), children_left.as_c_array(),
             children_right.as_c_array(), feature.as_c_array(), threshold.as_c_array(),
             value.as_c_array(), n_node_samples.as_c_array(), weighted_n_node_samples.as_c_array(),
             impurity.as_c_array(), ctypes.byref(handle)))
     elif isinstance(sklearn_model, IsolationForest):
         _check_call(_LIB.TreeliteLoadSKLearnIsolationForest(
-            ctypes.c_int(sklearn_model.n_estimators), ctypes.c_int(sklearn_model.n_features_),
+            ctypes.c_int(sklearn_model.n_estimators), ctypes.c_int(sklearn_model.n_features_in_),
             c_array(ctypes.c_int64, node_count), children_left.as_c_array(),
             children_right.as_c_array(), feature.as_c_array(), threshold.as_c_array(),
             value.as_c_array(), n_node_samples.as_c_array(), weighted_n_node_samples.as_c_array(),
             impurity.as_c_array(), ctypes.c_double(ratio_c), ctypes.byref(handle)))
     elif isinstance(sklearn_model, (RandomForestC, ExtraTreesC)):
         _check_call(_LIB.TreeliteLoadSKLearnRandomForestClassifier(
-            ctypes.c_int(sklearn_model.n_estimators), ctypes.c_int(sklearn_model.n_features_),
+            ctypes.c_int(sklearn_model.n_estimators), ctypes.c_int(sklearn_model.n_features_in_),
             ctypes.c_int(sklearn_model.n_classes_), c_array(ctypes.c_int64, node_count),
             children_left.as_c_array(), children_right.as_c_array(), feature.as_c_array(),
             threshold.as_c_array(), value.as_c_array(), n_node_samples.as_c_array(),
             weighted_n_node_samples.as_c_array(), impurity.as_c_array(), ctypes.byref(handle)))
     elif isinstance(sklearn_model, GradientBoostingR):
         _check_call(_LIB.TreeliteLoadSKLearnGradientBoostingRegressor(
-            ctypes.c_int(sklearn_model.n_estimators), ctypes.c_int(sklearn_model.n_features_),
+            ctypes.c_int(sklearn_model.n_estimators), ctypes.c_int(sklearn_model.n_features_in_),
             c_array(ctypes.c_int64, node_count), children_left.as_c_array(),
             children_right.as_c_array(), feature.as_c_array(), threshold.as_c_array(),
             value.as_c_array(), n_node_samples.as_c_array(), weighted_n_node_samples.as_c_array(),
             impurity.as_c_array(), ctypes.byref(handle)))
     elif isinstance(sklearn_model, GradientBoostingC):
         _check_call(_LIB.TreeliteLoadSKLearnGradientBoostingClassifier(
-            ctypes.c_int(sklearn_model.n_estimators), ctypes.c_int(sklearn_model.n_features_),
+            ctypes.c_int(sklearn_model.n_estimators), ctypes.c_int(sklearn_model.n_features_in_),
             ctypes.c_int(sklearn_model.n_classes_), c_array(ctypes.c_int64, node_count),
             children_left.as_c_array(), children_right.as_c_array(), feature.as_c_array(),
             threshold.as_c_array(), value.as_c_array(), n_node_samples.as_c_array(),

--- a/python/treelite/sklearn/rf_classifier.py
+++ b/python/treelite/sklearn/rf_classifier.py
@@ -11,7 +11,7 @@ class SKLRFClassifierMixin:
         """Process a RandomForestClassifier (binary classifier) to convert it into a
            Treelite model"""
         builder = treelite.ModelBuilder(
-            num_feature=sklearn_model.n_features_, average_tree_output=True,
+            num_feature=sklearn_model.n_features_in_, average_tree_output=True,
             threshold_type='float64', leaf_output_type='float64')
         for i in range(sklearn_model.n_estimators):
             # Process i-th tree and add to the builder

--- a/python/treelite/sklearn/rf_multi_classifier.py
+++ b/python/treelite/sklearn/rf_multi_classifier.py
@@ -12,7 +12,7 @@ class SKLRFMultiClassifierMixin:
            Treelite model"""
         # Must specify num_class and pred_transform
         builder = treelite.ModelBuilder(
-            num_feature=sklearn_model.n_features_, num_class=sklearn_model.n_classes_,
+            num_feature=sklearn_model.n_features_in_, num_class=sklearn_model.n_classes_,
             average_tree_output=True, pred_transform='identity_multiclass',
             threshold_type='float64', leaf_output_type='float64')
         for i in range(sklearn_model.n_estimators):

--- a/python/treelite/sklearn/rf_regressor.py
+++ b/python/treelite/sklearn/rf_regressor.py
@@ -12,7 +12,7 @@ class SKLRFRegressorMixin:
         # Initialize Treelite model builder
         # Set average_tree_output=True for random forests
         builder = treelite.ModelBuilder(
-            num_feature=sklearn_model.n_features_, average_tree_output=True,
+            num_feature=sklearn_model.n_features_in_, average_tree_output=True,
             threshold_type='float64', leaf_output_type='float64')
 
         # Iterate over individual trees

--- a/tests/python/test_skl_importer.py
+++ b/tests/python/test_skl_importer.py
@@ -33,7 +33,7 @@ def test_skl_converter_multiclass_classifier(tmpdir, import_method, clazz, toolc
         model = treelite.sklearn.import_model(clf)
     else:
         model = treelite.sklearn.import_model_with_model_builder(clf)
-    assert model.num_feature == clf.n_features_
+    assert model.num_feature == clf.n_features_in_
     assert model.num_class == clf.n_classes_
     assert (model.num_tree ==
             clf.n_estimators * (clf.n_classes_ if clazz == GradientBoostingClassifier else 1))
@@ -48,7 +48,7 @@ def test_skl_converter_multiclass_classifier(tmpdir, import_method, clazz, toolc
     model.export_lib(toolchain=toolchain, libpath=libpath, params={'annotate_in': annotation_path},
                      verbose=True)
     predictor = treelite_runtime.Predictor(libpath=libpath)
-    assert predictor.num_feature == clf.n_features_
+    assert predictor.num_feature == clf.n_features_in_
     assert predictor.num_class == clf.n_classes_
     assert (predictor.pred_transform ==
             ('softmax' if clazz == GradientBoostingClassifier else 'identity_multiclass'))
@@ -77,7 +77,7 @@ def test_skl_converter_binary_classifier(tmpdir, import_method, clazz, toolchain
         model = treelite.sklearn.import_model(clf)
     else:
         model = treelite.sklearn.import_model_with_model_builder(clf)
-    assert model.num_feature == clf.n_features_
+    assert model.num_feature == clf.n_features_in_
     assert model.num_class == 1
     assert model.num_tree == clf.n_estimators
 
@@ -91,7 +91,7 @@ def test_skl_converter_binary_classifier(tmpdir, import_method, clazz, toolchain
     model.export_lib(toolchain=toolchain, libpath=libpath, params={'annotate_in': annotation_path},
                      verbose=True)
     predictor = treelite_runtime.Predictor(libpath=libpath)
-    assert predictor.num_feature == clf.n_features_
+    assert predictor.num_feature == clf.n_features_in_
     assert model.num_class == 1
     assert (predictor.pred_transform
             == ('sigmoid' if clazz == GradientBoostingClassifier else 'identity'))
@@ -120,7 +120,7 @@ def test_skl_converter_regressor(tmpdir, import_method, clazz, toolchain):
         model = treelite.sklearn.import_model(clf)
     else:
         model = treelite.sklearn.import_model_with_model_builder(clf)
-    assert model.num_feature == clf.n_features_
+    assert model.num_feature == clf.n_features_in_
     assert model.num_class == 1
     assert model.num_tree == clf.n_estimators
 
@@ -134,7 +134,7 @@ def test_skl_converter_regressor(tmpdir, import_method, clazz, toolchain):
     model.export_lib(toolchain=toolchain, libpath=libpath, params={'annotate_in': annotation_path},
                      verbose=True)
     predictor = treelite_runtime.Predictor(libpath=libpath)
-    assert predictor.num_feature == clf.n_features_
+    assert predictor.num_feature == clf.n_features_in_
     assert model.num_class == 1
     assert predictor.pred_transform == 'identity'
     assert predictor.global_bias == 0.0
@@ -152,7 +152,7 @@ def test_skl_converter_iforest(tmpdir, toolchain):  # pylint: disable=W0212
     expected_pred = clf._compute_chunked_score_samples(X) # pylint: disable=W0212
 
     model = treelite.sklearn.import_model(clf)
-    assert model.num_feature == clf.n_features_
+    assert model.num_feature == clf.n_features_in_
     assert model.num_class == 1
     assert model.num_tree == clf.n_estimators
 
@@ -166,7 +166,7 @@ def test_skl_converter_iforest(tmpdir, toolchain):  # pylint: disable=W0212
     model.export_lib(toolchain=toolchain, libpath=libpath, params={'annotate_in': annotation_path},
                      verbose=True)
     predictor = treelite_runtime.Predictor(libpath=libpath)
-    assert predictor.num_feature == clf.n_features_
+    assert predictor.num_feature == clf.n_features_in_
     assert model.num_class == 1
     assert predictor.pred_transform == 'exponential_standard_ratio'
     assert predictor.global_bias == 0.0


### PR DESCRIPTION
Update to use `n_features_in_` instead of the deprecated `n_features_` attribute.

## Context

- scikit-learn 1.2.0 (released yesterday) has started removing the `n_features_` attribute from classifiers.
- `n_features_in_` was added in [scikit-learn/pull/16112](https://github.com/scikit-learn/scikit-learn/pull/16112). Version 0.23.2 (August 2020). And started adding [deprecation warnings in 1.0](https://github.com/scikit-learn/scikit-learn/blob/2708aac0348402850f8e5b3176e84b39c6f5917d/doc/whats_new/v1.0.rst#id1395).