### PR TITLE
[CI] Require C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,6 @@ set (CMAKE_FIND_NO_INSTALL_PREFIX TRUE FORCE)
 cmake_minimum_required (VERSION 3.13)
 project(treelite LANGUAGES CXX C VERSION 3.2.0)
 
-set(CMAKE_CXX_STANDARD 14)
-
 # check MSVC version
 if(MSVC)
   if(MSVC_VERSION LESS 1910)

--- a/runtime/java/CMakeLists.txt
+++ b/runtime/java/CMakeLists.txt
@@ -7,5 +7,5 @@ target_include_directories(treelite4j PUBLIC ${JNI_INCLUDE_DIRS})
 set_target_properties(treelite4j
   PROPERTIES
   POSITION_INDEPENDENT_CODE ON
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,7 +73,7 @@ endforeach()
 set_target_properties(objtreelite objtreelite_runtime objtreelite_common
   PROPERTIES
   POSITION_INDEPENDENT_CODE ON
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED ON)
 
 target_sources(objtreelite

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(treelite_cpp_test)
 set_target_properties(treelite_cpp_test
     PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON)
 target_link_libraries(treelite_cpp_test
     PRIVATE objtreelite objtreelite_runtime objtreelite_common rapidjson

--- a/tests/example_app/CMakeLists.txt
+++ b/tests/example_app/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(c_example example.c)
 target_link_libraries(c_example PRIVATE treelite::treelite treelite::treelite_runtime)
 
 set_target_properties(cpp_example PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
 )
 


### PR DESCRIPTION
By upgrading to C++17, we will be able to use latest C++ features such as  `std::variant<>` and `constexpr if`