### PR TITLE
[CI] Replace load_boston with a randomly generated regression data

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+profile=black
+known_first_party=treelite,treelite_runtime

--- a/ops/conda_env/dev.yml
+++ b/ops/conda_env/dev.yml
@@ -8,6 +8,7 @@ dependencies:
 - pandas
 - pytest
 - pytest-cov
+- hypothesis
 - scikit-learn
 - coverage
 - codecov

--- a/ops/cpp-python-coverage.sh
+++ b/ops/cpp-python-coverage.sh
@@ -22,7 +22,7 @@ cd ../..
 
 echo "##[section]Running Python integration tests..."
 export PYTHONPATH='./python:./runtime/python'
-python -m pytest --cov=treelite --cov=treelite_runtime -v -rxXs --fulltrace tests/python tests/cython
+python -m pytest --cov=treelite --cov=treelite_runtime -v -rxXs --fulltrace --durations=0 tests/python tests/cython
 
 echo "##[section]Collecting coverage data..."
 lcov --directory . --capture --output-file coverage.info

--- a/ops/macos-python-coverage.sh
+++ b/ops/macos-python-coverage.sh
@@ -17,7 +17,7 @@ cd ..
 
 ./build/treelite_cpp_test
 PYTHONPATH=./python:./runtime/python python -m pytest --cov=treelite --cov=treelite_runtime -v -rxXs \
-  --fulltrace tests/python
+  --fulltrace --durations=0 tests/python
 lcov --directory . --capture --output-file coverage.info
 lcov --remove coverage.info '*dmlccore*' --output-file coverage.info
 lcov --remove coverage.info '*fmtlib*' --output-file coverage.info

--- a/ops/test-linux-python-wheel.sh
+++ b/ops/test-linux-python-wheel.sh
@@ -6,7 +6,7 @@ echo "##[section]Installing Treelite into Python environment..."
 pip install python/dist/*.whl runtime/python/dist/*.whl
 
 echo "##[section]Running Python tests..."
-python -m pytest -v -rxXs --fulltrace tests/python/test_basic.py
+python -m pytest -v -rxXs --fulltrace --durations=0 tests/python/test_basic.py
 
 echo "##[section]Uploading Python wheels..."
 python -m awscli s3 cp python/dist/*.whl s3://treelite-wheels/ --acl public-read || true

--- a/ops/test-macos-python-wheel.sh
+++ b/ops/test-macos-python-wheel.sh
@@ -6,4 +6,4 @@ echo "##[section]Installing Treelite into Python environment..."
 pip install wheelhouse/*.whl
 
 echo "##[section]Running Python tests..."
-python -m pytest -v -rxXs --fulltrace tests/python/test_basic.py
+python -m pytest -v -rxXs --fulltrace --durations=0 tests/python/test_basic.py

--- a/ops/test-sdist.sh
+++ b/ops/test-sdist.sh
@@ -8,7 +8,7 @@ make pippack
 echo "##[section]Testing the source distribution..."
 python -m pip install -v treelite-*.tar.gz
 python -m pip install -v treelite_runtime-*.tar.gz
-python -m pytest -v -rxXs --fulltrace tests/python/test_basic.py
+python -m pytest -v -rxXs --fulltrace --durations=0 tests/python/test_basic.py
 
 # Deploy source distribution to S3
 for file in ./treelite-*.tar.gz ./treelite_runtime-*.tar.gz

--- a/ops/test-win-python-wheel.bat
+++ b/ops/test-win-python-wheel.bat
@@ -18,7 +18,7 @@ for /R %%i in (runtime\\python\\dist\\*.whl) DO (
 
 echo ##[section]Running Python tests...
 mkdir temp
-python -m pytest --basetemp="%WORKING_DIR%\temp" -v -rxXs --fulltrace tests\python\test_basic.py
+python -m pytest --basetemp="%WORKING_DIR%\temp" -v -rxXs --fulltrace --durations=0 tests\python\test_basic.py
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo ##[section]Uploading Python wheels...

--- a/ops/win-python-coverage.bat
+++ b/ops/win-python-coverage.bat
@@ -14,7 +14,7 @@ mkdir temp
 call micromamba activate dev
 if %errorlevel% neq 0 exit /b %errorlevel%
 set "PYTHONPATH=./python;./runtime/python"
-python -m pytest --basetemp="%WORKING_DIR%\temp" --cov=treelite --cov=treelite_runtime --cov-report xml -v -rxXs --fulltrace tests\python
+python -m pytest --basetemp="%WORKING_DIR%\temp" --cov=treelite --cov=treelite_runtime --cov-report xml -v -rxXs --fulltrace --durations=0 tests\python
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo ##[section]Submitting code coverage data to CodeCov...

--- a/ops/win-python-coverage.bat
+++ b/ops/win-python-coverage.bat
@@ -14,6 +14,7 @@ mkdir temp
 call micromamba activate dev
 if %errorlevel% neq 0 exit /b %errorlevel%
 set "PYTHONPATH=./python;./runtime/python"
+set "PYTEST_TMPDIR=%WORKING_DIR%\temp"
 python -m pytest --basetemp="%WORKING_DIR%\temp" --cov=treelite --cov=treelite_runtime --cov-report xml -v -rxXs --fulltrace --durations=0 tests\python
 if %errorlevel% neq 0 exit /b %errorlevel%
 

--- a/src/annotator.cc
+++ b/src/annotator.cc
@@ -228,7 +228,8 @@ AnnotateImpl(
   // change layout of counts
   std::vector<std::vector<uint64_t>>& counts = *out_counts;
   for (size_t i = 0; i < ntree; ++i) {
-    counts.emplace_back(&new_counts[count_row_ptr[i]], &new_counts[count_row_ptr[i + 1]]);
+    counts.emplace_back(new_counts.begin() + count_row_ptr[i],
+                        new_counts.begin() + count_row_ptr[i + 1]);
   }
 }
 

--- a/tests/cython/compatibility_tester.py
+++ b/tests/cython/compatibility_tester.py
@@ -1,9 +1,12 @@
-import pickle
 import argparse
+import os
+import pickle
+
+import lightgbm as lgb
 import numpy as np
-import treelite
 from sklearn.datasets import load_iris
-from sklearn.ensemble import RandomForestClassifier
+
+import treelite
 
 
 def _fetch_data():
@@ -12,7 +15,7 @@ def _fetch_data():
 
 
 def _train_model(X, y):
-    clf = RandomForestClassifier(max_depth=3, random_state=0, n_estimators=3)
+    clf = lgb.LGBMClassifier(max_depth=3, random_state=0, n_estimators=3)
     clf.fit(X, y)
     return clf
 
@@ -22,7 +25,7 @@ def save(args):
     clf = _train_model(X, y)
     with open(args.model_pickle_path, "wb") as f:
         pickle.dump(clf, f)
-    tl_model = treelite.sklearn.import_model(clf)
+    tl_model = treelite.Model.from_lightgbm(clf.booster_)
     tl_model.serialize(args.checkpoint_path)
 
 

--- a/tests/python/hypothesis_util.py
+++ b/tests/python/hypothesis_util.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+"""Utility functions for hypothesis-based testing"""
+
+import os
+from sys import platform as _platform
+
+import numpy as np
+from hypothesis.strategies import composite, integers, just, none
+from sklearn.datasets import make_regression
+
+
+@composite
+def standard_regression_datasets(
+    draw,
+    n_samples=integers(min_value=100, max_value=200),
+    n_features=integers(min_value=100, max_value=200),
+    *,
+    n_informative=None,
+    n_targets=just(1),
+    bias=just(0.0),
+    effective_rank=none(),
+    tail_strength=just(0.5),
+    noise=just(0.0),
+    shuffle=just(True),
+    random_state=None,
+):
+    """
+    Returns a strategy to generate regression problem input datasets.
+    Note:
+    This function uses the sklearn.datasets.make_regression function to
+    generate the regression problem from the provided search strategies.
+
+    Credit: Carl Simon Adorf (@csadorf)
+    https://github.com/rapidsai/cuml/blob/447bded/python/cuml/testing/strategies.py
+
+    Parameters
+    ----------
+    n_samples: SearchStrategy[int]
+        Returned arrays will have number of rows drawn from these values.
+    n_features: SearchStrategy[int]
+        Returned arrays will have number of columns drawn from these values.
+    n_informative: SearchStrategy[int], default=none
+        A search strategy for the number of informative features. If none,
+        will use 10% of the actual number of features, but not less than 1
+        unless the number of features is zero.
+    n_targets: SearchStrategy[int], default=just(1)
+        A search strategy for the number of targets, that means the number of
+        columns of the returned y output array.
+    bias: SearchStrategy[float], default=just(0.0)
+        A search strategy for the bias term.
+    effective_rank=none()
+        If not None, a search strategy for the effective rank of the input data
+        for the regression problem. See sklearn.dataset.make_regression() for a
+        detailed explanation of this parameter.
+    tail_strength: SearchStrategy[float], default=just(0.5)
+        See sklearn.dataset.make_regression() for a detailed explanation of
+        this parameter.
+    noise: SearchStrategy[float], default=just(0.0)
+        A search strategy for the standard deviation of the gaussian noise.
+    shuffle: SearchStrategy[bool], default=just(True)
+        A boolean search strategy to determine whether samples and features
+        are shuffled.
+    random_state: int, RandomState instance or None, default=None
+        Pass a random state or integer to determine the random number
+        generation for data set generation.
+    Returns
+    -------
+    (X, y):  SearchStrategy[array], SearchStrategy[array]
+        A tuple of search strategies for arrays subject to the constraints of
+        the provided parameters.
+    """
+    n_features_ = draw(n_features)
+    if n_informative is None:
+        n_informative = just(max(min(n_features_, 1), int(0.1 * n_features_)))
+    X, y = make_regression(
+        n_samples=draw(n_samples),
+        n_features=n_features_,
+        n_informative=draw(n_informative),
+        n_targets=draw(n_targets),
+        bias=draw(bias),
+        effective_rank=draw(effective_rank),
+        tail_strength=draw(tail_strength),
+        noise=draw(noise),
+        shuffle=draw(shuffle),
+        random_state=random_state,
+    )
+    return X.astype(np.float32), y.astype(np.float32)
+
+
+def standard_settings():
+    """Default hypotheiss settings. Set a smaller max_examples on Windows"""
+    kwargs = {
+        "deadline": None,
+        "max_examples": 20,
+        "print_blob": True,
+    }
+    if _platform == "win32":
+        kwargs["max_examples"] = 3
+    return kwargs

--- a/tests/python/hypothesis_util.py
+++ b/tests/python/hypothesis_util.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Utility functions for hypothesis-based testing"""
 
-import os
 from sys import platform as _platform
 
 import numpy as np

--- a/tests/python/test_gtil.py
+++ b/tests/python/test_gtil.py
@@ -2,59 +2,76 @@
 Tests for General Tree Inference Library (GTIL). The tests ensure that GTIL produces correct
 prediction results for a variety of tree models.
 """
-import os
 import json
-import pytest
-import treelite
+import os
+
 import numpy as np
+import pytest
 import scipy
-from sklearn.ensemble import RandomForestClassifier, GradientBoostingClassifier, \
-    ExtraTreesClassifier, RandomForestRegressor, GradientBoostingRegressor, \
-    ExtraTreesRegressor, IsolationForest
-from sklearn.datasets import load_iris, load_breast_cancer, load_boston, load_svmlight_file
+from hypothesis import given, settings
+from hypothesis.strategies import integers, sampled_from
+from sklearn.datasets import load_breast_cancer, load_iris, load_svmlight_file
+from sklearn.ensemble import (
+    ExtraTreesClassifier,
+    ExtraTreesRegressor,
+    GradientBoostingClassifier,
+    GradientBoostingRegressor,
+    IsolationForest,
+    RandomForestClassifier,
+    RandomForestRegressor,
+)
 from sklearn.model_selection import train_test_split
 
+import treelite
+
+from .hypothesis_util import standard_regression_datasets, standard_settings
 from .metadata import dataset_db
-from .util import load_txt
+from .util import TemporaryDirectory, load_txt
 
 try:
     import xgboost as xgb
 except ImportError:
     # skip this test suite if XGBoost is not installed
-    pytest.skip('XGBoost not installed; skipping', allow_module_level=True)
+    pytest.skip("XGBoost not installed; skipping", allow_module_level=True)
 
 try:
     import lightgbm as lgb
 except ImportError:
     # skip this test suite if LightGBM is not installed
-    pytest.skip('LightGBM not installed; skipping', allow_module_level=True)
+    pytest.skip("LightGBM not installed; skipping", allow_module_level=True)
 
 
-@pytest.mark.parametrize('clazz', [RandomForestRegressor, ExtraTreesRegressor,
-                                   GradientBoostingRegressor])
-def test_skl_regressor(clazz):
+@given(
+    clazz=sampled_from(
+        [RandomForestRegressor, ExtraTreesRegressor, GradientBoostingRegressor]
+    ),
+    dataset=standard_regression_datasets(),
+)
+@settings(**standard_settings())
+def test_skl_regressor(clazz, dataset):
     """Scikit-learn regressor"""
-    X, y = load_boston(return_X_y=True)
-    kwargs = {'max_depth': 3, 'random_state': 0, 'n_estimators': 10}
+    X, y = dataset
+    kwargs = {"max_depth": 3, "random_state": 0, "n_estimators": 10}
     if clazz == GradientBoostingRegressor:
-        kwargs['init'] = 'zero'
+        kwargs["init"] = "zero"
     clf = clazz(**kwargs)
     clf.fit(X, y)
     expected_pred = clf.predict(X)
 
     tl_model = treelite.sklearn.import_model(clf)
     out_pred = treelite.gtil.predict(tl_model, X)
-    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
+    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=4)
 
 
-@pytest.mark.parametrize('clazz', [RandomForestClassifier, ExtraTreesClassifier,
-                                   GradientBoostingClassifier])
+@pytest.mark.parametrize(
+    "clazz", [RandomForestClassifier, ExtraTreesClassifier, GradientBoostingClassifier]
+)
 def test_skl_binary_classifier(clazz):
     """Scikit-learn binary classifier"""
     X, y = load_breast_cancer(return_X_y=True)
-    kwargs = {'max_depth': 3, 'random_state': 0, 'n_estimators': 10}
+    kwargs = {"max_depth": 3, "random_state": 0, "n_estimators": 10}
     if clazz == GradientBoostingClassifier:
-        kwargs['init'] = 'zero'
+        kwargs["init"] = "zero"
     clf = clazz(**kwargs)
     clf.fit(X, y)
     expected_prob = clf.predict_proba(X)[:, 1]
@@ -64,14 +81,15 @@ def test_skl_binary_classifier(clazz):
     np.testing.assert_almost_equal(out_prob, expected_prob, decimal=5)
 
 
-@pytest.mark.parametrize('clazz', [RandomForestClassifier, ExtraTreesClassifier,
-                                   GradientBoostingClassifier])
+@pytest.mark.parametrize(
+    "clazz", [RandomForestClassifier, ExtraTreesClassifier, GradientBoostingClassifier]
+)
 def test_skl_multiclass_classifier(clazz):
     """Scikit-learn multi-class classifier"""
     X, y = load_iris(return_X_y=True)
-    kwargs = {'max_depth': 3, 'random_state': 0, 'n_estimators': 10}
+    kwargs = {"max_depth": 3, "random_state": 0, "n_estimators": 10}
     if clazz == GradientBoostingClassifier:
-        kwargs['init'] = 'zero'
+        kwargs["init"] = "zero"
     clf = clazz(**kwargs)
     clf.fit(X, y)
     expected_prob = clf.predict_proba(X)
@@ -81,9 +99,11 @@ def test_skl_multiclass_classifier(clazz):
     np.testing.assert_almost_equal(out_prob, expected_prob, decimal=5)
 
 
-def test_skl_converter_iforest():
+@given(standard_regression_datasets())
+@settings(**standard_settings())
+def test_skl_converter_iforest(dataset):
     """Scikit-learn isolation forest"""
-    X, _ = load_boston(return_X_y=True)
+    X, _ = dataset
     clf = IsolationForest(max_samples=64, random_state=0, n_estimators=10)
     clf.fit(X)
     expected_pred = clf._compute_chunked_score_samples(X)  # pylint: disable=W0212
@@ -93,67 +113,106 @@ def test_skl_converter_iforest():
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=2)
 
 
-@pytest.mark.parametrize('num_parallel_tree', [1, 3, 5])
-@pytest.mark.parametrize('model_format', ['binary', 'json'])
-@pytest.mark.parametrize('objective', ['reg:linear', 'reg:squarederror', 'reg:squaredlogerror',
-                                       'reg:pseudohubererror'])
-def test_xgb_boston(tmpdir, objective, model_format, num_parallel_tree):
+@given(
+    objective=sampled_from(
+        [
+            "reg:linear",
+            "reg:squarederror",
+            "reg:squaredlogerror",
+            "reg:pseudohubererror",
+        ]
+    ),
+    model_format=sampled_from(["binary", "json"]),
+    num_parallel_tree=integers(min_value=1, max_value=10),
+    dataset=standard_regression_datasets(),
+)
+@settings(**standard_settings())
+def test_xgb_regression(objective, model_format, num_parallel_tree, dataset):
     # pylint: disable=too-many-locals
-    """Test XGBoost with Boston data (regression)"""
-    X, y = load_boston(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
+    """Test XGBoost with regression data"""
+    X, y = dataset
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, shuffle=False
+    )
     dtrain = xgb.DMatrix(X_train, label=y_train)
     dtest = xgb.DMatrix(X_test, label=y_test)
-    param = {'max_depth': 8, 'eta': 1, 'verbosity': 0, 'objective': objective,
-             'num_parallel_tree': num_parallel_tree}
+    param = {
+        "max_depth": 8,
+        "eta": 1,
+        "verbosity": 0,
+        "objective": objective,
+        "num_parallel_tree": num_parallel_tree,
+    }
     num_round = 10
-    xgb_model = xgb.train(param, dtrain, num_boost_round=num_round,
-                          evals=[(dtrain, 'train'), (dtest, 'test')])
-    if model_format == 'json':
-        model_name = 'boston.json'
-        model_path = os.path.join(tmpdir, model_name)
-        xgb_model.save_model(model_path)
-        tl_model = treelite.Model.load(filename=model_path, model_format='xgboost_json')
-    else:
-        model_name = 'boston.model'
-        model_path = os.path.join(tmpdir, model_name)
-        xgb_model.save_model(model_path)
-        tl_model = treelite.Model.load(filename=model_path, model_format='xgboost')
-    assert len(json.loads(tl_model.dump_as_json())["trees"]) == num_round * num_parallel_tree
+    xgb_model = xgb.train(
+        param,
+        dtrain,
+        num_boost_round=num_round,
+        evals=[(dtrain, "train"), (dtest, "test")],
+    )
+    with TemporaryDirectory() as tmpdir:
+        if model_format == "json":
+            model_name = "boston.json"
+            model_path = os.path.join(tmpdir, model_name)
+            xgb_model.save_model(model_path)
+            tl_model = treelite.Model.load(
+                filename=model_path, model_format="xgboost_json"
+            )
+        else:
+            model_name = "boston.model"
+            model_path = os.path.join(tmpdir, model_name)
+            xgb_model.save_model(model_path)
+            tl_model = treelite.Model.load(filename=model_path, model_format="xgboost")
+        assert (
+            len(json.loads(tl_model.dump_as_json())["trees"])
+            == num_round * num_parallel_tree
+        )
 
-    out_pred = treelite.gtil.predict(tl_model, X_test)
-    expected_pred = xgb_model.predict(dtest)
-    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
+        out_pred = treelite.gtil.predict(tl_model, X_test)
+        expected_pred = xgb_model.predict(dtest)
+        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
-@pytest.mark.parametrize('num_parallel_tree', [1, 3, 5])
-@pytest.mark.parametrize('model_format', ['binary', 'json'])
-@pytest.mark.parametrize('objective', ['multi:softmax', 'multi:softprob'])
+@pytest.mark.parametrize("num_parallel_tree", [1, 3, 5])
+@pytest.mark.parametrize("model_format", ["binary", "json"])
+@pytest.mark.parametrize("objective", ["multi:softmax", "multi:softprob"])
 def test_xgb_iris(tmpdir, objective, model_format, num_parallel_tree):
     # pylint: disable=too-many-locals
     """Test XGBoost with Iris data (multi-class classification)"""
     X, y = load_iris(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, shuffle=False
+    )
     dtrain = xgb.DMatrix(X_train, label=y_train)
     dtest = xgb.DMatrix(X_test, label=y_test)
     num_class = 3
-    param = {'max_depth': 6, 'eta': 0.05, 'num_class': num_class, 'verbosity': 0,
-             'objective': objective, 'metric': 'mlogloss',
-             'num_parallel_tree': num_parallel_tree}
+    param = {
+        "max_depth": 6,
+        "eta": 0.05,
+        "num_class": num_class,
+        "verbosity": 0,
+        "objective": objective,
+        "metric": "mlogloss",
+        "num_parallel_tree": num_parallel_tree,
+    }
     num_round = 3
-    xgb_model = xgb.train(param, dtrain, num_boost_round=num_round,
-                          evals=[(dtrain, 'train'), (dtest, 'test')])
+    xgb_model = xgb.train(
+        param,
+        dtrain,
+        num_boost_round=num_round,
+        evals=[(dtrain, "train"), (dtest, "test")],
+    )
 
-    if model_format == 'json':
-        model_name = 'iris.json'
+    if model_format == "json":
+        model_name = "iris.json"
         model_path = os.path.join(tmpdir, model_name)
         xgb_model.save_model(model_path)
-        tl_model = treelite.Model.load(filename=model_path, model_format='xgboost_json')
+        tl_model = treelite.Model.load(filename=model_path, model_format="xgboost_json")
     else:
-        model_name = 'iris.model'
+        model_name = "iris.model"
         model_path = os.path.join(tmpdir, model_name)
         xgb_model.save_model(model_path)
-        tl_model = treelite.Model.load(filename=model_path, model_format='xgboost')
+        tl_model = treelite.Model.load(filename=model_path, model_format="xgboost")
     expected_num_tree = num_class * num_round * num_parallel_tree
     assert len(json.loads(tl_model.dump_as_json())["trees"]) == expected_num_tree
 
@@ -162,17 +221,28 @@ def test_xgb_iris(tmpdir, objective, model_format, num_parallel_tree):
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
-@pytest.mark.parametrize('model_format', ['binary', 'json'])
-@pytest.mark.parametrize('objective,max_label',
-                         [('binary:logistic', 2),
-                          ('binary:hinge', 2),
-                          ('binary:logitraw', 2),
-                          ('count:poisson', 4),
-                          ('rank:pairwise', 5),
-                          ('rank:ndcg', 5),
-                          ('rank:map', 5)],
-                         ids=['binary:logistic', 'binary:hinge', 'binary:logitraw',
-                              'count:poisson', 'rank:pairwise', 'rank:ndcg', 'rank:map'])
+@pytest.mark.parametrize("model_format", ["binary", "json"])
+@pytest.mark.parametrize(
+    "objective,max_label",
+    [
+        ("binary:logistic", 2),
+        ("binary:hinge", 2),
+        ("binary:logitraw", 2),
+        ("count:poisson", 4),
+        ("rank:pairwise", 5),
+        ("rank:ndcg", 5),
+        ("rank:map", 5),
+    ],
+    ids=[
+        "binary:logistic",
+        "binary:hinge",
+        "binary:logitraw",
+        "count:poisson",
+        "rank:pairwise",
+        "rank:ndcg",
+        "rank:map",
+    ],
+)
 def test_xgb_nonlinear_objective(tmpdir, objective, max_label, model_format):
     # pylint: disable=too-many-locals
     """Test XGBoost with non-linear objectives with dummy data"""
@@ -186,37 +256,43 @@ def test_xgb_nonlinear_objective(tmpdir, objective, max_label, model_format):
 
     num_round = 4
     dtrain = xgb.DMatrix(X, label=y)
-    if objective.startswith('rank:'):
+    if objective.startswith("rank:"):
         dtrain.set_group([nrow])
-    xgb_model = xgb.train({'objective': objective, 'base_score': 0.5, 'seed': 0},
-                          dtrain=dtrain, num_boost_round=num_round)
+    xgb_model = xgb.train(
+        {"objective": objective, "base_score": 0.5, "seed": 0},
+        dtrain=dtrain,
+        num_boost_round=num_round,
+    )
 
-    objective_tag = objective.replace(':', '_')
-    if model_format == 'json':
-        model_name = f'nonlinear_{objective_tag}.json'
+    objective_tag = objective.replace(":", "_")
+    if model_format == "json":
+        model_name = f"nonlinear_{objective_tag}.json"
     else:
-        model_name = f'nonlinear_{objective_tag}.bin'
+        model_name = f"nonlinear_{objective_tag}.bin"
     model_path = os.path.join(tmpdir, model_name)
     xgb_model.save_model(model_path)
 
     tl_model = treelite.Model.load(
         filename=model_path,
-        model_format=('xgboost_json' if model_format == 'json' else 'xgboost'))
+        model_format=("xgboost_json" if model_format == "json" else "xgboost"),
+    )
 
     out_pred = treelite.gtil.predict(tl_model, X)
     expected_pred = xgb_model.predict(dtrain)
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
-@pytest.mark.parametrize('in_memory', [True, False])
+@pytest.mark.parametrize("in_memory", [True, False])
 def test_xgb_categorical_split(in_memory):
     """Test toy XGBoost model with categorical splits"""
-    dataset = 'xgb_toy_categorical'
+    dataset = "xgb_toy_categorical"
     if in_memory:
         xgb_model = xgb.Booster(model_file=dataset_db[dataset].model)
         tl_model = treelite.Model.from_xgboost(xgb_model)
     else:
-        tl_model = treelite.Model.load(dataset_db[dataset].model, model_format='xgboost_json')
+        tl_model = treelite.Model.load(
+            dataset_db[dataset].model, model_format="xgboost_json"
+        )
 
     X, _ = load_svmlight_file(dataset_db[dataset].dtest, zero_based=True)
     expected_pred = load_txt(dataset_db[dataset].expected_margin)
@@ -224,7 +300,7 @@ def test_xgb_categorical_split(in_memory):
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
-@pytest.mark.parametrize('model_format', ['binary', 'json'])
+@pytest.mark.parametrize("model_format", ["binary", "json"])
 def test_xgb_dart(tmpdir, model_format):
     # pylint: disable=too-many-locals
     """Test XGBoost DART model with dummy data"""
@@ -238,20 +314,23 @@ def test_xgb_dart(tmpdir, model_format):
 
     num_round = 50
     dtrain = xgb.DMatrix(X, label=y)
-    param = {'booster': 'dart',
-             'max_depth': 5, 'learning_rate': 0.1,
-             'objective': 'binary:logistic',
-             'sample_type': 'uniform',
-             'normalize_type': 'tree',
-             'rate_drop': 0.1,
-             'skip_drop': 0.5}
+    param = {
+        "booster": "dart",
+        "max_depth": 5,
+        "learning_rate": 0.1,
+        "objective": "binary:logistic",
+        "sample_type": "uniform",
+        "normalize_type": "tree",
+        "rate_drop": 0.1,
+        "skip_drop": 0.5,
+    }
     xgb_model = xgb.train(param, dtrain=dtrain, num_boost_round=num_round)
 
-    if model_format == 'json':
-        model_name = 'dart.json'
+    if model_format == "json":
+        model_name = "dart.json"
         model_path = os.path.join(tmpdir, model_name)
         xgb_model.save_model(model_path)
-        tl_model = treelite.Model.load(filename=model_path, model_format='xgboost_json')
+        tl_model = treelite.Model.load(filename=model_path, model_format="xgboost_json")
     else:
         tl_model = treelite.Model.from_xgboost(xgb_model)
     out_pred = treelite.gtil.predict(tl_model, X)
@@ -259,79 +338,125 @@ def test_xgb_dart(tmpdir, model_format):
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
-@pytest.mark.parametrize('objective', ['regression', 'regression_l1', 'huber'])
-@pytest.mark.parametrize('reg_sqrt', [True, False])
-def test_lightgbm_regression(tmpdir, objective, reg_sqrt):
+@given(
+    objective=sampled_from(["regression", "regression_l1", "huber"]),
+    reg_sqrt=sampled_from([True, False]),
+    dataset=standard_regression_datasets(),
+)
+@settings(**standard_settings())
+def test_lightgbm_regression(objective, reg_sqrt, dataset):
     # pylint: disable=too-many-locals
     """Test LightGBM regressor"""
-    lgb_model_path = os.path.join(tmpdir, 'boston_lightgbm.txt')
-
-    X, y = load_boston(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
+    X, y = dataset
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, shuffle=False
+    )
     dtrain = lgb.Dataset(X_train, y_train, free_raw_data=False)
     dtest = lgb.Dataset(X_test, y_test, reference=dtrain, free_raw_data=False)
-    param = {'task': 'train', 'boosting_type': 'gbdt', 'objective': objective, 'reg_sqrt': reg_sqrt,
-             'metric': 'rmse', 'num_leaves': 31, 'learning_rate': 0.05}
-    lgb_model = lgb.train(param, dtrain, num_boost_round=10, valid_sets=[dtrain, dtest],
-                          valid_names=['train', 'test'])
+    param = {
+        "task": "train",
+        "boosting_type": "gbdt",
+        "objective": objective,
+        "reg_sqrt": reg_sqrt,
+        "metric": "rmse",
+        "num_leaves": 31,
+        "learning_rate": 0.05,
+    }
+    lgb_model = lgb.train(
+        param,
+        dtrain,
+        num_boost_round=10,
+        valid_sets=[dtrain, dtest],
+        valid_names=["train", "test"],
+    )
     expected_pred = lgb_model.predict(X_test)
-    lgb_model.save_model(lgb_model_path)
 
-    tl_model = treelite.Model.load(lgb_model_path, model_format='lightgbm')
-    out_pred = treelite.gtil.predict(tl_model, X_test)
-    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
+    with TemporaryDirectory() as tmpdir:
+        lgb_model_path = os.path.join(tmpdir, "boston_lightgbm.txt")
+        lgb_model.save_model(lgb_model_path)
+
+        tl_model = treelite.Model.load(lgb_model_path, model_format="lightgbm")
+        out_pred = treelite.gtil.predict(tl_model, X_test)
+        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
-@pytest.mark.parametrize('objective', ['binary', 'xentlambda', 'xentropy'])
+@pytest.mark.parametrize("objective", ["binary", "xentlambda", "xentropy"])
 def test_lightgbm_binary_classification(tmpdir, objective):
     # pylint: disable=too-many-locals
     """Test LightGBM binary classifier"""
-    lgb_model_path = os.path.join(tmpdir, 'breast_cancer_lightgbm.txt')
+    lgb_model_path = os.path.join(tmpdir, "breast_cancer_lightgbm.txt")
     X, y = load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, shuffle=False
+    )
     dtrain = lgb.Dataset(X_train, y_train, free_raw_data=False)
     dtest = lgb.Dataset(X_test, y_test, reference=dtrain, free_raw_data=False)
-    param = {'task': 'train', 'boosting_type': 'gbdt', 'objective': objective, 'metric': 'auc',
-             'num_leaves': 7, 'learning_rate': 0.1}
-    lgb_model = lgb.train(param, dtrain, num_boost_round=10, valid_sets=[dtrain, dtest],
-                               valid_names=['train', 'test'])
+    param = {
+        "task": "train",
+        "boosting_type": "gbdt",
+        "objective": objective,
+        "metric": "auc",
+        "num_leaves": 7,
+        "learning_rate": 0.1,
+    }
+    lgb_model = lgb.train(
+        param,
+        dtrain,
+        num_boost_round=10,
+        valid_sets=[dtrain, dtest],
+        valid_names=["train", "test"],
+    )
     expected_prob = lgb_model.predict(X_test)
     lgb_model.save_model(lgb_model_path)
 
-    tl_model = treelite.Model.load(lgb_model_path, model_format='lightgbm')
+    tl_model = treelite.Model.load(lgb_model_path, model_format="lightgbm")
     out_prob = treelite.gtil.predict(tl_model, X_test)
     np.testing.assert_almost_equal(out_prob, expected_prob, decimal=5)
 
 
-@pytest.mark.parametrize('boosting_type', ['gbdt', 'rf'])
-@pytest.mark.parametrize('objective', ['multiclass', 'multiclassova'])
+@pytest.mark.parametrize("boosting_type", ["gbdt", "rf"])
+@pytest.mark.parametrize("objective", ["multiclass", "multiclassova"])
 def test_lightgbm_multiclass_classification(tmpdir, objective, boosting_type):
     # pylint: disable=too-many-locals
     """Test LightGBM multi-class classifier"""
-    lgb_model_path = os.path.join(tmpdir, 'iris_lightgbm.txt')
+    lgb_model_path = os.path.join(tmpdir, "iris_lightgbm.txt")
     X, y = load_iris(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, shuffle=False
+    )
     dtrain = lgb.Dataset(X_train, y_train, free_raw_data=False)
     dtest = lgb.Dataset(X_test, y_test, reference=dtrain, free_raw_data=False)
-    param = {'task': 'train', 'boosting': boosting_type, 'objective': objective,
-             'metric': 'multi_logloss', 'num_class': 3, 'num_leaves': 31, 'learning_rate': 0.05}
-    if boosting_type == 'rf':
-        param.update({'bagging_fraction': 0.8, 'bagging_freq': 1})
-    lgb_model = lgb.train(param, dtrain, num_boost_round=10, valid_sets=[dtrain, dtest],
-                               valid_names=['train', 'test'])
+    param = {
+        "task": "train",
+        "boosting": boosting_type,
+        "objective": objective,
+        "metric": "multi_logloss",
+        "num_class": 3,
+        "num_leaves": 31,
+        "learning_rate": 0.05,
+    }
+    if boosting_type == "rf":
+        param.update({"bagging_fraction": 0.8, "bagging_freq": 1})
+    lgb_model = lgb.train(
+        param,
+        dtrain,
+        num_boost_round=10,
+        valid_sets=[dtrain, dtest],
+        valid_names=["train", "test"],
+    )
     expected_pred = lgb_model.predict(X_test)
     lgb_model.save_model(lgb_model_path)
 
-    tl_model = treelite.Model.load(lgb_model_path, model_format='lightgbm')
+    tl_model = treelite.Model.load(lgb_model_path, model_format="lightgbm")
     out_pred = treelite.gtil.predict(tl_model, X_test)
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
 def test_lightgbm_categorical_data():
     """Test LightGBM with toy categorical data"""
-    dataset = 'toy_categorical'
+    dataset = "toy_categorical"
     lgb_model_path = dataset_db[dataset].model
-    tl_model = treelite.Model.load(lgb_model_path, model_format='lightgbm')
+    tl_model = treelite.Model.load(lgb_model_path, model_format="lightgbm")
 
     X, _ = load_svmlight_file(dataset_db[dataset].dtest, zero_based=True)
     expected_pred = load_txt(dataset_db[dataset].expected_margin)
@@ -342,33 +467,34 @@ def test_lightgbm_categorical_data():
 def test_lightgbm_sparse_ranking_model(tmpdir):
     """Generate a LightGBM ranking model with highly sparse data."""
     rng = np.random.default_rng(seed=2020)
-    X = scipy.sparse.random(m=10, n=206947, format='csr', dtype=np.float64, random_state=0,
-                            density=0.0001)
+    X = scipy.sparse.random(
+        m=10, n=206947, format="csr", dtype=np.float64, random_state=0, density=0.0001
+    )
     X.data = rng.standard_normal(size=X.data.shape[0], dtype=np.float64)
     y = rng.integers(low=0, high=5, size=X.shape[0])
 
     params = {
-        'objective': 'lambdarank',
-        'num_leaves': 32,
-        'lambda_l1': 0.0,
-        'lambda_l2': 0.0,
-        'min_gain_to_split': 0.0,
-        'learning_rate': 1.0,
-        'min_data_in_leaf': 1
+        "objective": "lambdarank",
+        "num_leaves": 32,
+        "lambda_l1": 0.0,
+        "lambda_l2": 0.0,
+        "min_gain_to_split": 0.0,
+        "learning_rate": 1.0,
+        "min_data_in_leaf": 1,
     }
 
-    lgb_model_path = os.path.join(tmpdir, 'sparse_ranking_lightgbm.txt')
+    lgb_model_path = os.path.join(tmpdir, "sparse_ranking_lightgbm.txt")
 
     dtrain = lgb.Dataset(X, label=y, group=[X.shape[0]])
     lgb_model = lgb.train(params, dtrain, num_boost_round=1)
     lgb_out = lgb_model.predict(X)
     lgb_model.save_model(lgb_model_path)
 
-    tl_model = treelite.Model.load(lgb_model_path, model_format='lightgbm')
+    tl_model = treelite.Model.load(lgb_model_path, model_format="lightgbm")
 
     # GTIL doesn't yet support sparse matrix; so use NaN to represent missing values
     Xa = X.toarray()
-    Xa[Xa == 0] = 'nan'
+    Xa[Xa == 0] = "nan"
     out = treelite.gtil.predict(tl_model, Xa)
 
     np.testing.assert_almost_equal(out, lgb_out)
@@ -376,15 +502,16 @@ def test_lightgbm_sparse_ranking_model(tmpdir):
 
 def test_lightgbm_sparse_categorical_model():
     """Test LightGBM with high-cardinality categorical features"""
-    dataset = 'sparse_categorical'
+    dataset = "sparse_categorical"
     lgb_model_path = dataset_db[dataset].model
-    tl_model = treelite.Model.load(lgb_model_path, model_format='lightgbm')
+    tl_model = treelite.Model.load(lgb_model_path, model_format="lightgbm")
 
-    X, _ = load_svmlight_file(dataset_db[dataset].dtest, zero_based=True,
-                              n_features=tl_model.num_feature)
+    X, _ = load_svmlight_file(
+        dataset_db[dataset].dtest, zero_based=True, n_features=tl_model.num_feature
+    )
     expected_pred = load_txt(dataset_db[dataset].expected_margin)
     # GTIL doesn't yet support sparse matrix; so use NaN to represent missing values
     Xa = X.toarray()
-    Xa[Xa == 0] = 'nan'
+    Xa[Xa == 0] = "nan"
     out_pred = treelite.gtil.predict(tl_model, Xa, pred_margin=True)
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)

--- a/tests/python/test_gtil.py
+++ b/tests/python/test_gtil.py
@@ -172,7 +172,7 @@ def test_xgb_regression(objective, model_format, num_parallel_tree, dataset):
 
         out_pred = treelite.gtil.predict(tl_model, X_test)
         expected_pred = xgb_model.predict(dtest)
-        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=4)
+        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=3)
 
 
 @pytest.mark.parametrize("num_parallel_tree", [1, 3, 5])

--- a/tests/python/test_gtil.py
+++ b/tests/python/test_gtil.py
@@ -8,7 +8,7 @@ import os
 import numpy as np
 import pytest
 import scipy
-from hypothesis import given, settings
+from hypothesis import assume, given, settings
 from hypothesis.strategies import integers, sampled_from
 from sklearn.datasets import load_breast_cancer, load_iris, load_svmlight_file
 from sklearn.ensemble import (
@@ -131,6 +131,8 @@ def test_xgb_regression(objective, model_format, num_parallel_tree, dataset):
     # pylint: disable=too-many-locals
     """Test XGBoost with regression data"""
     X, y = dataset
+    if objective == "reg:squaredlogerror":
+        assume(np.all(y > -1))
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.2, shuffle=False
     )

--- a/tests/python/test_gtil.py
+++ b/tests/python/test_gtil.py
@@ -379,7 +379,7 @@ def test_lightgbm_regression(objective, reg_sqrt, dataset):
 
         tl_model = treelite.Model.load(lgb_model_path, model_format="lightgbm")
         out_pred = treelite.gtil.predict(tl_model, X_test)
-        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
+        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=4)
 
 
 @pytest.mark.parametrize("objective", ["binary", "xentlambda", "xentropy"])

--- a/tests/python/test_gtil.py
+++ b/tests/python/test_gtil.py
@@ -170,7 +170,7 @@ def test_xgb_regression(objective, model_format, num_parallel_tree, dataset):
 
         out_pred = treelite.gtil.predict(tl_model, X_test)
         expected_pred = xgb_model.predict(dtest)
-        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
+        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=4)
 
 
 @pytest.mark.parametrize("num_parallel_tree", [1, 3, 5])

--- a/tests/python/test_lightgbm_integration.py
+++ b/tests/python/test_lightgbm_integration.py
@@ -3,105 +3,166 @@
 import os
 
 import numpy as np
-import scipy.sparse
 import pytest
+import scipy.sparse
+from hypothesis import given, settings
+from hypothesis.strategies import sampled_from
+from sklearn.datasets import load_iris, load_svmlight_file
+from sklearn.model_selection import train_test_split
+
 import treelite
 import treelite_runtime
-from sklearn.datasets import load_svmlight_file, load_boston, load_iris
-from sklearn.model_selection import train_test_split
 from treelite.contrib import _libext
-from .metadata import dataset_db, _qualify_path
-from .util import os_compatible_toolchains, os_platform, check_predictor, has_pandas
+
+from .hypothesis_util import standard_regression_datasets, standard_settings
+from .metadata import _qualify_path, dataset_db
+from .util import (
+    TemporaryDirectory,
+    check_predictor,
+    has_pandas,
+    os_compatible_toolchains,
+    os_platform,
+)
 
 try:
     import lightgbm
 except ImportError:
     # skip this test suite if LightGBM is not installed
-    pytest.skip('LightGBM not installed; skipping', allow_module_level=True)
+    pytest.skip("LightGBM not installed; skipping", allow_module_level=True)
 
 
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-@pytest.mark.parametrize('objective', ['regression', 'regression_l1', 'huber'])
-@pytest.mark.parametrize('reg_sqrt', [True, False])
-def test_lightgbm_regression(tmpdir, objective, reg_sqrt, toolchain):
+@given(
+    toolchain=sampled_from(os_compatible_toolchains()),
+    objective=sampled_from(["regression", "regression_l1", "huber"]),
+    reg_sqrt=sampled_from([True, False]),
+    dataset=standard_regression_datasets(),
+)
+@settings(**standard_settings())
+def test_lightgbm_regression(toolchain, objective, reg_sqrt, dataset):
     # pylint: disable=too-many-locals
     """Test a regressor"""
-    X, y = load_boston(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
+    X, y = dataset
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, shuffle=False
+    )
     dtrain = lightgbm.Dataset(X_train, y_train, free_raw_data=False)
     dtest = lightgbm.Dataset(X_test, y_test, reference=dtrain, free_raw_data=False)
-    param = {'task': 'train', 'boosting_type': 'gbdt', 'objective': objective, 'reg_sqrt': reg_sqrt,
-             'metric': 'rmse', 'num_leaves': 31, 'learning_rate': 0.05}
-    bst = lightgbm.train(param, dtrain, num_boost_round=10, valid_sets=[dtrain, dtest],
-                         valid_names=['train', 'test'])
+    param = {
+        "task": "train",
+        "boosting_type": "gbdt",
+        "objective": objective,
+        "reg_sqrt": reg_sqrt,
+        "metric": "rmse",
+        "num_leaves": 31,
+        "learning_rate": 0.05,
+    }
+    bst = lightgbm.train(
+        param,
+        dtrain,
+        num_boost_round=10,
+        valid_sets=[dtrain, dtest],
+        valid_names=["train", "test"],
+    )
 
     model = treelite.Model.from_lightgbm(bst)
-    libpath = os.path.join(tmpdir, f'boston_{objective}' + _libext())
-    model.export_lib(toolchain=toolchain, libpath=libpath, params={'quantize': 1}, verbose=True)
-    predictor = treelite_runtime.Predictor(libpath=libpath, verbose=True)
+    with TemporaryDirectory() as tmpdir:
+        libpath = os.path.join(tmpdir, f"regression_{objective}" + _libext())
+        model.export_lib(
+            toolchain=toolchain, libpath=libpath, params={"quantize": 1}, verbose=True
+        )
+        predictor = treelite_runtime.Predictor(libpath=libpath, verbose=True)
 
-    dmat = treelite_runtime.DMatrix(X_test, dtype='float64')
-    out_pred = predictor.predict(dmat)
-    expected_pred = bst.predict(X_test)
-    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
+        dmat = treelite_runtime.DMatrix(X_test, dtype="float64")
+        out_pred = predictor.predict(dmat)
+        expected_pred = bst.predict(X_test)
+        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-@pytest.mark.parametrize('boosting_type', ['gbdt', 'rf'])
-@pytest.mark.parametrize('objective', ['multiclass', 'multiclassova'])
-def test_lightgbm_multiclass_classification(tmpdir, objective, boosting_type, toolchain):
+@pytest.mark.parametrize("toolchain", os_compatible_toolchains())
+@pytest.mark.parametrize("boosting_type", ["gbdt", "rf"])
+@pytest.mark.parametrize("objective", ["multiclass", "multiclassova"])
+def test_lightgbm_multiclass_classification(
+    tmpdir, objective, boosting_type, toolchain
+):
     # pylint: disable=too-many-locals
     """Test a multi-class classifier"""
-    model_path = os.path.join(tmpdir, 'iris_lightgbm.txt')
+    model_path = os.path.join(tmpdir, "iris_lightgbm.txt")
 
     X, y = load_iris(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, shuffle=False
+    )
     dtrain = lightgbm.Dataset(X_train, y_train, free_raw_data=False)
     dtest = lightgbm.Dataset(X_test, y_test, reference=dtrain, free_raw_data=False)
-    param = {'task': 'train', 'boosting': boosting_type, 'objective': objective,
-             'metric': 'multi_logloss', 'num_class': 3, 'num_leaves': 31, 'learning_rate': 0.05}
-    if boosting_type == 'rf':
-        param.update({'bagging_fraction': 0.8, 'bagging_freq': 1})
-    bst = lightgbm.train(param, dtrain, num_boost_round=10, valid_sets=[dtrain, dtest],
-                         valid_names=['train', 'test'])
+    param = {
+        "task": "train",
+        "boosting": boosting_type,
+        "objective": objective,
+        "metric": "multi_logloss",
+        "num_class": 3,
+        "num_leaves": 31,
+        "learning_rate": 0.05,
+    }
+    if boosting_type == "rf":
+        param.update({"bagging_fraction": 0.8, "bagging_freq": 1})
+    bst = lightgbm.train(
+        param,
+        dtrain,
+        num_boost_round=10,
+        valid_sets=[dtrain, dtest],
+        valid_names=["train", "test"],
+    )
     bst.save_model(model_path)
 
-    model = treelite.Model.load(model_path, model_format='lightgbm')
-    libpath = os.path.join(tmpdir, f'iris_{objective}' + _libext())
-    model.export_lib(toolchain=toolchain, libpath=libpath, params={'quantize': 1}, verbose=True)
+    model = treelite.Model.load(model_path, model_format="lightgbm")
+    libpath = os.path.join(tmpdir, f"iris_{objective}" + _libext())
+    model.export_lib(
+        toolchain=toolchain, libpath=libpath, params={"quantize": 1}, verbose=True
+    )
     predictor = treelite_runtime.Predictor(libpath=libpath, verbose=True)
 
-    dmat = treelite_runtime.DMatrix(X_test, dtype='float64')
+    dmat = treelite_runtime.DMatrix(X_test, dtype="float64")
     out_pred = predictor.predict(dmat)
     expected_pred = bst.predict(X_test)
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-@pytest.mark.parametrize('objective', ['binary', 'xentlambda', 'xentropy'])
+@pytest.mark.parametrize("toolchain", os_compatible_toolchains())
+@pytest.mark.parametrize("objective", ["binary", "xentlambda", "xentropy"])
 def test_lightgbm_binary_classification(tmpdir, objective, toolchain):
     # pylint: disable=too-many-locals
     """Test a binary classifier"""
-    dataset = 'mushroom'
-    model_path = os.path.join(tmpdir, 'mushroom_lightgbm.txt')
+    dataset = "mushroom"
+    model_path = os.path.join(tmpdir, "mushroom_lightgbm.txt")
     dtest_path = dataset_db[dataset].dtest
 
     dtrain = lightgbm.Dataset(dataset_db[dataset].dtrain)
     dtest = lightgbm.Dataset(dtest_path, reference=dtrain)
-    param = {'task': 'train', 'boosting_type': 'gbdt', 'objective': objective, 'metric': 'auc',
-             'num_leaves': 7, 'learning_rate': 0.1}
-    bst = lightgbm.train(param, dtrain, num_boost_round=10, valid_sets=[dtrain, dtest],
-                         valid_names=['train', 'test'])
+    param = {
+        "task": "train",
+        "boosting_type": "gbdt",
+        "objective": objective,
+        "metric": "auc",
+        "num_leaves": 7,
+        "learning_rate": 0.1,
+    }
+    bst = lightgbm.train(
+        param,
+        dtrain,
+        num_boost_round=10,
+        valid_sets=[dtrain, dtest],
+        valid_names=["train", "test"],
+    )
     bst.save_model(model_path)
 
     expected_prob = bst.predict(dtest_path)
     expected_margin = bst.predict(dtest_path, raw_score=True)
 
-    model = treelite.Model.load(model_path, model_format='lightgbm')
-    libpath = os.path.join(tmpdir, f'agaricus_{objective}' + _libext())
+    model = treelite.Model.load(model_path, model_format="lightgbm")
+    libpath = os.path.join(tmpdir, f"agaricus_{objective}" + _libext())
     dmat = treelite_runtime.DMatrix(
-        load_svmlight_file(dtest_path, zero_based=True)[0],
-        dtype='float64')
+        load_svmlight_file(dtest_path, zero_based=True)[0], dtype="float64"
+    )
     model.export_lib(toolchain=toolchain, libpath=libpath, params={}, verbose=True)
     predictor = treelite_runtime.Predictor(libpath, verbose=True)
     out_prob = predictor.predict(dmat)
@@ -110,9 +171,9 @@ def test_lightgbm_binary_classification(tmpdir, objective, toolchain):
     np.testing.assert_almost_equal(out_margin, expected_margin, decimal=5)
 
 
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-@pytest.mark.parametrize('parallel_comp', [None, 2])
-@pytest.mark.parametrize('quantize', [True, False])
+@pytest.mark.parametrize("toolchain", os_compatible_toolchains())
+@pytest.mark.parametrize("parallel_comp", [None, 2])
+@pytest.mark.parametrize("quantize", [True, False])
 def test_categorical_data(tmpdir, quantize, parallel_comp, toolchain):
     """
     LightGBM is able to produce categorical splits directly, so that
@@ -134,21 +195,23 @@ def test_categorical_data(tmpdir, quantize, parallel_comp, toolchain):
                          3      1
                          4      2
     """
-    dataset = 'toy_categorical'
+    dataset = "toy_categorical"
     libpath = os.path.join(tmpdir, dataset_db[dataset].libname + _libext())
-    model = treelite.Model.load(dataset_db[dataset].model, model_format=dataset_db[dataset].format)
+    model = treelite.Model.load(
+        dataset_db[dataset].model, model_format=dataset_db[dataset].format
+    )
 
     params = {
-        'quantize': (1 if quantize else 0),
-        'parallel_comp': (parallel_comp if parallel_comp else 0)
+        "quantize": (1 if quantize else 0),
+        "parallel_comp": (parallel_comp if parallel_comp else 0),
     }
     model.export_lib(toolchain=toolchain, libpath=libpath, params=params, verbose=True)
     predictor = treelite_runtime.Predictor(libpath=libpath, verbose=True)
     check_predictor(predictor, dataset)
 
 
-@pytest.mark.skipif(not has_pandas(), reason='Pandas required')
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
+@pytest.mark.skipif(not has_pandas(), reason="Pandas required")
+@pytest.mark.parametrize("toolchain", os_compatible_toolchains())
 def test_categorical_data_pandas_df_with_dummies(tmpdir, toolchain):
     # pylint: disable=too-many-locals
     """
@@ -178,30 +241,48 @@ def test_categorical_data_pandas_df_with_dummies(tmpdir, toolchain):
     x1 = rng.integers(low=0, high=5, size=n_row)
     noise = rng.standard_normal(size=n_row) * 0.1
     y = (x0 * 10 - 20) + (x1 - 2) + noise
-    df = pd.DataFrame({'x0': x0, 'x1': x1}).astype('category')
-    df_dummies = pd.get_dummies(df, prefix=['x0', 'x1'], prefix_sep='=')
+    df = pd.DataFrame({"x0": x0, "x1": x1}).astype("category")
+    df_dummies = pd.get_dummies(df, prefix=["x0", "x1"], prefix_sep="=")
     assert df_dummies.columns.tolist() == [
-        'x0=0', 'x0=1', 'x0=2', 'x1=0', 'x1=1', 'x1=2', 'x1=3', 'x1=4']
+        "x0=0",
+        "x0=1",
+        "x0=2",
+        "x1=0",
+        "x1=1",
+        "x1=2",
+        "x1=3",
+        "x1=4",
+    ]
 
-    model_path = os.path.join(tmpdir, 'toy_dummies.txt')
-    libpath = os.path.join(tmpdir, 'dummies' + _libext())
+    model_path = os.path.join(tmpdir, "toy_dummies.txt")
+    libpath = os.path.join(tmpdir, "dummies" + _libext())
 
     dtrain = lightgbm.Dataset(df_dummies, label=y)
-    param = {'task': 'train', 'boosting_type': 'gbdt', 'objective': 'regression', 'metric': 'rmse',
-             'num_leaves': 7, 'learning_rate': 0.1}
-    bst = lightgbm.train(param, dtrain, num_boost_round=15, valid_sets=[dtrain],
-                         valid_names=['train'])
+    param = {
+        "task": "train",
+        "boosting_type": "gbdt",
+        "objective": "regression",
+        "metric": "rmse",
+        "num_leaves": 7,
+        "learning_rate": 0.1,
+    }
+    bst = lightgbm.train(
+        param, dtrain, num_boost_round=15, valid_sets=[dtrain], valid_names=["train"]
+    )
     lgb_out = bst.predict(df_dummies)
     bst.save_model(model_path)
 
-    model = treelite.Model.load(model_path, model_format='lightgbm')
+    model = treelite.Model.load(model_path, model_format="lightgbm")
     model.export_lib(toolchain=toolchain, libpath=libpath, params={}, verbose=True)
     predictor = treelite_runtime.Predictor(libpath=libpath, verbose=True)
-    tl_out = predictor.predict(treelite_runtime.DMatrix(df_dummies.values, dtype='float32'))
+    tl_out = predictor.predict(
+        treelite_runtime.DMatrix(df_dummies.values, dtype="float32")
+    )
     np.testing.assert_almost_equal(lgb_out, tl_out, decimal=5)
 
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-@pytest.mark.parametrize('quantize', [True, False])
+
+@pytest.mark.parametrize("toolchain", os_compatible_toolchains())
+@pytest.mark.parametrize("quantize", [True, False])
 def test_sparse_ranking_model(tmpdir, quantize, toolchain):
     # pylint: disable=too-many-locals
     """Generate a LightGBM ranking model with highly sparse data.
@@ -220,23 +301,24 @@ def test_sparse_ranking_model(tmpdir, quantize, toolchain):
     This example is crafted so as to invoke the second mode of missing value handling.
     """
     rng = np.random.default_rng(seed=2020)
-    X = scipy.sparse.random(m=10, n=206947, format='csr', dtype=np.float64, random_state=0,
-                            density=0.0001)
+    X = scipy.sparse.random(
+        m=10, n=206947, format="csr", dtype=np.float64, random_state=0, density=0.0001
+    )
     X.data = rng.standard_normal(size=X.data.shape[0], dtype=np.float64)
     y = rng.integers(low=0, high=5, size=X.shape[0])
 
     params = {
-        'objective': 'lambdarank',
-        'num_leaves': 32,
-        'lambda_l1': 0.0,
-        'lambda_l2': 0.0,
-        'min_gain_to_split': 0.0,
-        'learning_rate': 1.0,
-        'min_data_in_leaf': 1
+        "objective": "lambdarank",
+        "num_leaves": 32,
+        "lambda_l1": 0.0,
+        "lambda_l2": 0.0,
+        "min_gain_to_split": 0.0,
+        "learning_rate": 1.0,
+        "min_data_in_leaf": 1,
     }
 
-    model_path = os.path.join(tmpdir, 'sparse_ranking_lightgbm.txt')
-    libpath = os.path.join(tmpdir, 'sparse_ranking_lgb' + _libext())
+    model_path = os.path.join(tmpdir, "sparse_ranking_lightgbm.txt")
+    libpath = os.path.join(tmpdir, "sparse_ranking_lgb" + _libext())
 
     dtrain = lightgbm.Dataset(X, label=y, group=[X.shape[0]])
 
@@ -244,8 +326,8 @@ def test_sparse_ranking_model(tmpdir, quantize, toolchain):
     lgb_out = bst.predict(X)
     bst.save_model(model_path)
 
-    model = treelite.Model.load(model_path, model_format='lightgbm')
-    params = {'quantize': (1 if quantize else 0)}
+    model = treelite.Model.load(model_path, model_format="lightgbm")
+    params = {"quantize": (1 if quantize else 0)}
     model.export_lib(toolchain=toolchain, libpath=libpath, params=params, verbose=True)
 
     predictor = treelite_runtime.Predictor(libpath, verbose=True)
@@ -256,8 +338,8 @@ def test_sparse_ranking_model(tmpdir, quantize, toolchain):
     np.testing.assert_almost_equal(out, lgb_out)
 
 
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-@pytest.mark.parametrize('quantize', [True, False])
+@pytest.mark.parametrize("toolchain", os_compatible_toolchains())
+@pytest.mark.parametrize("quantize", [True, False])
 def test_sparse_categorical_model(tmpdir, quantize, toolchain):
     """
     LightGBM is able to produce categorical splits directly, so that
@@ -268,18 +350,25 @@ def test_sparse_categorical_model(tmpdir, quantize, toolchain):
     The training data has many missing values, so we need to match LightGBM
     when it comes to handling missing values
     """
-    if toolchain == 'clang':
-        pytest.xfail(reason='Clang cannot handle long if conditional')
-    if os_platform() == 'windows':
-        pytest.xfail(reason='MSVC cannot handle long if conditional')
-    if os_platform() == 'osx':
-        pytest.xfail(reason='Apple Clang cannot handle long if conditional')
-    dataset = 'sparse_categorical'
+    if toolchain == "clang":
+        pytest.xfail(reason="Clang cannot handle long if conditional")
+    if os_platform() == "windows":
+        pytest.xfail(reason="MSVC cannot handle long if conditional")
+    if os_platform() == "osx":
+        pytest.xfail(reason="Apple Clang cannot handle long if conditional")
+    dataset = "sparse_categorical"
     libpath = os.path.join(tmpdir, dataset_db[dataset].libname + _libext())
-    model = treelite.Model.load(dataset_db[dataset].model, model_format=dataset_db[dataset].format)
-    params = {'quantize': (1 if quantize else 0)}
-    model.export_lib(toolchain=toolchain, libpath=libpath, params=params, verbose=True,
-                     options=['-O0'])
+    model = treelite.Model.load(
+        dataset_db[dataset].model, model_format=dataset_db[dataset].format
+    )
+    params = {"quantize": (1 if quantize else 0)}
+    model.export_lib(
+        toolchain=toolchain,
+        libpath=libpath,
+        params=params,
+        verbose=True,
+        options=["-O0"],
+    )
     predictor = treelite_runtime.Predictor(libpath=libpath, verbose=True)
     check_predictor(predictor, dataset)
 
@@ -287,12 +376,12 @@ def test_sparse_categorical_model(tmpdir, quantize, toolchain):
 def test_constant_tree():
     """Test whether Treelite can handle LightGBM models with a constant tree (which has a single
     node)"""
-    model_path = _qualify_path('lightgbm_constant_tree', 'model_with_constant_tree.txt')
-    model = treelite.Model.load(model_path, model_format='lightgbm')
+    model_path = _qualify_path("lightgbm_constant_tree", "model_with_constant_tree.txt")
+    model = treelite.Model.load(model_path, model_format="lightgbm")
     assert model.num_tree == 2
 
 
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
+@pytest.mark.parametrize("toolchain", os_compatible_toolchains())
 def test_nan_handling_with_categorical_splits(tmpdir, toolchain):
     """Test that NaN inputs are handled correctly in categorical splits"""
 
@@ -302,15 +391,15 @@ def test_nan_handling_with_categorical_splits(tmpdir, toolchain):
     train_data = lightgbm.Dataset(X, label=y, categorical_feature=[0])
     bst = lightgbm.train({}, train_data, 1)
 
-    model_path = os.path.join(tmpdir, 'dummy_categorical.txt')
-    libpath = os.path.join(tmpdir, 'dummy_categorical_lgb' + _libext())
+    model_path = os.path.join(tmpdir, "dummy_categorical.txt")
+    libpath = os.path.join(tmpdir, "dummy_categorical_lgb" + _libext())
 
     input_with_nan = np.array([[np.NaN], [0.0]])
 
     lgb_pred = bst.predict(input_with_nan)
     bst.save_model(model_path)
 
-    model = treelite.Model.load(model_path, model_format='lightgbm')
+    model = treelite.Model.load(model_path, model_format="lightgbm")
     model.export_lib(toolchain=toolchain, libpath=libpath)
     predictor = treelite_runtime.Predictor(libpath)
     dmat = treelite_runtime.DMatrix(input_with_nan)

--- a/tests/python/test_lightgbm_integration.py
+++ b/tests/python/test_lightgbm_integration.py
@@ -75,7 +75,7 @@ def test_lightgbm_regression(toolchain, objective, reg_sqrt, dataset):
         dmat = treelite_runtime.DMatrix(X_test, dtype="float64")
         out_pred = predictor.predict(dmat)
         expected_pred = bst.predict(X_test)
-        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
+        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=4)
 
 
 @pytest.mark.parametrize("toolchain", os_compatible_toolchains())

--- a/tests/python/test_skl_importer.py
+++ b/tests/python/test_skl_importer.py
@@ -2,78 +2,97 @@
 """Tests for scikit-learn importer"""
 import os
 
-import pytest
 import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis.strategies import sampled_from
+from sklearn.datasets import load_breast_cancer, load_iris
+from sklearn.ensemble import (
+    ExtraTreesClassifier,
+    ExtraTreesRegressor,
+    GradientBoostingClassifier,
+    GradientBoostingRegressor,
+    IsolationForest,
+    RandomForestClassifier,
+    RandomForestRegressor,
+)
+
 import treelite
 import treelite_runtime
 from treelite.contrib import _libext
-from sklearn.ensemble import RandomForestClassifier, GradientBoostingClassifier, \
-    ExtraTreesClassifier, RandomForestRegressor, GradientBoostingRegressor, \
-    ExtraTreesRegressor, IsolationForest
-from sklearn.datasets import load_iris, load_breast_cancer, load_boston
-from .util import os_compatible_toolchains
+
+from .hypothesis_util import standard_regression_datasets, standard_settings
+from .util import TemporaryDirectory, os_compatible_toolchains
 
 
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-@pytest.mark.parametrize('clazz', [RandomForestClassifier, ExtraTreesClassifier,
-                                   GradientBoostingClassifier])
-@pytest.mark.parametrize('import_method', ['import_old', 'import_new'])
+@pytest.mark.parametrize("toolchain", os_compatible_toolchains())
+@pytest.mark.parametrize(
+    "clazz", [RandomForestClassifier, ExtraTreesClassifier, GradientBoostingClassifier]
+)
+@pytest.mark.parametrize("import_method", ["import_old", "import_new"])
 def test_skl_converter_multiclass_classifier(tmpdir, import_method, clazz, toolchain):
     # pylint: disable=too-many-locals
     """Convert scikit-learn multi-class classifier"""
     X, y = load_iris(return_X_y=True)
     kwargs = {}
     if clazz == GradientBoostingClassifier:
-        kwargs['init'] = 'zero'
+        kwargs["init"] = "zero"
     clf = clazz(max_depth=3, random_state=0, n_estimators=10, **kwargs)
     clf.fit(X, y)
     expected_prob = clf.predict_proba(X)
 
-    if import_method == 'import_new':
+    if import_method == "import_new":
         model = treelite.sklearn.import_model(clf)
     else:
         model = treelite.sklearn.import_model_with_model_builder(clf)
     assert model.num_feature == clf.n_features_in_
     assert model.num_class == clf.n_classes_
-    assert (model.num_tree ==
-            clf.n_estimators * (clf.n_classes_ if clazz == GradientBoostingClassifier else 1))
+    assert model.num_tree == clf.n_estimators * (
+        clf.n_classes_ if clazz == GradientBoostingClassifier else 1
+    )
 
-    dtrain = treelite_runtime.DMatrix(X, dtype='float64')
-    annotation_path = os.path.join(tmpdir, 'annotation.json')
+    dtrain = treelite_runtime.DMatrix(X, dtype="float64")
+    annotation_path = os.path.join(tmpdir, "annotation.json")
     annotator = treelite.Annotator()
     annotator.annotate_branch(model=model, dmat=dtrain, verbose=True)
     annotator.save(path=annotation_path)
 
-    libpath = os.path.join(tmpdir, 'skl' + _libext())
-    model.export_lib(toolchain=toolchain, libpath=libpath, params={'annotate_in': annotation_path},
-                     verbose=True)
+    libpath = os.path.join(tmpdir, "skl" + _libext())
+    model.export_lib(
+        toolchain=toolchain,
+        libpath=libpath,
+        params={"annotate_in": annotation_path},
+        verbose=True,
+    )
     predictor = treelite_runtime.Predictor(libpath=libpath)
     assert predictor.num_feature == clf.n_features_in_
     assert predictor.num_class == clf.n_classes_
-    assert (predictor.pred_transform ==
-            ('softmax' if clazz == GradientBoostingClassifier else 'identity_multiclass'))
+    assert predictor.pred_transform == (
+        "softmax" if clazz == GradientBoostingClassifier else "identity_multiclass"
+    )
     assert predictor.global_bias == 0.0
     assert predictor.sigmoid_alpha == 1.0
     out_prob = predictor.predict(dtrain)
     np.testing.assert_almost_equal(out_prob, expected_prob)
 
 
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-@pytest.mark.parametrize('clazz', [RandomForestClassifier, ExtraTreesClassifier,
-                                   GradientBoostingClassifier])
-@pytest.mark.parametrize('import_method', ['import_old', 'import_new'])
+@pytest.mark.parametrize("toolchain", os_compatible_toolchains())
+@pytest.mark.parametrize(
+    "clazz", [RandomForestClassifier, ExtraTreesClassifier, GradientBoostingClassifier]
+)
+@pytest.mark.parametrize("import_method", ["import_old", "import_new"])
 def test_skl_converter_binary_classifier(tmpdir, import_method, clazz, toolchain):
     # pylint: disable=too-many-locals
     """Convert scikit-learn binary classifier"""
     X, y = load_breast_cancer(return_X_y=True)
     kwargs = {}
     if clazz == GradientBoostingClassifier:
-        kwargs['init'] = 'zero'
+        kwargs["init"] = "zero"
     clf = clazz(max_depth=3, random_state=0, n_estimators=10, **kwargs)
     clf.fit(X, y)
     expected_prob = clf.predict_proba(X)[:, 1]
 
-    if import_method == 'import_new':
+    if import_method == "import_new":
         model = treelite.sklearn.import_model(clf)
     else:
         model = treelite.sklearn.import_model_with_model_builder(clf)
@@ -81,42 +100,52 @@ def test_skl_converter_binary_classifier(tmpdir, import_method, clazz, toolchain
     assert model.num_class == 1
     assert model.num_tree == clf.n_estimators
 
-    dtrain = treelite_runtime.DMatrix(X, dtype='float64')
-    annotation_path = os.path.join(tmpdir, 'annotation.json')
+    dtrain = treelite_runtime.DMatrix(X, dtype="float64")
+    annotation_path = os.path.join(tmpdir, "annotation.json")
     annotator = treelite.Annotator()
     annotator.annotate_branch(model=model, dmat=dtrain, verbose=True)
     annotator.save(path=annotation_path)
 
-    libpath = os.path.join(tmpdir, 'skl' + _libext())
-    model.export_lib(toolchain=toolchain, libpath=libpath, params={'annotate_in': annotation_path},
-                     verbose=True)
+    libpath = os.path.join(tmpdir, "skl" + _libext())
+    model.export_lib(
+        toolchain=toolchain,
+        libpath=libpath,
+        params={"annotate_in": annotation_path},
+        verbose=True,
+    )
     predictor = treelite_runtime.Predictor(libpath=libpath)
     assert predictor.num_feature == clf.n_features_in_
     assert model.num_class == 1
-    assert (predictor.pred_transform
-            == ('sigmoid' if clazz == GradientBoostingClassifier else 'identity'))
+    assert predictor.pred_transform == (
+        "sigmoid" if clazz == GradientBoostingClassifier else "identity"
+    )
     assert predictor.global_bias == 0.0
     assert predictor.sigmoid_alpha == 1.0
     out_prob = predictor.predict(dtrain)
     np.testing.assert_almost_equal(out_prob, expected_prob)
 
 
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-@pytest.mark.parametrize('clazz', [RandomForestRegressor, ExtraTreesRegressor,
-                                   GradientBoostingRegressor])
-@pytest.mark.parametrize('import_method', ['import_old', 'import_new'])
-def test_skl_converter_regressor(tmpdir, import_method, clazz, toolchain):
+@given(
+    toolchain=sampled_from(os_compatible_toolchains()),
+    clazz=sampled_from(
+        [RandomForestRegressor, ExtraTreesRegressor, GradientBoostingRegressor]
+    ),
+    import_method=sampled_from(["import_old", "import_new"]),
+    dataset=standard_regression_datasets(),
+)
+@settings(**standard_settings())
+def test_skl_converter_regressor(toolchain, clazz, import_method, dataset):
     # pylint: disable=too-many-locals
     """Convert scikit-learn regressor"""
-    X, y = load_boston(return_X_y=True)
+    X, y = dataset
     kwargs = {}
     if clazz == GradientBoostingRegressor:
-        kwargs['init'] = 'zero'
+        kwargs["init"] = "zero"
     clf = clazz(max_depth=3, random_state=0, n_estimators=10, **kwargs)
     clf.fit(X, y)
     expected_pred = clf.predict(X)
 
-    if import_method == 'import_new':
+    if import_method == "import_new":
         model = treelite.sklearn.import_model(clf)
     else:
         model = treelite.sklearn.import_model_with_model_builder(clf)
@@ -124,54 +153,69 @@ def test_skl_converter_regressor(tmpdir, import_method, clazz, toolchain):
     assert model.num_class == 1
     assert model.num_tree == clf.n_estimators
 
-    dtrain = treelite_runtime.DMatrix(X, dtype='float32')
-    annotation_path = os.path.join(tmpdir, 'annotation.json')
-    annotator = treelite.Annotator()
-    annotator.annotate_branch(model=model, dmat=dtrain, verbose=True)
-    annotator.save(path=annotation_path)
+    with TemporaryDirectory() as tmpdir:
+        dtrain = treelite_runtime.DMatrix(X, dtype="float32")
+        annotation_path = os.path.join(tmpdir, "annotation.json")
+        annotator = treelite.Annotator()
+        annotator.annotate_branch(model=model, dmat=dtrain, verbose=True, nthread=1)
+        annotator.save(path=annotation_path)
 
-    libpath = os.path.join(tmpdir, 'skl' + _libext())
-    model.export_lib(toolchain=toolchain, libpath=libpath, params={'annotate_in': annotation_path},
-                     verbose=True)
-    predictor = treelite_runtime.Predictor(libpath=libpath)
-    assert predictor.num_feature == clf.n_features_in_
-    assert model.num_class == 1
-    assert predictor.pred_transform == 'identity'
-    assert predictor.global_bias == 0.0
-    assert predictor.sigmoid_alpha == 1.0
-    out_pred = predictor.predict(dtrain)
-    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
+        libpath = os.path.join(tmpdir, "skl" + _libext())
+        model.export_lib(
+            toolchain=toolchain,
+            libpath=libpath,
+            params={"annotate_in": annotation_path},
+            verbose=True,
+        )
+        predictor = treelite_runtime.Predictor(libpath=libpath)
+        assert predictor.num_feature == clf.n_features_in_
+        assert model.num_class == 1
+        assert predictor.pred_transform == "identity"
+        assert predictor.global_bias == 0.0
+        assert predictor.sigmoid_alpha == 1.0
+        out_pred = predictor.predict(dtrain)
+        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-def test_skl_converter_iforest(tmpdir, toolchain):  # pylint: disable=W0212
+
+@given(
+    toolchain=sampled_from(os_compatible_toolchains()),
+    dataset=standard_regression_datasets(),
+)
+@settings(**standard_settings())
+def test_skl_converter_iforest(toolchain, dataset):  # pylint: disable=W0212
     # pylint: disable=too-many-locals
-    """Convert scikit-learn regressor"""
-    X = load_boston(return_X_y=True)[0]
+    """Convert scikit-learn Isolation forest"""
+    X, _ = dataset
     clf = IsolationForest(max_samples=64, random_state=0, n_estimators=10)
     clf.fit(X)
-    expected_pred = clf._compute_chunked_score_samples(X) # pylint: disable=W0212
+    expected_pred = clf._compute_chunked_score_samples(X)  # pylint: disable=W0212
 
     model = treelite.sklearn.import_model(clf)
     assert model.num_feature == clf.n_features_in_
     assert model.num_class == 1
     assert model.num_tree == clf.n_estimators
 
-    dtrain = treelite_runtime.DMatrix(X, dtype='float32')
-    annotation_path = os.path.join(tmpdir, 'annotation.json')
-    annotator = treelite.Annotator()
-    annotator.annotate_branch(model=model, dmat=dtrain, verbose=True)
-    annotator.save(path=annotation_path)
+    with TemporaryDirectory() as tmpdir:
+        dtrain = treelite_runtime.DMatrix(X, dtype="float32")
+        annotation_path = os.path.join(tmpdir, "annotation.json")
+        annotator = treelite.Annotator()
+        annotator.annotate_branch(model=model, dmat=dtrain, verbose=True)
+        annotator.save(path=annotation_path)
 
-    libpath = os.path.join(tmpdir, 'skl' + _libext())
-    model.export_lib(toolchain=toolchain, libpath=libpath, params={'annotate_in': annotation_path},
-                     verbose=True)
-    predictor = treelite_runtime.Predictor(libpath=libpath)
-    assert predictor.num_feature == clf.n_features_in_
-    assert model.num_class == 1
-    assert predictor.pred_transform == 'exponential_standard_ratio'
-    assert predictor.global_bias == 0.0
-    assert predictor.sigmoid_alpha == 1.0
-    assert predictor.ratio_c > 0
-    assert predictor.ratio_c < 64
-    out_pred = predictor.predict(dtrain)
-    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=2)
+        libpath = os.path.join(tmpdir, "skl" + _libext())
+        model.export_lib(
+            toolchain=toolchain,
+            libpath=libpath,
+            params={"annotate_in": annotation_path},
+            verbose=True,
+        )
+        predictor = treelite_runtime.Predictor(libpath=libpath)
+        assert predictor.num_feature == clf.n_features_in_
+        assert model.num_class == 1
+        assert predictor.pred_transform == "exponential_standard_ratio"
+        assert predictor.global_bias == 0.0
+        assert predictor.sigmoid_alpha == 1.0
+        assert predictor.ratio_c > 0
+        assert predictor.ratio_c < 64
+        out_pred = predictor.predict(dtrain)
+        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=2)

--- a/tests/python/test_skl_importer.py
+++ b/tests/python/test_skl_importer.py
@@ -157,7 +157,7 @@ def test_skl_converter_regressor(toolchain, clazz, import_method, dataset):
         dtrain = treelite_runtime.DMatrix(X, dtype="float32")
         annotation_path = os.path.join(tmpdir, "annotation.json")
         annotator = treelite.Annotator()
-        annotator.annotate_branch(model=model, dmat=dtrain, verbose=True, nthread=1)
+        annotator.annotate_branch(model=model, dmat=dtrain, verbose=True)
         annotator.save(path=annotation_path)
 
         libpath = os.path.join(tmpdir, "skl" + _libext())

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -100,7 +100,7 @@ def test_xgb_regression(toolchain, objective, model_format, num_parallel_tree, d
         dmat = treelite_runtime.DMatrix(X_test, dtype="float32")
         out_pred = predictor.predict(dmat)
         expected_pred = bst.predict(dtest)
-        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=4)
+        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=3)
 
 
 @pytest.mark.parametrize("num_parallel_tree", [1, 3, 5])
@@ -346,9 +346,9 @@ def test_xgb_deserializers(toolchain, dataset):
         json_str_pred = predictor_json_str.predict(dmat)
 
         expected_pred = bst.predict(dtest)
-        np.testing.assert_almost_equal(bin_pred, expected_pred, decimal=5)
-        np.testing.assert_almost_equal(json_pred, expected_pred, decimal=5)
-        np.testing.assert_almost_equal(json_str_pred, expected_pred, decimal=5)
+        np.testing.assert_almost_equal(bin_pred, expected_pred, decimal=4)
+        np.testing.assert_almost_equal(json_pred, expected_pred, decimal=4)
+        np.testing.assert_almost_equal(json_str_pred, expected_pred, decimal=4)
 
 
 @pytest.mark.parametrize("parallel_comp", [None, 5])

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -6,104 +6,159 @@ import os
 
 import numpy as np
 import pytest
+from hypothesis import assume, given, settings
+from hypothesis.strategies import integers, sampled_from
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
+
 import treelite
 import treelite_runtime
 from treelite.contrib import _libext
-from sklearn.datasets import load_boston, load_iris
-from sklearn.model_selection import train_test_split
-from .util import os_compatible_toolchains, check_predictor
+
+from .hypothesis_util import standard_regression_datasets, standard_settings
 from .metadata import dataset_db
+from .util import TemporaryDirectory, check_predictor, os_compatible_toolchains
 
 try:
-    import xgboost
+    import xgboost as xgb
 except ImportError:
     # skip this test suite if XGBoost is not installed
-    pytest.skip('XGBoost not installed; skipping', allow_module_level=True)
+    pytest.skip("XGBoost not installed; skipping", allow_module_level=True)
 
 
-@pytest.mark.parametrize('num_parallel_tree', [1, 3, 5])
-@pytest.mark.parametrize('model_format', ['binary', 'json'])
-@pytest.mark.parametrize('objective', ['reg:linear', 'reg:squarederror', 'reg:squaredlogerror',
-                                       'reg:pseudohubererror'])
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-def test_xgb_boston(tmpdir, toolchain, objective, model_format, num_parallel_tree):
+@given(
+    toolchain=sampled_from(os_compatible_toolchains()),
+    objective=sampled_from(
+        [
+            "reg:linear",
+            "reg:squarederror",
+            "reg:squaredlogerror",
+            "reg:pseudohubererror",
+        ]
+    ),
+    model_format=sampled_from(["binary", "json"]),
+    num_parallel_tree=integers(min_value=1, max_value=10),
+    dataset=standard_regression_datasets(),
+)
+@settings(**standard_settings())
+def test_xgb_regression(toolchain, objective, model_format, num_parallel_tree, dataset):
     # pylint: disable=too-many-locals
-    """Test Boston data (regression)"""
-    X, y = load_boston(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
-    dtrain = xgboost.DMatrix(X_train, label=y_train)
-    dtest = xgboost.DMatrix(X_test, label=y_test)
-    param = {'max_depth': 8, 'eta': 1, 'silent': 1, 'objective': objective,
-             'num_parallel_tree': num_parallel_tree}
+    """Test a random regression dataset"""
+    X, y = dataset
+    if objective == "reg:squaredlogerror":
+        assume(np.all(y > -1))
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, shuffle=False
+    )
+    dtrain = xgb.DMatrix(X_train, label=y_train)
+    dtest = xgb.DMatrix(X_test, label=y_test)
+    param = {
+        "max_depth": 8,
+        "eta": 1,
+        "verbosity": 0,
+        "objective": objective,
+        "num_parallel_tree": num_parallel_tree,
+    }
     num_round = 10
-    bst = xgboost.train(param, dtrain, num_boost_round=num_round,
-                        evals=[(dtrain, 'train'), (dtest, 'test')])
-    if model_format == 'json':
-        model_name = 'boston.json'
-        model_path = os.path.join(tmpdir, model_name)
-        bst.save_model(model_path)
-        model = treelite.Model.load(filename=model_path, model_format='xgboost_json')
-    else:
-        model_name = 'boston.model'
-        model_path = os.path.join(tmpdir, model_name)
-        bst.save_model(model_path)
-        model = treelite.Model.load(filename=model_path, model_format='xgboost')
+    bst = xgb.train(
+        param,
+        dtrain,
+        num_boost_round=num_round,
+        evals=[(dtrain, "train"), (dtest, "test")],
+    )
+    with TemporaryDirectory() as tmpdir:
+        if model_format == "json":
+            model_name = "regression.json"
+            model_path = os.path.join(tmpdir, model_name)
+            bst.save_model(model_path)
+            model = treelite.Model.load(
+                filename=model_path, model_format="xgboost_json"
+            )
+        else:
+            model_name = "regression.model"
+            model_path = os.path.join(tmpdir, model_name)
+            bst.save_model(model_path)
+            model = treelite.Model.load(filename=model_path, model_format="xgboost")
 
-    assert model.num_feature == dtrain.num_col()
-    assert model.num_class == 1
-    assert model.num_tree == num_round * num_parallel_tree
-    libpath = os.path.join(tmpdir, 'boston' + _libext())
-    model.export_lib(toolchain=toolchain, libpath=libpath, params={'parallel_comp': model.num_tree},
-                     verbose=True)
+        assert model.num_feature == dtrain.num_col()
+        assert model.num_class == 1
+        assert model.num_tree == num_round * num_parallel_tree
+        libpath = os.path.join(tmpdir, "regression" + _libext())
+        model.export_lib(
+            toolchain=toolchain,
+            libpath=libpath,
+            params={"parallel_comp": model.num_tree},
+            verbose=True,
+        )
 
-    predictor = treelite_runtime.Predictor(libpath=libpath, verbose=True)
-    assert predictor.num_feature == dtrain.num_col()
-    assert predictor.num_class == 1
-    assert predictor.pred_transform == 'identity'
-    assert predictor.global_bias == 0.5
-    assert predictor.sigmoid_alpha == 1.0
-    dmat = treelite_runtime.DMatrix(X_test, dtype='float32')
-    out_pred = predictor.predict(dmat)
-    expected_pred = bst.predict(dtest)
-    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
+        predictor = treelite_runtime.Predictor(libpath=libpath, verbose=True)
+        assert predictor.num_feature == dtrain.num_col()
+        assert predictor.num_class == 1
+        assert predictor.pred_transform == "identity"
+        assert predictor.global_bias == 0.5
+        assert predictor.sigmoid_alpha == 1.0
+        dmat = treelite_runtime.DMatrix(X_test, dtype="float32")
+        out_pred = predictor.predict(dmat)
+        expected_pred = bst.predict(dtest)
+        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=4)
 
 
-@pytest.mark.parametrize('num_parallel_tree', [1, 3, 5])
-@pytest.mark.parametrize('model_format', ['binary', 'json'])
-@pytest.mark.parametrize('objective,expected_pred_transform',
-                         [('multi:softmax', 'max_index'), ('multi:softprob', 'softmax')],
-                         ids=['multi:softmax', 'multi:softprob'])
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-def test_xgb_iris(tmpdir, toolchain, objective, model_format, expected_pred_transform,
-                  num_parallel_tree):
+@pytest.mark.parametrize("num_parallel_tree", [1, 3, 5])
+@pytest.mark.parametrize("model_format", ["binary", "json"])
+@pytest.mark.parametrize(
+    "objective,expected_pred_transform",
+    [("multi:softmax", "max_index"), ("multi:softprob", "softmax")],
+    ids=["multi:softmax", "multi:softprob"],
+)
+@pytest.mark.parametrize("toolchain", os_compatible_toolchains())
+def test_xgb_iris(
+    tmpdir,
+    toolchain,
+    objective,
+    model_format,
+    expected_pred_transform,
+    num_parallel_tree,
+):
     # pylint: disable=too-many-locals, too-many-arguments
     """Test Iris data (multi-class classification)"""
     X, y = load_iris(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
-    dtrain = xgboost.DMatrix(X_train, label=y_train)
-    dtest = xgboost.DMatrix(X_test, label=y_test)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, shuffle=False
+    )
+    dtrain = xgb.DMatrix(X_train, label=y_train)
+    dtest = xgb.DMatrix(X_test, label=y_test)
     num_class = 3
     num_round = 10
-    param = {'max_depth': 6, 'eta': 0.05, 'num_class': num_class, 'verbosity': 0,
-             'objective': objective, 'metric': 'mlogloss',
-             'num_parallel_tree': num_parallel_tree}
-    bst = xgboost.train(param, dtrain, num_boost_round=num_round,
-                        evals=[(dtrain, 'train'), (dtest, 'test')])
+    param = {
+        "max_depth": 6,
+        "eta": 0.05,
+        "num_class": num_class,
+        "verbosity": 0,
+        "objective": objective,
+        "metric": "mlogloss",
+        "num_parallel_tree": num_parallel_tree,
+    }
+    bst = xgb.train(
+        param,
+        dtrain,
+        num_boost_round=num_round,
+        evals=[(dtrain, "train"), (dtest, "test")],
+    )
 
-    if model_format == 'json':
-        model_name = 'iris.json'
+    if model_format == "json":
+        model_name = "iris.json"
         model_path = os.path.join(tmpdir, model_name)
         bst.save_model(model_path)
-        model = treelite.Model.load(filename=model_path, model_format='xgboost_json')
+        model = treelite.Model.load(filename=model_path, model_format="xgboost_json")
     else:
-        model_name = 'iris.model'
+        model_name = "iris.model"
         model_path = os.path.join(tmpdir, model_name)
         bst.save_model(model_path)
-        model = treelite.Model.load(filename=model_path, model_format='xgboost')
+        model = treelite.Model.load(filename=model_path, model_format="xgboost")
     assert model.num_feature == dtrain.num_col()
     assert model.num_class == num_class
     assert model.num_tree == num_round * num_class * num_parallel_tree
-    libpath = os.path.join(tmpdir, 'iris' + _libext())
+    libpath = os.path.join(tmpdir, "iris" + _libext())
     model.export_lib(toolchain=toolchain, libpath=libpath, params={}, verbose=True)
 
     predictor = treelite_runtime.Predictor(libpath=libpath, verbose=True)
@@ -112,26 +167,38 @@ def test_xgb_iris(tmpdir, toolchain, objective, model_format, expected_pred_tran
     assert predictor.pred_transform == expected_pred_transform
     assert predictor.global_bias == 0.5
     assert predictor.sigmoid_alpha == 1.0
-    dmat = treelite_runtime.DMatrix(X_test, dtype='float32')
+    dmat = treelite_runtime.DMatrix(X_test, dtype="float32")
     out_pred = predictor.predict(dmat)
     expected_pred = bst.predict(dtest)
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
-@pytest.mark.parametrize('model_format', ['binary', 'json'])
-@pytest.mark.parametrize('objective,max_label,expected_global_bias',
-                         [('binary:logistic', 2, 0),
-                          ('binary:hinge', 2, 0.5),
-                          ('binary:logitraw', 2, 0.5),
-                          ('count:poisson', 4, math.log(0.5)),
-                          ('rank:pairwise', 5, 0.5),
-                          ('rank:ndcg', 5, 0.5),
-                          ('rank:map', 5, 0.5)],
-                         ids=['binary:logistic', 'binary:hinge', 'binary:logitraw',
-                              'count:poisson', 'rank:pairwise', 'rank:ndcg', 'rank:map'])
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-def test_nonlinear_objective(tmpdir, objective, max_label, expected_global_bias, toolchain,
-                             model_format):
+@pytest.mark.parametrize("model_format", ["binary", "json"])
+@pytest.mark.parametrize(
+    "objective,max_label,expected_global_bias",
+    [
+        ("binary:logistic", 2, 0),
+        ("binary:hinge", 2, 0.5),
+        ("binary:logitraw", 2, 0.5),
+        ("count:poisson", 4, math.log(0.5)),
+        ("rank:pairwise", 5, 0.5),
+        ("rank:ndcg", 5, 0.5),
+        ("rank:map", 5, 0.5),
+    ],
+    ids=[
+        "binary:logistic",
+        "binary:hinge",
+        "binary:logitraw",
+        "count:poisson",
+        "rank:pairwise",
+        "rank:ndcg",
+        "rank:map",
+    ],
+)
+@pytest.mark.parametrize("toolchain", os_compatible_toolchains())
+def test_nonlinear_objective(
+    tmpdir, objective, max_label, expected_global_bias, toolchain, model_format
+):
     # pylint: disable=too-many-locals,too-many-arguments
     """Test non-linear objectives with dummy data"""
     np.random.seed(0)
@@ -143,147 +210,159 @@ def test_nonlinear_objective(tmpdir, objective, max_label, expected_global_bias,
     assert np.max(y) == max_label - 1
 
     num_round = 4
-    dtrain = xgboost.DMatrix(X, label=y)
-    if objective.startswith('rank:'):
+    dtrain = xgb.DMatrix(X, label=y)
+    if objective.startswith("rank:"):
         dtrain.set_group([nrow])
-    bst = xgboost.train({'objective': objective, 'base_score': 0.5, 'seed': 0},
-                        dtrain=dtrain, num_boost_round=num_round)
+    bst = xgb.train(
+        {"objective": objective, "base_score": 0.5, "seed": 0},
+        dtrain=dtrain,
+        num_boost_round=num_round,
+    )
 
-    objective_tag = objective.replace(':', '_')
-    if model_format == 'json':
-        model_name = f'nonlinear_{objective_tag}.json'
+    objective_tag = objective.replace(":", "_")
+    if model_format == "json":
+        model_name = f"nonlinear_{objective_tag}.json"
     else:
-        model_name = f'nonlinear_{objective_tag}.bin'
+        model_name = f"nonlinear_{objective_tag}.bin"
     model_path = os.path.join(tmpdir, model_name)
     bst.save_model(model_path)
 
     model = treelite.Model.load(
         filename=model_path,
-        model_format=('xgboost_json' if model_format == 'json' else 'xgboost'))
+        model_format=("xgboost_json" if model_format == "json" else "xgboost"),
+    )
     assert model.num_feature == dtrain.num_col()
     assert model.num_class == 1
     assert model.num_tree == num_round
     libpath = os.path.join(tmpdir, objective_tag + _libext())
     model.export_lib(toolchain=toolchain, libpath=libpath, params={}, verbose=True)
 
-    expected_pred_transform = {'binary:logistic': 'sigmoid',
-                               'binary:hinge': 'hinge',
-                               'binary:logitraw': 'identity',
-                               'count:poisson': 'exponential',
-                               'rank:pairwise': 'identity',
-                               'rank:ndcg': 'identity',
-                               'rank:map': 'identity'}
+    expected_pred_transform = {
+        "binary:logistic": "sigmoid",
+        "binary:hinge": "hinge",
+        "binary:logitraw": "identity",
+        "count:poisson": "exponential",
+        "rank:pairwise": "identity",
+        "rank:ndcg": "identity",
+        "rank:map": "identity",
+    }
 
     predictor = treelite_runtime.Predictor(libpath=libpath, verbose=True)
     assert predictor.num_feature == dtrain.num_col()
     assert predictor.num_class == 1
     assert predictor.pred_transform == expected_pred_transform[objective]
-    np.testing.assert_almost_equal(predictor.global_bias, expected_global_bias, decimal=5)
+    np.testing.assert_almost_equal(
+        predictor.global_bias, expected_global_bias, decimal=5
+    )
     assert predictor.sigmoid_alpha == 1.0
-    dmat = treelite_runtime.DMatrix(X, dtype='float32')
+    dmat = treelite_runtime.DMatrix(X, dtype="float32")
     out_pred = predictor.predict(dmat)
     expected_pred = bst.predict(dtrain)
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
-def test_xgb_deserializers(tmpdir, toolchain):
+@given(
+    toolchain=sampled_from(os_compatible_toolchains()),
+    dataset=standard_regression_datasets(),
+)
+@settings(**standard_settings())
+def test_xgb_deserializers(toolchain, dataset):
     # pylint: disable=too-many-locals
-    """Test Boston data (regression)"""
-    # Train xgboost model
-    X, y = load_boston(return_X_y=True)
+    """Test a random regression dataset and test serializers"""
+    X, y = dataset
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.2, shuffle=False
     )
-    dtrain = xgboost.DMatrix(X_train, label=y_train)
-    dtest = xgboost.DMatrix(X_test, label=y_test)
-    param = {'max_depth': 8, 'eta': 1, 'silent': 1, 'objective': 'reg:linear'}
+    dtrain = xgb.DMatrix(X_train, label=y_train)
+    dtest = xgb.DMatrix(X_test, label=y_test)
+    param = {"max_depth": 8, "eta": 1, "silent": 1, "objective": "reg:linear"}
     num_round = 10
-    bst = xgboost.train(param, dtrain, num_boost_round=num_round,
-                        evals=[(dtrain, 'train'), (dtest, 'test')])
-
-    # Serialize xgboost model
-    model_bin_path = os.path.join(tmpdir, 'serialized.model')
-    bst.save_model(model_bin_path)
-    model_json_path = os.path.join(tmpdir, 'serialized.json')
-    bst.save_model(model_json_path)
-    model_json_str = bst.save_raw(raw_format="json")
-
-    # Construct Treelite models from xgboost serializations
-    model_bin = treelite.Model.load(
-        model_bin_path, model_format='xgboost'
-    )
-    model_json = treelite.Model.load(
-        model_json_path, model_format='xgboost_json'
-    )
-    model_json_str = treelite.Model.from_xgboost_json(model_json_str)
-
-    # Compile models to libraries
-    model_bin_lib = os.path.join(tmpdir, 'bin{}'.format(_libext()))
-    model_bin.export_lib(
-        toolchain=toolchain,
-        libpath=model_bin_lib,
-        params={'parallel_comp': model_bin.num_tree}
-    )
-    model_json_lib = os.path.join(tmpdir, 'json{}'.format(_libext()))
-    model_json.export_lib(
-        toolchain=toolchain,
-        libpath=model_json_lib,
-        params={'parallel_comp': model_json.num_tree}
-    )
-    model_json_str_lib = os.path.join(tmpdir, 'json_str{}'.format(_libext()))
-    model_json_str.export_lib(
-        toolchain=toolchain,
-        libpath=model_json_str_lib,
-        params={'parallel_comp': model_json_str.num_tree}
+    bst = xgb.train(
+        param,
+        dtrain,
+        num_boost_round=num_round,
+        evals=[(dtrain, "train"), (dtest, "test")],
     )
 
-    # Generate predictors from compiled libraries
-    predictor_bin = treelite_runtime.Predictor(model_bin_lib)
-    assert predictor_bin.num_feature == dtrain.num_col()
-    assert predictor_bin.num_class == 1
-    assert predictor_bin.pred_transform == 'identity'
-    assert predictor_bin.global_bias == pytest.approx(0.5)
-    assert predictor_bin.sigmoid_alpha == pytest.approx(1.0)
+    with TemporaryDirectory() as tmpdir:
+        # Serialize xgboost model
+        model_bin_path = os.path.join(tmpdir, "serialized.model")
+        bst.save_model(model_bin_path)
+        model_json_path = os.path.join(tmpdir, "serialized.json")
+        bst.save_model(model_json_path)
+        model_json_str = bst.save_raw(raw_format="json")
 
-    predictor_json = treelite_runtime.Predictor(model_json_lib)
-    assert predictor_json.num_feature == dtrain.num_col()
-    assert predictor_json.num_class == 1
-    assert predictor_json.pred_transform == 'identity'
-    assert predictor_json.global_bias == pytest.approx(0.5)
-    assert predictor_json.sigmoid_alpha == pytest.approx(1.0)
+        # Construct Treelite models from xgboost serializations
+        model_bin = treelite.Model.load(model_bin_path, model_format="xgboost")
+        model_json = treelite.Model.load(model_json_path, model_format="xgboost_json")
+        model_json_str = treelite.Model.from_xgboost_json(model_json_str)
 
-    predictor_json_str = treelite_runtime.Predictor(model_json_str_lib)
-    assert predictor_json_str.num_feature == dtrain.num_col()
-    assert predictor_json_str.num_class == 1
-    assert predictor_json_str.pred_transform == 'identity'
-    assert predictor_json_str.global_bias == pytest.approx(0.5)
-    assert predictor_json_str.sigmoid_alpha == pytest.approx(1.0)
+        # Compile models to libraries
+        model_bin_lib = os.path.join(tmpdir, "bin{}".format(_libext()))
+        model_bin.export_lib(
+            toolchain=toolchain,
+            libpath=model_bin_lib,
+            params={"parallel_comp": model_bin.num_tree},
+        )
+        model_json_lib = os.path.join(tmpdir, "json{}".format(_libext()))
+        model_json.export_lib(
+            toolchain=toolchain,
+            libpath=model_json_lib,
+            params={"parallel_comp": model_json.num_tree},
+        )
+        model_json_str_lib = os.path.join(tmpdir, "json_str{}".format(_libext()))
+        model_json_str.export_lib(
+            toolchain=toolchain,
+            libpath=model_json_str_lib,
+            params={"parallel_comp": model_json_str.num_tree},
+        )
 
-    # Run inference with each predictor
-    dmat = treelite_runtime.DMatrix(X_test, dtype='float32')
-    bin_pred = predictor_bin.predict(dmat)
-    json_pred = predictor_json.predict(dmat)
-    json_str_pred = predictor_json_str.predict(dmat)
+        # Generate predictors from compiled libraries
+        predictor_bin = treelite_runtime.Predictor(model_bin_lib)
+        assert predictor_bin.num_feature == dtrain.num_col()
+        assert predictor_bin.num_class == 1
+        assert predictor_bin.pred_transform == "identity"
+        assert predictor_bin.global_bias == pytest.approx(0.5)
+        assert predictor_bin.sigmoid_alpha == pytest.approx(1.0)
 
-    expected_pred = bst.predict(dtest)
-    np.testing.assert_almost_equal(bin_pred, expected_pred, decimal=5)
-    np.testing.assert_almost_equal(json_pred, expected_pred, decimal=5)
-    np.testing.assert_almost_equal(json_str_pred, expected_pred, decimal=5)
+        predictor_json = treelite_runtime.Predictor(model_json_lib)
+        assert predictor_json.num_feature == dtrain.num_col()
+        assert predictor_json.num_class == 1
+        assert predictor_json.pred_transform == "identity"
+        assert predictor_json.global_bias == pytest.approx(0.5)
+        assert predictor_json.sigmoid_alpha == pytest.approx(1.0)
+
+        predictor_json_str = treelite_runtime.Predictor(model_json_str_lib)
+        assert predictor_json_str.num_feature == dtrain.num_col()
+        assert predictor_json_str.num_class == 1
+        assert predictor_json_str.pred_transform == "identity"
+        assert predictor_json_str.global_bias == pytest.approx(0.5)
+        assert predictor_json_str.sigmoid_alpha == pytest.approx(1.0)
+
+        # Run inference with each predictor
+        dmat = treelite_runtime.DMatrix(X_test, dtype="float32")
+        bin_pred = predictor_bin.predict(dmat)
+        json_pred = predictor_json.predict(dmat)
+        json_str_pred = predictor_json_str.predict(dmat)
+
+        expected_pred = bst.predict(dtest)
+        np.testing.assert_almost_equal(bin_pred, expected_pred, decimal=5)
+        np.testing.assert_almost_equal(json_pred, expected_pred, decimal=5)
+        np.testing.assert_almost_equal(json_str_pred, expected_pred, decimal=5)
 
 
-@pytest.mark.parametrize('parallel_comp', [None, 5])
-@pytest.mark.parametrize('quantize', [True, False])
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
+@pytest.mark.parametrize("parallel_comp", [None, 5])
+@pytest.mark.parametrize("quantize", [True, False])
+@pytest.mark.parametrize("toolchain", os_compatible_toolchains())
 def test_xgb_categorical_split(tmpdir, toolchain, quantize, parallel_comp):
     """Test toy XGBoost model with categorical splits"""
-    dataset = 'xgb_toy_categorical'
-    model = treelite.Model.load(dataset_db[dataset].model, model_format='xgboost_json')
+    dataset = "xgb_toy_categorical"
+    model = treelite.Model.load(dataset_db[dataset].model, model_format="xgboost_json")
     libpath = os.path.join(tmpdir, dataset_db[dataset].libname + _libext())
 
     params = {
-        'quantize': (1 if quantize else 0),
-        'parallel_comp': (parallel_comp if parallel_comp else 0)
+        "quantize": (1 if quantize else 0),
+        "parallel_comp": (parallel_comp if parallel_comp else 0),
     }
     model.export_lib(toolchain=toolchain, libpath=libpath, params=params, verbose=True)
 
@@ -291,8 +370,8 @@ def test_xgb_categorical_split(tmpdir, toolchain, quantize, parallel_comp):
     check_predictor(predictor, dataset)
 
 
-@pytest.mark.parametrize('model_format', ['binary', 'json'])
-@pytest.mark.parametrize('toolchain', os_compatible_toolchains())
+@pytest.mark.parametrize("model_format", ["binary", "json"])
+@pytest.mark.parametrize("toolchain", os_compatible_toolchains())
 def test_xgb_dart(tmpdir, toolchain, model_format):
     # pylint: disable=too-many-locals,too-many-arguments
     """Test dart booster with dummy data"""
@@ -305,24 +384,27 @@ def test_xgb_dart(tmpdir, toolchain, model_format):
     assert np.max(y) == 1
 
     num_round = 50
-    dtrain = xgboost.DMatrix(X, label=y)
-    param = {'booster': 'dart',
-             'max_depth': 5, 'learning_rate': 0.1,
-             'objective': 'binary:logistic',
-             'sample_type': 'uniform',
-             'normalize_type': 'tree',
-             'rate_drop': 0.1,
-             'skip_drop': 0.5}
-    bst = xgboost.train(param, dtrain=dtrain, num_boost_round=num_round)
+    dtrain = xgb.DMatrix(X, label=y)
+    param = {
+        "booster": "dart",
+        "max_depth": 5,
+        "learning_rate": 0.1,
+        "objective": "binary:logistic",
+        "sample_type": "uniform",
+        "normalize_type": "tree",
+        "rate_drop": 0.1,
+        "skip_drop": 0.5,
+    }
+    bst = xgb.train(param, dtrain=dtrain, num_boost_round=num_round)
 
-    if model_format == 'json':
-        model_json_path = os.path.join(tmpdir, 'serialized.json')
+    if model_format == "json":
+        model_json_path = os.path.join(tmpdir, "serialized.json")
         bst.save_model(model_json_path)
-        model = treelite.Model.load(model_json_path, model_format='xgboost_json')
+        model = treelite.Model.load(model_json_path, model_format="xgboost_json")
     else:
-        model_bin_path = os.path.join(tmpdir, 'serialized.model')
+        model_bin_path = os.path.join(tmpdir, "serialized.model")
         bst.save_model(model_bin_path)
-        model = treelite.Model.load(model_bin_path, model_format='xgboost')
+        model = treelite.Model.load(model_bin_path, model_format="xgboost")
 
     assert model.num_feature == dtrain.num_col()
     assert model.num_class == 1
@@ -333,10 +415,10 @@ def test_xgb_dart(tmpdir, toolchain, model_format):
     predictor = treelite_runtime.Predictor(libpath=libpath, verbose=True)
     assert predictor.num_feature == dtrain.num_col()
     assert predictor.num_class == 1
-    assert predictor.pred_transform == 'sigmoid'
+    assert predictor.pred_transform == "sigmoid"
     np.testing.assert_almost_equal(predictor.global_bias, 0, decimal=5)
     assert predictor.sigmoid_alpha == 1.0
-    dmat = treelite_runtime.DMatrix(X, dtype='float32')
+    dmat = treelite_runtime.DMatrix(X, dtype="float32")
     out_pred = predictor.predict(dmat)
     expected_pred = bst.predict(dtrain)
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)

--- a/tests/python/util.py
+++ b/tests/python/util.py
@@ -97,16 +97,17 @@ def check_predictor_output(dataset, shape, out_margin, out_prob):
 
 @contextmanager
 def TemporaryDirectory(*args, **kwargs):
+    # pylint: disable=C0103
     """
     Simulate the effect of 'ignore_cleanup_errors' parameter of tempfile.TemporaryDirectory.
     The parameter is only available for Python >= 3.10.
     """
-    dir = tempfile.TemporaryDirectory(*args, **kwargs)
+    tmpdir = tempfile.TemporaryDirectory(*args, **kwargs)
     try:
-        yield dir.name
+        yield tmpdir.name
     finally:
         try:
-            dir.cleanup()
+            tmpdir.cleanup()
         except (PermissionError, NotADirectoryError):
             if _platform != "win32":
                 raise

--- a/tests/python/util.py
+++ b/tests/python/util.py
@@ -102,6 +102,8 @@ def TemporaryDirectory(*args, **kwargs):
     Simulate the effect of 'ignore_cleanup_errors' parameter of tempfile.TemporaryDirectory.
     The parameter is only available for Python >= 3.10.
     """
+    if "PYTEST_TMPDIR" in os.environ and "dir" not in kwargs:
+        kwargs["dir"] = os.environ["PYTEST_TMPDIR"]
     tmpdir = tempfile.TemporaryDirectory(*args, **kwargs)
     try:
         yield tmpdir.name

--- a/tests/python/util.py
+++ b/tests/python/util.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
 """Utility functions for tests"""
 import os
-from sys import platform as _platform
+import tempfile
 from contextlib import contextmanager
+from sys import platform as _platform
 
 import numpy as np
-import treelite_runtime
 from sklearn.datasets import load_svmlight_file
+
+import treelite_runtime
 from treelite.contrib import _libext
+
 from .metadata import dataset_db
 
 
@@ -16,7 +19,7 @@ def load_txt(filename):
     if filename is None:
         return None
     content = []
-    with open(filename, 'r', encoding='UTF-8') as f:
+    with open(filename, "r", encoding="UTF-8") as f:
         for line in f:
             content.append(float(line))
     return np.array(content, dtype=np.float32)
@@ -24,23 +27,23 @@ def load_txt(filename):
 
 def os_compatible_toolchains():
     """Get the list of C compilers to test with the current OS"""
-    if _platform == 'darwin':
-        gcc = os.environ.get('GCC_PATH', 'gcc')
+    if _platform == "darwin":
+        gcc = os.environ.get("GCC_PATH", "gcc")
         toolchains = [gcc]
-    elif _platform == 'win32':
-        toolchains = ['msvc']
+    elif _platform == "win32":
+        toolchains = ["msvc"]
     else:
-        toolchains = ['gcc', 'clang']
+        toolchains = ["gcc", "clang"]
     return toolchains
 
 
 def os_platform():
     """Detect OS that's running this program"""
-    if _platform == 'darwin':
-        return 'osx'
-    if _platform in ['win32', 'cygwin']:
-        return 'windows'
-    return 'unix'
+    if _platform == "darwin":
+        return "osx"
+    if _platform in ["win32", "cygwin"]:
+        return "windows"
+    return "unix"
 
 
 def libname(fmt):
@@ -52,6 +55,7 @@ def has_pandas():
     """Check whether pandas is available"""
     try:
         import pandas  # pylint: disable=unused-import
+
         return True
     except ImportError:
         return False
@@ -67,7 +71,8 @@ def check_predictor(predictor, dataset):
     """Check whether a predictor produces correct predictions for a given dataset"""
     dmat = treelite_runtime.DMatrix(
         load_svmlight_file(dataset_db[dataset].dtest, zero_based=True)[0],
-        dtype=dataset_db[dataset].dtype)
+        dtype=dataset_db[dataset].dtype,
+    )
     out_margin = predictor.predict(dmat, pred_margin=True)
     out_prob = predictor.predict(dmat)
     check_predictor_output(dataset, dmat.shape, out_margin, out_prob)
@@ -78,8 +83,9 @@ def check_predictor_output(dataset, shape, out_margin, out_prob):
     expected_margin = load_txt(dataset_db[dataset].expected_margin)
     if dataset_db[dataset].is_multiclass:
         expected_margin = expected_margin.reshape((shape[0], -1))
-    assert out_margin.shape == expected_margin.shape, \
-        f'out_margin.shape = {out_margin.shape}, expected_margin.shape = {expected_margin.shape}'
+    assert (
+        out_margin.shape == expected_margin.shape
+    ), f"out_margin.shape = {out_margin.shape}, expected_margin.shape = {expected_margin.shape}"
     np.testing.assert_almost_equal(out_margin, expected_margin, decimal=5)
 
     if dataset_db[dataset].expected_prob is not None:
@@ -87,3 +93,20 @@ def check_predictor_output(dataset, shape, out_margin, out_prob):
         if dataset_db[dataset].is_multiclass:
             expected_prob = expected_prob.reshape((shape[0], -1))
         np.testing.assert_almost_equal(out_prob, expected_prob, decimal=5)
+
+
+@contextmanager
+def TemporaryDirectory(*args, **kwargs):
+    """
+    Simulate the effect of 'ignore_cleanup_errors' parameter of tempfile.TemporaryDirectory.
+    The parameter is only available for Python >= 3.10.
+    """
+    dir = tempfile.TemporaryDirectory(*args, **kwargs)
+    try:
+        yield dir.name
+    finally:
+        try:
+            dir.cleanup()
+        except (PermissionError, NotADirectoryError):
+            if _platform != "win32":
+                raise


### PR DESCRIPTION
* Use `hypothesis` to randomly generate regression data
* Remove all uses of `load_boston`
* [CI] Don't use sklearn in `compatibility_tester.py`, since old version of Treelite can't handle latest sklearn.

This should fix the CI.

Close #371