### PR TITLE
Implement predict_leaf and predict_per_tree

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -152,6 +152,7 @@ Contents
   tutorials/index
   treelite-api
   treelite-runtime-api
+  treelite-gtil-api
   treelite-c-api
   javadoc/packages
   Treelite runtime Rust API <http://dovahcrow.github.io/treerite/treerite/>

--- a/docs/treelite-c-api.rst
+++ b/docs/treelite-c-api.rst
@@ -78,6 +78,13 @@ from shared libraries and to make predictions.
    :project: treelite
    :content-only:
 
+General Tree Inference Library (GTIL)
+-------------------------------------
+
+.. doxygengroup:: gtil
+   :project: treelite
+   :content-only:
+
 Handle types
 ------------
 Treelite uses C++ classes to define its internal data structures. In order to

--- a/docs/treelite-gtil-api.rst
+++ b/docs/treelite-gtil-api.rst
@@ -1,0 +1,12 @@
+=====================================
+General Tree Inference Library (GTIL)
+=====================================
+
+GTIL is a **reference implementation** of a prediction runtime for all Treelite models. It has the following goals:
+
+* **Universal coverage**: GTIL shall support all tree ensemble models that can be represented as Treelite objects.
+* **Accessible code**: GTIL should be written in an easy-to-read style that can be understood to a first-time contributor. We prefer code legibility to performance optimization.
+* **Correct output**: As a reference implementation, GTIL should produce correct prediction outputs.
+
+.. automodule:: treelite.gtil
+   :members:

--- a/include/treelite/c_api.h
+++ b/include/treelite/c_api.h
@@ -474,9 +474,13 @@ TREELITE_DLL int TreeliteFreeModel(ModelHandle handle);
 
 /*!
  * \brief Load a configuration for GTIL predictor from a JSON string.
- * \param config_json a JSON string. Valid entries are:
- *   - nthread (optional): Number of threads used for initializing DMatrix.
- *   - pred_transform (optional, defaults to True): Whether to apply post-prediction transformation
+ * \param config_json a JSON string with the following fields:
+ *   - "nthread" (optional): Number of threads used for initializing DMatrix.
+ *   - "predict_type" (required): Must be one of the following.
+ *     - "default": Sum over trees and apply post-processing
+ *     - "raw": Sum over trees, but don't apply post-processing; get raw margin scores instead.
+ *     - "leaf_id": Output one (integer) leaf ID per tree.
+ *     - "score_per_tree": Output one or more margin scores per tree.
  * \param out Parsed configuration
  * \return 0 for success; -1 for failure
  */

--- a/include/treelite/c_api.h
+++ b/include/treelite/c_api.h
@@ -31,6 +31,8 @@ typedef void* AnnotationHandle;
 typedef void* CompilerHandle;
 /*! \brief handle to a polymorphic value type, used in the model builder API */
 typedef void* ValueHandle;
+/*! \brief handle to a configuration of GTIL predictor */
+typedef void* GTILConfigHandle;
 /*! \} */
 
 /*!
@@ -471,32 +473,63 @@ TREELITE_DLL int TreeliteFreeModel(ModelHandle handle);
  */
 
 /*!
+ * \brief Load a configuration for GTIL predictor from a JSON string.
+ * \param config_json a JSON string. Valid entries are:
+ *   - nthread (optional): Number of threads used for initializing DMatrix.
+ *   - pred_transform (optional, defaults to True): Whether to apply post-prediction transformation
+ * \param out Parsed configuration
+ * \return 0 for success; -1 for failure
+ */
+TREELITE_DLL int TreeliteGTILParseConfig(const char* config_json, GTILConfigHandle* out);
+
+/*!
+ * \brief Delete a GTIL configuration from memory
+ * \param handle Handle to the GTIL configuration to be deleted
+ * \return 0 for success; -1 for failure
+ */
+TREELITE_DLL int TreeliteGTILDeleteConfig(GTILConfigHandle handle);
+
+/*!
+ * \brief Deprecated. Please use \ref TreeliteGTILGetPredictOutputSizeEx instead.
+ */
+TREELITE_DLL int TreeliteGTILGetPredictOutputSize(ModelHandle model, size_t num_row, size_t* out);
+
+/*!
  * \brief Given a batch of data rows, query the necessary size of array to hold predictions for all
  *        data points.
  * \param model Treelite Model object
  * \param num_row Number of rows in the input
+ * \param config Configuration of GTIL predictor. Set this by calling \ref TreeliteGTILParseConfig.
  * \param out Size of output buffer that should be allocated
  * \return 0 for success; -1 for failure
  */
-TREELITE_DLL int TreeliteGTILGetPredictOutputSize(ModelHandle model, size_t num_row, size_t* out);
+TREELITE_DLL int TreeliteGTILGetPredictOutputSizeEx(ModelHandle model, size_t num_row,
+                                                    GTILConfigHandle config, size_t* out);
+
+/*!
+ * \brief Deprecated. Please use \ref TreeliteGTILPredictEx instead.
+ */
+TREELITE_DLL int TreeliteGTILPredict(ModelHandle model, const float* input, size_t num_row,
+                                     float* output, int nthread, int pred_transform,
+                                     size_t* out_result_size);
 
 /*!
  * \brief Predict with a 2D dense array
  * \param model Treelite Model object
  * \param input The 2D data array, laid out in row-major layout
  * \param num_row Number of rows in the data matrix.
- * \param output Pointer to buffer to store the output. Call TreeliteGTILGetPredictOutputSize()
- *               to get the amount of buffer you should allocate for this parameter.
- * \param nthread number of CPU threads to use. Set <= 0 to use all CPU cores.
- * \param pred_transform After computing the prediction score, whether to transform it.
+ * \param output Pointer to buffer to store the output. Call \ref
+ *               TreeliteGTILGetPredictOutputSizeEx to get the amount of buffer you should
+ *               allocate for this parameter.
+ * \param config Configuration of GTIL predictor. Set this by calling \ref TreeliteGTILParseConfig.
  * \param out_result_size Size of output. This could be smaller than
- *                        TreeliteGTILGetPredictOutputSize() but could never be larger than
- *                        TreeliteGTILGetPredictOutputSize().
+ *                        \ref TreeliteGTILGetPredictOutputSizeEx but could never be larger than
+ *                        \ref TreeliteGTILGetPredictOutputSizeEx.
  * \return 0 for success; -1 for failure
  */
-TREELITE_DLL int TreeliteGTILPredict(ModelHandle model, const float* input, size_t num_row,
-                                     float* output, int nthread, int pred_transform,
-                                     size_t* out_result_size);
+TREELITE_DLL int TreeliteGTILPredictEx(ModelHandle model, const float* input, size_t num_row,
+                                       float* output, GTILConfigHandle config,
+                                       size_t* out_result_size);
 
 /*! \} */
 

--- a/include/treelite/c_api.h
+++ b/include/treelite/c_api.h
@@ -476,6 +476,7 @@ TREELITE_DLL int TreeliteFreeModel(ModelHandle handle);
  * \brief Load a configuration for GTIL predictor from a JSON string.
  * \param config_json a JSON string with the following fields:
  *   - "nthread" (optional): Number of threads used for initializing DMatrix.
+ *                           Set <= 0 to use all CPU cores.
  *   - "predict_type" (required): Must be one of the following.
  *     - "default": Sum over trees and apply post-processing
  *     - "raw": Sum over trees, but don't apply post-processing; get raw margin scores instead.

--- a/include/treelite/c_api.h
+++ b/include/treelite/c_api.h
@@ -529,11 +529,16 @@ TREELITE_DLL int TreeliteGTILPredict(ModelHandle model, const float* input, size
  * \param out_result_size Size of output. This could be smaller than
  *                        \ref TreeliteGTILGetPredictOutputSizeEx but could never be larger than
  *                        \ref TreeliteGTILGetPredictOutputSizeEx.
+ * \param out_result_ndim Number of dimensions in the output array.
+ * \param out_result_shape Pointer to an array containing dimensions of the prediction output.
+ *                         This array shall have [out_result_ndim] elements.
+ *                         The product of the elements shall be equal to out_result_size.
  * \return 0 for success; -1 for failure
  */
 TREELITE_DLL int TreeliteGTILPredictEx(ModelHandle model, const float* input, size_t num_row,
                                        float* output, GTILConfigHandle config,
-                                       size_t* out_result_size);
+                                       size_t* out_result_size, size_t* out_result_ndim,
+                                       size_t** out_result_shape);
 
 /*! \} */
 

--- a/include/treelite/gtil.h
+++ b/include/treelite/gtil.h
@@ -28,6 +28,12 @@ enum class PredictType : std::int8_t {
    *  - (num_row,) for model type kBinaryClfRegr
    *  - (num_row,) for model type kMultiClfGrovePerClass, when pred_transform="max_index"
    *  - (num_row, num_class) for model type kMultiClfGrovePerClass / kMultiClfProbDistLeaf
+   *
+   * \note Most of the time, the dimensions of the prediction output is the same as the return
+   * value of \ref GetPredictOutputSize, with one exception: when pred_transform is "max_index",
+   * \ref GetPredictOutputSize returns (num_row * num_class), to hold the margin scores. The final
+   * output dimension is (num_row,) since the class with the largest margin score is chosen for
+   * each data row.
    */
   kPredictDefault = 0,
   /*!
@@ -63,11 +69,11 @@ struct Configuration {
  * \brief Predict with a DMatrix
  * \param model The model object
  * \param input The data matrix (sparse or dense)
- * \param output Pointer to buffer to store the output. Call GetPredictOutputSize() to get the
+ * \param output Pointer to buffer to store the output. Call \ref GetPredictOutputSize to get the
  *               amount of buffer you should allocate for this parameter.
  * \param config Configuration for GTIL Predictor
- * \return Size of output. This could be smaller than GetPredictOutputSize() but could never be
- *         larger than GetPredictOutputSize().
+ * \return Size of output. This could be smaller than \ref GetPredictOutputSize but could never be
+ *         larger than \ref GetPredictOutputSize.
  */
 std::size_t Predict(const Model* model, const DMatrix* input, float* output,
                     const Configuration& config);
@@ -76,11 +82,11 @@ std::size_t Predict(const Model* model, const DMatrix* input, float* output,
  * \param model The model object
  * \param input The 2D data array, laid out in row-major layout
  * \param num_row Number of rows in the data matrix.
- * \param output Pointer to buffer to store the output. Call GetPredictOutputSize() to get the
+ * \param output Pointer to buffer to store the output. Call \ref GetPredictOutputSize to get the
  *               amount of buffer you should allocate for this parameter.
  * \param config Configuration for GTIL Predictor
- * \return Size of output. This could be smaller than GetPredictOutputSize() but could never be
- *         larger than GetPredictOutputSize().
+ * \return Size of output. This could be smaller than \ref GetPredictOutputSize but could never be
+ *         larger than \ref GetPredictOutputSize.
  */
 std::size_t Predict(const Model* model, const float* input, std::size_t num_row, float* output,
                     const Configuration& config);

--- a/include/treelite/gtil.h
+++ b/include/treelite/gtil.h
@@ -52,8 +52,8 @@ enum class PredictType : std::int8_t {
   /*!
    * \brief Output one or more margin scores per tree.
    * Expected output dimensions:
-   *  - (num_row, num_tree) for model type kBinaryClfRegr
-   *  - (num_row, num_tree, num_class) for model type kMultiClfGrovePerClass / kMultiClfProbDistLeaf
+   *  - (num_row, num_tree) for model type kBinaryClfRegr / kMultiClfGrovePerClass
+   *  - (num_row, num_tree, num_class) for model type kMultiClfProbDistLeaf
    */
   kPredictPerTree = 3
 };

--- a/include/treelite/gtil.h
+++ b/include/treelite/gtil.h
@@ -19,19 +19,25 @@ class DMatrix;
 
 namespace gtil {
 
+struct GTILConfig {
+  int nthread{0};  // use all threads by default
+  bool pred_transform{true};
+  GTILConfig() = default;
+  explicit GTILConfig(const char* config_json);
+};
+
 /*!
  * \brief Predict with a DMatrix
  * \param model The model object
  * \param input The data matrix (sparse or dense)
  * \param output Pointer to buffer to store the output. Call GetPredictOutputSize() to get the
  *               amount of buffer you should allocate for this parameter.
- * \param nthread number of CPU threads to use. Set <= 0 to use all CPU cores.
- * \param pred_transform After computing the prediction score, whether to transform it.
+ * \param config Configuration for GTIL Predictor
  * \return Size of output. This could be smaller than GetPredictOutputSize() but could never be
  *         larger than GetPredictOutputSize().
  */
-std::size_t Predict(const Model* model, const DMatrix* input, float* output, int nthread,
-                    bool pred_transform);
+std::size_t Predict(const Model* model, const DMatrix* input, float* output,
+                    const GTILConfig& config);
 /*!
  * \brief Predict with a 2D dense array
  * \param model The model object
@@ -39,29 +45,31 @@ std::size_t Predict(const Model* model, const DMatrix* input, float* output, int
  * \param num_row Number of rows in the data matrix.
  * \param output Pointer to buffer to store the output. Call GetPredictOutputSize() to get the
  *               amount of buffer you should allocate for this parameter.
- * \param nthread number of CPU threads to use. Set <= 0 to use all CPU cores.
- * \param pred_transform After computing the prediction score, whether to transform it.
+ * \param config Configuration for GTIL Predictor
  * \return Size of output. This could be smaller than GetPredictOutputSize() but could never be
  *         larger than GetPredictOutputSize().
  */
 std::size_t Predict(const Model* model, const float* input, std::size_t num_row, float* output,
-                    int nthread, bool pred_transform);
+                    const GTILConfig& config);
 /*!
  * \brief Given a batch of data rows, query the necessary size of array to hold predictions for all
  *        data points.
  * \param model Treelite Model object
  * \param num_row Number of rows in the input
+ * \param config Configuration for GTIL Predictor
  * \return Size of output buffer that should be allocated
  */
-std::size_t GetPredictOutputSize(const Model* model, std::size_t num_row);
+std::size_t GetPredictOutputSize(const Model* model, std::size_t num_row, const GTILConfig& config);
 /*!
  * \brief Given a batch of data rows, query the necessary size of array to hold predictions for all
  *        data points.
  * \param model Treelite Model object
  * \param input The input matrix
+ * \param config Configuration for GTIL Predictor
  * \return Size of output buffer that should be allocated
  */
-std::size_t GetPredictOutputSize(const Model* model, const DMatrix* input);
+std::size_t GetPredictOutputSize(const Model* model, const DMatrix* input,
+                                 const GTILConfig& config);
 
 }  // namespace gtil
 }  // namespace treelite

--- a/include/treelite/gtil.h
+++ b/include/treelite/gtil.h
@@ -10,6 +10,7 @@
 #ifndef TREELITE_GTIL_H_
 #define TREELITE_GTIL_H_
 
+#include <vector>
 #include <cstdint>
 #include <cstddef>
 
@@ -72,11 +73,13 @@ struct Configuration {
  * \param output Pointer to buffer to store the output. Call \ref GetPredictOutputSize to get the
  *               amount of buffer you should allocate for this parameter.
  * \param config Configuration for GTIL Predictor
+ * \param output_shape Shape of output. The product of the elements of this array shall be equal to
+ *                     the return value.
  * \return Size of output. This could be smaller than \ref GetPredictOutputSize but could never be
  *         larger than \ref GetPredictOutputSize.
  */
 std::size_t Predict(const Model* model, const DMatrix* input, float* output,
-                    const Configuration& config);
+                    const Configuration& config, std::vector<std::size_t>& output_shape);
 /*!
  * \brief Predict with a 2D dense array
  * \param model The model object
@@ -85,11 +88,13 @@ std::size_t Predict(const Model* model, const DMatrix* input, float* output,
  * \param output Pointer to buffer to store the output. Call \ref GetPredictOutputSize to get the
  *               amount of buffer you should allocate for this parameter.
  * \param config Configuration for GTIL Predictor
+ * \param output_shape Shape of output. The product of the elements of this array shall be equal to
+ *                     the return value.
  * \return Size of output. This could be smaller than \ref GetPredictOutputSize but could never be
  *         larger than \ref GetPredictOutputSize.
  */
 std::size_t Predict(const Model* model, const float* input, std::size_t num_row, float* output,
-                    const Configuration& config);
+                    const Configuration& config, std::vector<std::size_t>& output_shape);
 /*!
  * \brief Given a batch of data rows, query the necessary size of array to hold predictions for all
  *        data points.

--- a/python/treelite/gtil/__init__.py
+++ b/python/treelite/gtil/__init__.py
@@ -1,6 +1,6 @@
 """
 General Tree Inference Library (GTIL)
 """
-from .gtil import predict
+from .gtil import predict, predict_leaf, predict_per_tree
 
-__all__ = ['predict']
+__all__ = ["predict", "predict_leaf", "predict_per_tree"]

--- a/python/treelite/gtil/gtil.py
+++ b/python/treelite/gtil/gtil.py
@@ -107,6 +107,7 @@ def predict(
             ctypes.byref(output_size),
         )
     )
+    print(f"Allocating output with size {output_size.value}")
     out_result = np.zeros(shape=output_size.value, dtype=np.float32, order="C")
     out_result_size = ctypes.c_size_t()
     out_result_ndim = ctypes.c_size_t()

--- a/python/treelite/gtil/gtil.py
+++ b/python/treelite/gtil/gtil.py
@@ -28,6 +28,7 @@ class GTILConfig:
     # <= 0 indicates using all threads
 
     def to_json(self):
+        """Convert configuration object into a JSON string"""
         return json.dumps(asdict(self))
 
     def __post_init__(self):

--- a/python/treelite/gtil/gtil.py
+++ b/python/treelite/gtil/gtil.py
@@ -33,9 +33,7 @@ def predict(
     model: Model, data: np.ndarray, nthread: int = -1, pred_margin: bool = False
 ):
     """
-    Predict with a Treelite model using General Tree Inference Library (GTIL). GTIL is intended to
-    be a reference implementation. GTIL is also useful in situations where using a C compiler is
-    not feasible.
+    Predict with a Treelite model using General Tree Inference Library (GTIL).
 
     .. note:: GTIL is currently experimental
 

--- a/python/treelite/gtil/gtil.py
+++ b/python/treelite/gtil/gtil.py
@@ -3,7 +3,7 @@ General Tree Inference Library (GTIL)
 """
 import ctypes
 import json
-import warnings
+from dataclasses import asdict, dataclass
 from typing import Optional
 
 import numpy as np
@@ -13,21 +13,28 @@ from ..frontend import Model
 from ..util import c_str
 
 
+@dataclass
 class GTILConfig:
     """Object holding configuration data"""
 
-    # pylint: disable=too-few-public-methods
+    predict_type: str
+    # Prediction type is one of the following:
+    # * "default": Usual prediction method. Sum over trees and apply post-processing.
+    # * "raw": Sum over trees, but don't apply post-processing; get raw margin scores
+    #          instead.
+    # * "leaf_id": Output one (integer) leaf ID per tree.
+    # * "score_per_tree": Output one or more margin scores per tree.
+    nthread: int = -1
+    # <= 0 indicates using all threads
 
-    def __init__(self, *, nthread: int, predict_type: str):
-        predictor_config = {
-            "nthread": nthread,
-            "predict_type": predict_type,
-        }
-        predictor_config = json.dumps(predictor_config)
+    def to_json(self):
+        return json.dumps(asdict(self))
+
+    def __post_init__(self):
         self.handle = ctypes.c_void_p()
         _check_call(
             _LIB.TreeliteGTILParseConfig(
-                c_str(predictor_config), ctypes.byref(self.handle)
+                c_str(self.to_json()), ctypes.byref(self.handle)
             )
         )
 
@@ -41,16 +48,10 @@ def predict(
     data: np.ndarray,
     *,
     nthread: int = -1,
-    pred_margin: Optional[bool] = None,
-    predict_type: Optional[str] = None
+    pred_margin: Optional[bool] = None
 ):
     """
-    Predict with a Treelite model using General Tree Inference Library (GTIL).
-
-    .. note:: GTIL is currently experimental
-
-        GTIL is currently in its early stage of development and may have bugs and performance
-        issues. Please report any issues found on GitHub.
+    Predict with a Treelite model using the General Tree Inference Library (GTIL).
 
     Parameters
     ----------
@@ -60,37 +61,97 @@ def predict(
         2D NumPy array, with which to run prediction
     nthread : :py:class:`int <python:int>`, optional
         Number of CPU cores to use in prediction. If <= 0, use all CPU cores.
-    pred_margin : bool, optional
-        Deprecated. Set predict_type="raw" instead.
-    predict_type : string, optional
-        One of the following:
-        * "default": Usual prediction method. Sum over trees and apply post-processing.
-        * "raw": Sum over trees, but don't apply post-processing; get raw margin scores
-                 instead.
-        * "leaf_id": Output one (integer) leaf ID per tree.
-        * "score_per_tree": Output one or more margin scores per tree.
+    pred_margin : bool, optional (defaults to False)
+        Whether to produce raw margin scores. If pred_margin=True, post-processing
+        is no longer applied and raw margin scores are produced.
 
     Returns
     -------
     prediction : :py:class:`numpy.ndarray` array
-        Prediction
+        Prediction output.
+        Expected output dimensions for pred_margin=False:
+        - (num_row,) for regressors and binary classifiers
+        - (num_row,) for multi-class classifiers,
+                     where task_type="MultiClfGrovePerClass", pred_transform="max_index"
+        - (num_row, num_class) for all other multi-class classifiers
+        Expected output dimensions for pred_margin=True:
+        - (num_row,) for regressors and binary classifiers
+        - (num_row, num_class) for multi-class classifiers
     """
-    # Parameter validation
-    if pred_margin is not None:
-        if predict_type:
-            raise ValueError(
-                "Cannot specify pred_margin and predict_type at the same "
-                "time. Please set predict_type only."
-            )
-        warnings.warn(
-            "The pred_margin argument is deprecated. Please use "
-            'predict_type="raw" instead.',
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        predict_type = "raw"
-    if not predict_type:
-        predict_type = "default"
+    if pred_margin is None:
+        pred_margin = False
+    predict_type = "raw" if pred_margin else "default"
+
+    config = GTILConfig(nthread=nthread, predict_type=predict_type)
+    return _predict_impl(model, data, config=config)
+
+
+def predict_leaf(model: Model, data: np.ndarray, *, nthread: int = -1):
+    """
+    Predict with a Treelite model, outputting the leaf node's ID for each row.
+
+    Parameters
+    ----------
+    model : :py:class:`Model` object
+        Treelite model object
+    data : :py:class:`numpy.ndarray` array
+        2D NumPy array, with which to run prediction
+    nthread : :py:class:`int <python:int>`, optional
+        Number of CPU cores to use in prediction. If <= 0, use all CPU cores.
+
+    Returns
+    -------
+    prediction : :py:class:`numpy.ndarray` array
+        Prediction output.
+        Expected output dimensions:
+        - (num_row,) for regressors and binary classifiers
+        - (num_row, num_class) for multi-class classifiers
+
+    Notes
+    -----
+    Treelite assigns a unique integer ID for every node in the tree, including leaf
+    nodes as well as internal nodes. It does so by traversing the tree breadth-first.
+    So, for example, the root node is assigned ID 0, and the two nodes at depth=1 is
+    assigned ID 1 and 2, respectively.
+    Call :py:meth:`treelite.Model.dump_as_json` to obtain the ID of every tree node.
+    """
+
+    config = GTILConfig(nthread=nthread, predict_type="leaf_id")
+    return _predict_impl(model, data, config=config)
+
+
+def predict_per_tree(model: Model, data: np.ndarray, *, nthread: int = -1):
+    """
+    Predict with a Treelite model and output prediction of each tree.
+    This function computes one or more margin scores per tree.
+
+    Parameters
+    ----------
+    model : :py:class:`Model` object
+        Treelite model object
+    data : :py:class:`numpy.ndarray` array
+        2D NumPy array, with which to run prediction
+    nthread : :py:class:`int <python:int>`, optional
+        Number of CPU cores to use in prediction. If <= 0, use all CPU cores.
+
+    Returns
+    -------
+    prediction : :py:class:`numpy.ndarray` array
+        Prediction output.
+        Expected output dimensions:
+        - (num_row, num_tree) for regressors, binary classifiers,
+                              and multi-class classifiers with
+                              task_type="MultiClfGrovePerClass"
+        - (num_row, num_tree, num_class) for multi-class classifiers with
+                                         task_type="kMultiClfProbDistLeaf"
+    """
+
+    config = GTILConfig(nthread=nthread, predict_type="score_per_tree")
+    return _predict_impl(model, data, config=config)
+
+
+def _predict_impl(model, data, *, config):
+    # Validate parameters
     if not isinstance(model, Model):
         raise ValueError('Argument "model" must be a Model type')
     if (not isinstance(data, np.ndarray)) or len(data.shape) != 2:
@@ -98,7 +159,7 @@ def predict(
 
     data = np.array(data, copy=False, dtype=np.float32, order="C")
     output_size = ctypes.c_size_t()
-    config = GTILConfig(nthread=nthread, predict_type=predict_type)
+
     _check_call(
         _LIB.TreeliteGTILGetPredictOutputSizeEx(
             model.handle,

--- a/python/treelite/gtil/gtil.py
+++ b/python/treelite/gtil/gtil.py
@@ -37,12 +37,12 @@ class GTILConfig:
 
 
 def predict(
-        model: Model,
-        data: np.ndarray,
-        *,
-        nthread: int = -1,
-        pred_margin: Optional[bool] = None,
-        predict_type: Optional[str] = None
+    model: Model,
+    data: np.ndarray,
+    *,
+    nthread: int = -1,
+    pred_margin: Optional[bool] = None,
+    predict_type: Optional[str] = None
 ):
     """
     Predict with a Treelite model using General Tree Inference Library (GTIL).
@@ -107,7 +107,6 @@ def predict(
             ctypes.byref(output_size),
         )
     )
-    print(f"Allocating output with size {output_size.value}")
     out_result = np.zeros(shape=output_size.value, dtype=np.float32, order="C")
     out_result_size = ctypes.c_size_t()
     out_result_ndim = ctypes.c_size_t()
@@ -121,12 +120,14 @@ def predict(
             config.handle,
             ctypes.byref(out_result_size),
             ctypes.byref(out_result_ndim),
-            ctypes.byref(out_result_shape)
+            ctypes.byref(out_result_shape),
         )
     )
     # Reshape the result according to out_result_shape
     out_shape = np.ctypeslib.as_array(out_result_shape, shape=(out_result_ndim.value,))
     idx = int(out_result_size.value)
     assert idx == np.prod(out_shape)
-    res = out_result[0:idx].reshape(out_shape).squeeze()
+    res = out_result[0:idx].reshape(out_shape)
+    if data.shape[0] > 1:
+        res = res.squeeze()
     return res

--- a/python/treelite/gtil/gtil.py
+++ b/python/treelite/gtil/gtil.py
@@ -3,8 +3,9 @@ General Tree Inference Library (GTIL)
 """
 import ctypes
 import json
+import warnings
 from dataclasses import asdict, dataclass
-from typing import Optional
+from typing import Literal, Optional
 
 import numpy as np
 
@@ -17,7 +18,7 @@ from ..util import c_str
 class GTILConfig:
     """Object holding configuration data"""
 
-    predict_type: str
+    predict_type: Literal["default", "raw", "leaf_id", "score_per_tree"]
     # Prediction type is one of the following:
     # * "default": Usual prediction method. Sum over trees and apply post-processing.
     # * "raw": Sum over trees, but don't apply post-processing; get raw margin scores
@@ -158,6 +159,12 @@ def _predict_impl(model, data, *, config):
     if (not isinstance(data, np.ndarray)) or len(data.shape) != 2:
         raise ValueError('Argument "data" must be a 2D NumPy array')
 
+    if data.dtype != np.float32:
+        warnings.warn(
+            "GTIL currently only supports float32 type; data will be "
+            "converted to float32 and information might be lost.",
+            UserWarning,
+        )
     data = np.array(data, copy=False, dtype=np.float32, order="C")
     output_size = ctypes.c_size_t()
 

--- a/python/treelite/gtil/gtil.py
+++ b/python/treelite/gtil/gtil.py
@@ -68,15 +68,16 @@ def predict(
     Returns
     -------
     prediction : :py:class:`numpy.ndarray` array
-        Prediction output.
-        Expected output dimensions for pred_margin=False:
+        Prediction output. Expected output dimensions:
+
         - (num_row,) for regressors and binary classifiers
-        - (num_row,) for multi-class classifiers,
-                     where task_type="MultiClfGrovePerClass", pred_transform="max_index"
-        - (num_row, num_class) for all other multi-class classifiers
-        Expected output dimensions for pred_margin=True:
-        - (num_row,) for regressors and binary classifiers
-        - (num_row, num_class) for multi-class classifiers
+        - (num_row, num_class) for multi-class classifiers (See Notes for a special
+          case.)
+
+    Notes
+    -----
+    The output has shape (num_row,) if the model is a multi-class classifier with
+    task_type="MultiClfGrovePerClass" and pred_transform="max_index".
     """
     if pred_margin is None:
         pred_margin = False
@@ -102,8 +103,8 @@ def predict_leaf(model: Model, data: np.ndarray, *, nthread: int = -1):
     Returns
     -------
     prediction : :py:class:`numpy.ndarray` array
-        Prediction output.
-        Expected output dimensions:
+        Prediction output. Expected output dimensions:
+
         - (num_row,) for regressors and binary classifiers
         - (num_row, num_class) for multi-class classifiers
 
@@ -137,13 +138,12 @@ def predict_per_tree(model: Model, data: np.ndarray, *, nthread: int = -1):
     Returns
     -------
     prediction : :py:class:`numpy.ndarray` array
-        Prediction output.
-        Expected output dimensions:
+        Prediction output. Expected output dimensions:
+
         - (num_row, num_tree) for regressors, binary classifiers,
-                              and multi-class classifiers with
-                              task_type="MultiClfGrovePerClass"
+          and multi-class classifiers with task_type="MultiClfGrovePerClass"
         - (num_row, num_tree, num_class) for multi-class classifiers with
-                                         task_type="kMultiClfProbDistLeaf"
+          task_type="kMultiClfProbDistLeaf"
     """
 
     config = GTILConfig(nthread=nthread, predict_type="score_per_tree")

--- a/python/treelite/gtil/gtil.py
+++ b/python/treelite/gtil/gtil.py
@@ -14,8 +14,13 @@ from ..util import c_str
 class GTILConfig:
     """Object holding configuration data"""
 
+    # pylint: disable=too-few-public-methods
+
     def __init__(self, *, nthread: int, pred_margin: bool):
-        predictor_config = {"nthread": nthread, "pred_transform": (not pred_margin)}
+        predictor_config = {
+            "nthread": nthread,
+            "predict_type": ("raw" if pred_margin else "default"),
+        }
         predictor_config = json.dumps(predictor_config)
         self.handle = ctypes.c_void_p()
         _check_call(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,7 @@ target_sources(objtreelite
     frontend/xgboost_json.cc
     frontend/xgboost_util.cc
     gtil/predict.cc
+    gtil/config.cc
     gtil/pred_transform.h
     gtil/pred_transform.cc
     threading_utils/parallel_for.h

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -114,6 +114,9 @@ int TreeliteCompilerFree(CompilerHandle handle) {
 }
 
 int TreeliteLoadLightGBMModel(const char* filename, ModelHandle* out) {
+  TREELITE_LOG(WARNING)
+      << "TreeliteLoadLightGBMModel() is deprecated. Please use "
+      << "TreeliteLoadLightGBMModelEx() instead.";
   return TreeliteLoadLightGBMModelEx(filename, "{}", out);
 }
 
@@ -126,6 +129,9 @@ int TreeliteLoadLightGBMModelEx(const char* filename, const char* config_json, M
 }
 
 int TreeliteLoadXGBoostModel(const char* filename, ModelHandle* out) {
+  TREELITE_LOG(WARNING)
+      << "TreeliteLoadXGBoostModel() is deprecated. Please use "
+      << "TreeliteLoadXGBoostModelEx() instead.";
   return TreeliteLoadXGBoostModelEx(filename, "{}", out);
 }
 
@@ -138,6 +144,9 @@ int TreeliteLoadXGBoostModelEx(const char* filename, const char* config_json, Mo
 }
 
 int TreeliteLoadXGBoostJSON(const char* filename, ModelHandle* out) {
+  TREELITE_LOG(WARNING)
+      << "TreeliteLoadXGBoostJSON() is deprecated. Please use "
+      << "TreeliteLoadXGBoostJSONEx() instead.";
   return TreeliteLoadXGBoostJSONEx(filename, "{}", out);
 }
 
@@ -149,6 +158,9 @@ int TreeliteLoadXGBoostJSONEx(const char* filename, const char* config_json, Mod
 }
 
 int TreeliteLoadXGBoostJSONString(const char* json_str, size_t length, ModelHandle* out) {
+  TREELITE_LOG(WARNING)
+    << "TreeliteLoadXGBoostJSONString() is deprecated. Please use "
+    << "TreeliteLoadXGBoostJSONStringEx() instead.";
   return TreeliteLoadXGBoostJSONStringEx(json_str, length, "{}", out);
 }
 
@@ -162,6 +174,9 @@ int TreeliteLoadXGBoostJSONStringEx(
 }
 
 int TreeliteLoadXGBoostModelFromMemoryBuffer(const void* buf, size_t len, ModelHandle* out) {
+  TREELITE_LOG(WARNING)
+      << "TreeliteLoadXGBoostModelFromMemoryBuffer() is deprecated. Please use "
+      << "TreeliteLoadXGBoostModelFromMemoryBufferEx() instead.";
   return TreeliteLoadXGBoostModelFromMemoryBufferEx(buf, len, "{}", out);
 }
 
@@ -175,6 +190,9 @@ int TreeliteLoadXGBoostModelFromMemoryBufferEx(
 }
 
 int TreeliteLoadLightGBMModelFromString(const char* model_str, ModelHandle* out) {
+  TREELITE_LOG(WARNING)
+      << "TreeliteLoadLightGBMModelFromString() is deprecated. Please use "
+      << "TreeliteLoadLightGBMModelFromStringEx() instead.";
   return TreeliteLoadLightGBMModelFromStringEx(model_str, "{}", out);
 }
 
@@ -298,19 +316,59 @@ int TreeliteFreeModel(ModelHandle handle) {
   API_END();
 }
 
+int TreeliteGTILParseConfig(const char* config_json, GTILConfigHandle* out) {
+  API_BEGIN();
+  auto parsed_config = std::make_unique<gtil::GTILConfig>(config_json);
+  *out = static_cast<GTILConfigHandle>(parsed_config.release());
+  API_END();
+}
+
+int TreeliteGTILDeleteConfig(GTILConfigHandle handle) {
+  API_BEGIN();
+  delete static_cast<gtil::GTILConfig*>(handle);
+  API_END();
+}
+
 int TreeliteGTILGetPredictOutputSize(ModelHandle model, size_t num_row, size_t* out) {
   API_BEGIN();
+  TREELITE_LOG(WARNING)
+    << "TreeliteGTILGetPredictOutputSize() is deprecated; "
+    << "please use TreeliteGTILGetPredictOutputSizeEx() instead";
   const auto* model_ = static_cast<const Model*>(model);
-  *out = gtil::GetPredictOutputSize(model_, num_row);
+  *out = gtil::GetPredictOutputSize(model_, num_row, gtil::GTILConfig{});
+  API_END();
+}
+
+int TreeliteGTILGetPredictOutputSizeEx(ModelHandle model, size_t num_row, GTILConfigHandle config,
+                                       size_t* out) {
+  API_BEGIN();
+  const auto* model_ = static_cast<const Model*>(model);
+  const auto* config_ = static_cast<const gtil::GTILConfig*>(config);
+  *out = gtil::GetPredictOutputSize(model_, num_row, *config_);
   API_END();
 }
 
 int TreeliteGTILPredict(ModelHandle model, const float* input, size_t num_row, float* output,
                         int nthread, int pred_transform, size_t* out_result_size) {
   API_BEGIN();
+  TREELITE_LOG(WARNING)
+    << "TreeliteGTILPredict() is deprecated; please use TreeliteGTILPredictEx() instead.";
   const auto* model_ = static_cast<const Model*>(model);
+  gtil::GTILConfig config;
+  config.pred_transform = (pred_transform == 1);
+  config.nthread = nthread;
   *out_result_size =
-      gtil::Predict(model_, input, num_row, output, nthread, (pred_transform == 1));
+      gtil::Predict(model_, input, num_row, output, config);
+  API_END();
+}
+
+int TreeliteGTILPredictEx(ModelHandle model, const float* input, size_t num_row, float* output,
+                          GTILConfigHandle config, size_t* out_result_size) {
+  API_BEGIN();
+  const auto* model_ = static_cast<const Model*>(model);
+  const auto* config_ = static_cast<const gtil::GTILConfig*>(config);
+  *out_result_size =
+      gtil::Predict(model_, input, num_row, output, *config_);
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -377,8 +377,8 @@ int TreeliteGTILPredictEx(ModelHandle model, const float* input, size_t num_row,
   auto& pred_shape = TreeliteAPIThreadLocalStore::Get()->prediction_shape;
   *out_result_size = gtil::Predict(model_, input, num_row, output, *config_,
                                    pred_shape);
-  auto prod = std::reduce<>(std::begin(pred_shape), std::end(pred_shape),
-                                1, std::multiplies<>{});
+  auto prod = std::accumulate<>(std::begin(pred_shape), std::end(pred_shape), 1,
+                                std::multiplies<>{});
   TREELITE_CHECK_EQ(prod, *out_result_size);
   *out_result_ndim = pred_shape.size();
   *out_result_shape = pred_shape.data();

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -318,14 +318,14 @@ int TreeliteFreeModel(ModelHandle handle) {
 
 int TreeliteGTILParseConfig(const char* config_json, GTILConfigHandle* out) {
   API_BEGIN();
-  auto parsed_config = std::make_unique<gtil::GTILConfig>(config_json);
+  auto parsed_config = std::make_unique<gtil::Configuration>(config_json);
   *out = static_cast<GTILConfigHandle>(parsed_config.release());
   API_END();
 }
 
 int TreeliteGTILDeleteConfig(GTILConfigHandle handle) {
   API_BEGIN();
-  delete static_cast<gtil::GTILConfig*>(handle);
+  delete static_cast<gtil::Configuration*>(handle);
   API_END();
 }
 
@@ -335,7 +335,7 @@ int TreeliteGTILGetPredictOutputSize(ModelHandle model, size_t num_row, size_t* 
     << "TreeliteGTILGetPredictOutputSize() is deprecated; "
     << "please use TreeliteGTILGetPredictOutputSizeEx() instead";
   const auto* model_ = static_cast<const Model*>(model);
-  *out = gtil::GetPredictOutputSize(model_, num_row, gtil::GTILConfig{});
+  *out = gtil::GetPredictOutputSize(model_, num_row, gtil::Configuration{});
   API_END();
 }
 
@@ -343,7 +343,7 @@ int TreeliteGTILGetPredictOutputSizeEx(ModelHandle model, size_t num_row, GTILCo
                                        size_t* out) {
   API_BEGIN();
   const auto* model_ = static_cast<const Model*>(model);
-  const auto* config_ = static_cast<const gtil::GTILConfig*>(config);
+  const auto* config_ = static_cast<const gtil::Configuration*>(config);
   *out = gtil::GetPredictOutputSize(model_, num_row, *config_);
   API_END();
 }
@@ -354,8 +354,9 @@ int TreeliteGTILPredict(ModelHandle model, const float* input, size_t num_row, f
   TREELITE_LOG(WARNING)
     << "TreeliteGTILPredict() is deprecated; please use TreeliteGTILPredictEx() instead.";
   const auto* model_ = static_cast<const Model*>(model);
-  gtil::GTILConfig config;
-  config.pred_transform = (pred_transform == 1);
+  gtil::Configuration config;
+  config.pred_type = (pred_transform == 1 ? treelite::gtil::PredictType::kPredictDefault
+                                          : treelite::gtil::PredictType::kPredictRaw);
   config.nthread = nthread;
   *out_result_size =
       gtil::Predict(model_, input, num_row, output, config);
@@ -366,7 +367,7 @@ int TreeliteGTILPredictEx(ModelHandle model, const float* input, size_t num_row,
                           GTILConfigHandle config, size_t* out_result_size) {
   API_BEGIN();
   const auto* model_ = static_cast<const Model*>(model);
-  const auto* config_ = static_cast<const gtil::GTILConfig*>(config);
+  const auto* config_ = static_cast<const gtil::Configuration*>(config);
   *out_result_size =
       gtil::Predict(model_, input, num_row, output, *config_);
   API_END();

--- a/src/gtil/config.cc
+++ b/src/gtil/config.cc
@@ -31,11 +31,15 @@ Configuration::Configuration(const char* config_json) {
       } else {
         TREELITE_LOG(FATAL) << "Unknown prediction type: " << value;
       }
+    } else {
+      TREELITE_LOG(FATAL) << "The field \"predict_type\" must be specified";
     }
     itr = parsed_config.FindMember("nthread");
     if (itr != parsed_config.MemberEnd() && itr->value.IsInt()) {
       this->nthread = itr->value.GetInt();
     }
+  } else {
+    TREELITE_LOG(FATAL) << "The JSON string must be a valid JSON object";
   }
 }
 

--- a/src/gtil/config.cc
+++ b/src/gtil/config.cc
@@ -5,19 +5,32 @@
  * \brief Configuration handling logic for General Tree Inference Library (GTIL)
  */
 #include <treelite/gtil.h>
+#include <treelite/logging.h>
 #include <rapidjson/document.h>
+#include <string>
 
 namespace treelite {
 namespace gtil {
 
-GTILConfig::GTILConfig(const char* config_json) {
+Configuration::Configuration(const char* config_json) {
   rapidjson::Document parsed_config;
   parsed_config.Parse(config_json);
 
   if (parsed_config.IsObject()) {
-    auto itr = parsed_config.FindMember("pred_transform");
-    if (itr != parsed_config.MemberEnd() && itr->value.IsBool()) {
-      this->pred_transform = itr->value.GetBool();
+    auto itr = parsed_config.FindMember("predict_type");
+    if (itr != parsed_config.MemberEnd() && itr->value.IsString()) {
+      auto value = std::string(itr->value.GetString());
+      if (value == "default") {
+        this->pred_type = PredictType::kPredictDefault;
+      } else if (value == "raw") {
+        this->pred_type = PredictType::kPredictRaw;
+      } else if (value == "leaf_id") {
+        this->pred_type = PredictType::kPredictLeafID;
+      } else if (value == "score_per_tree") {
+        this->pred_type = PredictType::kPredictPerTree;
+      } else {
+        TREELITE_LOG(FATAL) << "Unknown prediction type: " << value;
+      }
     }
     itr = parsed_config.FindMember("nthread");
     if (itr != parsed_config.MemberEnd() && itr->value.IsInt()) {

--- a/src/gtil/config.cc
+++ b/src/gtil/config.cc
@@ -1,0 +1,30 @@
+/*!
+ * Copyright (c) 2023 by Contributors
+ * \file config.cc
+ * \author Hyunsu Cho
+ * \brief Configuration handling logic for General Tree Inference Library (GTIL)
+ */
+#include <treelite/gtil.h>
+#include <rapidjson/document.h>
+
+namespace treelite {
+namespace gtil {
+
+GTILConfig::GTILConfig(const char* config_json) {
+  rapidjson::Document parsed_config;
+  parsed_config.Parse(config_json);
+
+  if (parsed_config.IsObject()) {
+    auto itr = parsed_config.FindMember("pred_transform");
+    if (itr != parsed_config.MemberEnd() && itr->value.IsBool()) {
+      this->pred_transform = itr->value.GetBool();
+    }
+    itr = parsed_config.FindMember("nthread");
+    if (itr != parsed_config.MemberEnd() && itr->value.IsInt()) {
+      this->nthread = itr->value.GetInt();
+    }
+  }
+}
+
+}  // namespace gtil
+}  // namespace treelite

--- a/src/gtil/config.cc
+++ b/src/gtil/config.cc
@@ -35,7 +35,8 @@ Configuration::Configuration(const char* config_json) {
       TREELITE_LOG(FATAL) << "The field \"predict_type\" must be specified";
     }
     itr = parsed_config.FindMember("nthread");
-    if (itr != parsed_config.MemberEnd() && itr->value.IsInt()) {
+    if (itr != parsed_config.MemberEnd()) {
+      TREELITE_CHECK(itr->value.IsInt()) << "nthread must be an integer";
       this->nthread = itr->value.GetInt();
     }
   } else {

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -38,8 +38,6 @@ using treelite::threading_utils::ThreadConfig;
 using PredTransformFuncType = std::size_t (*) (const treelite::Model&, const float*, float*);
 
 constexpr std::size_t kBlockOfRowsSize = 64;
-constexpr std::int32_t largest_representable_int
-  = (static_cast<std::int32_t>(1) << std::numeric_limits<float>::digits);
 
 /*!
  * \brief A dense feature vector.

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -444,6 +444,7 @@ inline std::size_t PredictImpl(const treelite::ModelImpl<ThresholdType, LeafOutp
     return input->GetNumRow() * model.task_param.num_class;
   } else {
     TREELITE_LOG(FATAL) << "Not implemented";
+    return 0;
   }
 }
 
@@ -494,6 +495,9 @@ std::size_t GetPredictOutputSize(const Model* model, std::size_t num_row,
     return num_row * model->GetNumTree();
   case PredictType::kPredictPerTree:
     return num_row * model->GetNumTree() * model->task_param.num_class;
+  default:
+    TREELITE_LOG(FATAL) << "Unrecognized prediction type: " << static_cast<int>(config.pred_type);
+    return 0;
   }
 }
 

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -189,11 +189,38 @@ struct MultiClfProbDistLeafOutputLogic {
   }
 };
 
-struct PredLeafOutputLogic {
+struct PredictLeafOutputLogic {
   template <typename ThresholdType, typename LeafOutputType>
-  inline static void PushOutput(const treelite::Tree<ThresholdType, LeafOutputType>& tree,
+  inline static void PushOutput(const treelite::Tree<ThresholdType, LeafOutputType>&,
                                 std::size_t, int node_id, float* output, std::size_t) {
     *output = static_cast<float>(node_id);
+  }
+};
+
+struct PredictScoreByTreeWithScalarLeafOutputLogic {
+  inline static std::size_t GetOutputOffset(std::size_t row_id, std::size_t tree_id,
+                                            std::size_t num_tree, int) {
+    return row_id * num_tree + tree_id;
+  }
+  template <typename ThresholdType, typename LeafOutputType>
+  inline static void PushOutput(const treelite::Tree<ThresholdType, LeafOutputType>& tree,
+                                std::size_t, int node_id, float* output,
+                                std::size_t) {
+    *output = tree.LeafValue(node_id);
+  }
+};
+
+struct PredictScoreByTreeWithVectorLeafOutputLogic {
+  inline static std::size_t GetOutputOffset(std::size_t row_id, std::size_t tree_id,
+                                            std::size_t num_tree, int num_class) {
+    return (row_id * num_tree + tree_id) * num_class;
+  }
+  template <typename ThresholdType, typename LeafOutputType>
+  inline static void PushOutput(const treelite::Tree<ThresholdType, LeafOutputType>& tree,
+                                std::size_t, int node_id, float* output,
+                                std::size_t) {
+    auto leaf_vector = tree.LeafVector(node_id);
+    std::copy(std::begin(leaf_vector), std::end(leaf_vector), output);
   }
 };
 
@@ -431,13 +458,13 @@ void PredictLeafBatchTreeParallelKernel(
       const treelite::Tree<ThresholdType, LeafOutputType>& tree = model.trees[tree_id];
       auto has_categorical = tree.HasCategoricalSplit();
       if (has_categorical) {
-        PredValueByOneTree<true, PredLeafOutputLogic>(tree, tree_id, feats,
-                                                      &output[row_id * num_tree + tree_id],
-                                                      num_class);
+        PredValueByOneTree<true, PredictLeafOutputLogic>(tree, tree_id, feats,
+                                                         &output[row_id * num_tree + tree_id],
+                                                         num_class);
       } else {
-        PredValueByOneTree<false, PredLeafOutputLogic>(tree, tree_id, feats,
-                                                       &output[row_id * num_tree + tree_id],
-                                                       num_class);
+        PredValueByOneTree<false, PredictLeafOutputLogic>(tree, tree_id, feats,
+                                                          &output[row_id * num_tree + tree_id],
+                                                          num_class);
       }
     });
     feats.Clear(input, row_id);
@@ -472,15 +499,96 @@ void PredictLeafBatchByBlockOfRowsKernel(
       auto has_categorical = tree.HasCategoricalSplit();
       if (has_categorical) {
         for (std::size_t i = 0; i < block_size; ++i) {
-          PredValueByOneTree<true, PredLeafOutputLogic>(
+          PredValueByOneTree<true, PredictLeafOutputLogic>(
               tree, tree_id, feats[fvec_offset + i],
               &output[(batch_offset + i) * num_tree + tree_id], num_class);
         }
       } else {
         for (std::size_t i = 0; i < block_size; ++i) {
-          PredValueByOneTree<false, PredLeafOutputLogic>(
+          PredValueByOneTree<false, PredictLeafOutputLogic>(
               tree, tree_id, feats[fvec_offset + i],
               &output[(batch_offset + i) * num_tree + tree_id], num_class);
+        }
+      }
+    }
+    FVecDrop(block_size, batch_offset, input, fvec_offset, num_feature, feats);
+  });
+}
+
+template <typename OutputLogic, typename ThresholdType, typename LeafOutputType,
+          typename DMatrixType>
+void PredictScoreByTreeBatchTreeParallelKernel(
+    const treelite::ModelImpl<ThresholdType, LeafOutputType>& model, const DMatrixType* input,
+    float* output, const ThreadConfig& thread_config) {
+  const std::size_t num_row = input->GetNumRow();
+  const std::size_t num_tree = model.GetNumTree();
+  const int num_feature = model.num_feature;
+  const auto num_class = model.task_param.num_class;
+
+  FVec feats;
+  feats.Init(num_feature);
+  auto sched = treelite::threading_utils::ParallelSchedule::Static();
+  for (std::size_t row_id = 0; row_id < num_row; ++row_id) {
+    feats.Fill(input, row_id);
+    treelite::threading_utils::ParallelFor(std::size_t(0), num_tree, thread_config, sched,
+                                           [&](std::size_t tree_id, int) {
+      const treelite::Tree<ThresholdType, LeafOutputType>& tree = model.trees[tree_id];
+      auto has_categorical = tree.HasCategoricalSplit();
+      if (has_categorical) {
+        PredValueByOneTree<true, OutputLogic>(
+            tree, tree_id, feats,
+            &output[OutputLogic::GetOutputOffset(row_id, tree_id, num_tree, num_class)],
+            num_class);
+      } else {
+        PredValueByOneTree<false, OutputLogic>(
+            tree, tree_id, feats,
+            &output[OutputLogic::GetOutputOffset(row_id, tree_id, num_tree, num_class)],
+            num_class);
+      }
+    });
+    feats.Clear(input, row_id);
+  }
+}
+
+template <std::size_t block_of_rows_size, typename OutputLogic, typename ThresholdType,
+          typename LeafOutputType, typename DMatrixType>
+void PredictScoreByTreeBatchByBlockOfRowsKernel(
+    const treelite::ModelImpl<ThresholdType, LeafOutputType>& model, const DMatrixType* input,
+    float* output, const ThreadConfig& thread_config) {
+  const std::size_t num_row = input->GetNumRow();
+  const std::size_t num_tree = model.GetNumTree();
+  const auto num_class = model.task_param.num_class;
+  const int num_feature = model.num_feature;
+  const auto& task_param = model.task_param;
+  std::size_t n_blocks = DivRoundUp(num_row, block_of_rows_size);
+
+  std::vector<FVec> feats(thread_config.nthread * block_of_rows_size);
+  auto sched = treelite::threading_utils::ParallelSchedule::Static();
+  treelite::threading_utils::ParallelFor(std::size_t(0), n_blocks, thread_config, sched,
+                                         [&](std::size_t block_id, int thread_id) {
+    const std::size_t batch_offset = block_id * block_of_rows_size;
+    const std::size_t block_size =
+        std::min(num_row - batch_offset, block_of_rows_size);
+    const std::size_t fvec_offset = thread_id * block_of_rows_size;
+
+    FVecFill(block_size, batch_offset, input, fvec_offset, num_feature, feats);
+    // process block of rows through all trees to keep cache locality
+    for (std::size_t tree_id = 0; tree_id < num_tree; ++tree_id) {
+      const treelite::Tree<ThresholdType, LeafOutputType>& tree = model.trees[tree_id];
+      auto has_categorical = tree.HasCategoricalSplit();
+      if (has_categorical) {
+        for (std::size_t i = 0; i < block_size; ++i) {
+          PredValueByOneTree<true, OutputLogic>(
+              tree, tree_id, feats[fvec_offset + i],
+              &output[OutputLogic::GetOutputOffset(batch_offset + i, tree_id, num_tree, num_class)],
+              num_class);
+        }
+      } else {
+        for (std::size_t i = 0; i < block_size; ++i) {
+          PredValueByOneTree<false, OutputLogic>(
+              tree, tree_id, feats[fvec_offset + i],
+              &output[OutputLogic::GetOutputOffset(batch_offset + i, tree_id, num_tree, num_class)],
+              num_class);
         }
       }
     }
@@ -499,6 +607,51 @@ inline void PredictLeaf(const treelite::ModelImpl<ThresholdType, LeafOutputType>
     // Sufficiently large batch size => row parallel method
     PredictLeafBatchByBlockOfRowsKernel<kBlockOfRowsSize>(
         model, input, output, thread_config);
+  }
+}
+
+template <typename OutputLogic, typename ThresholdType, typename LeafOutputType,
+          typename DMatrixType>
+inline void PredictScoreByTreeImpl(const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
+                                   const DMatrixType* input, float* output,
+                                   const ThreadConfig& thread_config) {
+  if (input->GetNumRow() < kBlockOfRowsSize) {
+    // Small batch size => tree parallel method
+    PredictScoreByTreeBatchTreeParallelKernel<OutputLogic>(model, input, output, thread_config);
+  } else {
+    // Sufficiently large batch size => row parallel method
+    PredictScoreByTreeBatchByBlockOfRowsKernel<kBlockOfRowsSize, OutputLogic>(
+        model, input, output, thread_config);
+  }
+}
+
+template <typename ThresholdType, typename LeafOutputType, typename DMatrixType>
+inline std::size_t PredictScoreByTree(
+    const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
+    const DMatrixType* input, float* output, const ThreadConfig& thread_config,
+    std::vector<std::size_t>& output_shape) {
+  const auto num_row = input->GetNumRow();
+  const auto num_tree = model.GetNumTree();
+  const auto num_class = model.task_param.num_class;
+  switch (model.task_type) {
+    case treelite::TaskType::kBinaryClfRegr:
+    case treelite::TaskType::kMultiClfGrovePerClass:
+      PredictScoreByTreeImpl<PredictScoreByTreeWithScalarLeafOutputLogic>(
+          model, input, output, thread_config);
+      TREELITE_CHECK_EQ(num_tree % num_class, 0);
+      output_shape = {num_row, num_tree};
+      return num_row * num_tree;
+    case treelite::TaskType::kMultiClfProbDistLeaf:
+      PredictScoreByTreeImpl<PredictScoreByTreeWithVectorLeafOutputLogic>(
+          model, input, output, thread_config);
+      output_shape = {num_row, num_tree, num_class};
+      return num_row * num_tree * num_class;
+    case treelite::TaskType::kMultiClfCategLeaf:
+    default:
+      TREELITE_LOG(FATAL)
+          << "Unsupported task type of the tree ensemble model: "
+          << static_cast<int>(model.task_type);
+      return 0;
   }
 }
 
@@ -550,6 +703,8 @@ inline std::size_t PredictImpl(const treelite::ModelImpl<ThresholdType, LeafOutp
     PredictLeaf(model, input, output, thread_config);
     output_shape = {input->GetNumRow(), model.GetNumTree()};
     return input->GetNumRow() * model.GetNumTree();
+  } else if (pred_config.pred_type == PredictType::kPredictPerTree) {
+    return PredictScoreByTree(model, input, output, thread_config, output_shape);
   } else {
     TREELITE_LOG(FATAL) << "Not implemented";
     return 0;
@@ -602,7 +757,11 @@ std::size_t GetPredictOutputSize(const Model* model, std::size_t num_row,
   case PredictType::kPredictLeafID:
     return num_row * model->GetNumTree();
   case PredictType::kPredictPerTree:
-    return num_row * model->GetNumTree() * model->task_param.num_class;
+    if (model->task_type == TaskType::kMultiClfProbDistLeaf) {
+      return num_row * model->GetNumTree() * model->task_param.num_class;
+    } else {
+      return num_row * model->GetNumTree();
+    }
   default:
     TREELITE_LOG(FATAL) << "Unrecognized prediction type: " << static_cast<int>(config.pred_type);
     return 0;

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -406,11 +406,11 @@ template <typename ThresholdType, typename LeafOutputType, typename DMatrixType>
 inline std::size_t PredTransform(const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
                                  const DMatrixType* input, float* output,
                                  const ThreadConfig& thread_config,
-                                 const treelite::gtil::GTILConfig& pred_config) {
+                                 const treelite::gtil::Configuration& pred_config) {
   std::size_t output_size_per_row;
   const auto num_class = model.task_param.num_class;
   std::size_t num_row = input->GetNumRow();
-  if (pred_config.pred_transform) {
+  if (pred_config.pred_type == treelite::gtil::PredictType::kPredictDefault) {
     std::vector<float> temp(treelite::gtil::GetPredictOutputSize(&model, num_row, pred_config));
     PredTransformFuncType pred_transform_func
         = treelite::gtil::LookupPredTransform(model.param.pred_transform);
@@ -436,7 +436,7 @@ template <typename ThresholdType, typename LeafOutputType, typename DMatrixType>
 inline std::size_t PredictImpl(const treelite::ModelImpl<ThresholdType, LeafOutputType>& model,
                                const DMatrixType* input, float* output,
                                const ThreadConfig& thread_config,
-                               const treelite::gtil::GTILConfig& pred_config) {
+                               const treelite::gtil::Configuration& pred_config) {
   PredictRaw(model, input, output, thread_config);
   return PredTransform(model, input, output, thread_config, pred_config);
 }
@@ -447,7 +447,7 @@ namespace treelite {
 namespace gtil {
 
 std::size_t Predict(const Model* model, const DMatrix* input, float* output,
-                    const GTILConfig& config) {
+                    const Configuration& config) {
   // If nthread <= 0, then use all CPU cores in the system
   auto thread_config = threading_utils::ConfigureThreadConfig(config.nthread);
   // Check type of DMatrix
@@ -468,7 +468,7 @@ std::size_t Predict(const Model* model, const DMatrix* input, float* output,
 }
 
 std::size_t Predict(const Model* model, const float* input, std::size_t num_row, float* output,
-                    const GTILConfig& pred_config) {
+                    const Configuration& pred_config) {
   std::unique_ptr<DenseDMatrixImpl<float>> dmat =
       std::make_unique<DenseDMatrixImpl<float>>(
           std::vector<float>(input, input + num_row * model->num_feature),
@@ -479,12 +479,12 @@ std::size_t Predict(const Model* model, const float* input, std::size_t num_row,
 }
 
 std::size_t GetPredictOutputSize(const Model* model, std::size_t num_row,
-                                 const GTILConfig& config) {
+                                 const Configuration& config) {
   return model->task_param.num_class * num_row;
 }
 
 std::size_t GetPredictOutputSize(const Model* model, const DMatrix* input,
-                                 const GTILConfig& config) {
+                                 const Configuration& config) {
   return GetPredictOutputSize(model, input->GetNumRow(), config);
 }
 

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -480,7 +480,15 @@ std::size_t Predict(const Model* model, const float* input, std::size_t num_row,
 
 std::size_t GetPredictOutputSize(const Model* model, std::size_t num_row,
                                  const Configuration& config) {
-  return model->task_param.num_class * num_row;
+  switch (config.pred_type) {
+  case PredictType::kPredictDefault:
+  case PredictType::kPredictRaw:
+    return num_row * model->task_param.num_class;
+  case PredictType::kPredictLeafID:
+    return num_row * model->GetNumTree();
+  case PredictType::kPredictPerTree:
+    return num_row * model->GetNumTree() * model->task_param.num_class;
+  }
 }
 
 std::size_t GetPredictOutputSize(const Model* model, const DMatrix* input,

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -39,7 +39,7 @@ using PredTransformFuncType = std::size_t (*) (const treelite::Model&, const flo
 
 constexpr std::size_t kBlockOfRowsSize = 64;
 constexpr std::int32_t largest_representable_int
- = (static_cast<std::int32_t>(1) << std::numeric_limits<float>::digits);
+  = (static_cast<std::int32_t>(1) << std::numeric_limits<float>::digits);
 
 /*!
  * \brief A dense feature vector.

--- a/tests/python/hypothesis_util.py
+++ b/tests/python/hypothesis_util.py
@@ -47,6 +47,7 @@ def standard_classification_datasets(
     shuffle=just(True),
     random_state=None,
 ):
+    # pylint: disable=too-many-locals
     """
     Returns a strategy to generate classification problem input datasets.
     Note:

--- a/tests/python/hypothesis_util.py
+++ b/tests/python/hypothesis_util.py
@@ -4,8 +4,181 @@
 from sys import platform as _platform
 
 import numpy as np
+from hypothesis import assume
 from hypothesis.strategies import composite, integers, just, none
-from sklearn.datasets import make_regression
+from sklearn.datasets import make_classification, make_regression
+
+
+def _get_limits(strategy):
+    """Try to find the strategy's limits.
+    Raises AttributeError if limits cannot be determined.
+
+    Credit: Carl Simon Adorf (@csadorf)
+    https://github.com/rapidsai/cuml/blob/447bded/python/cuml/testing/strategies.py
+    """
+    # unwrap if lazy
+    strategy = getattr(strategy, "wrapped_strategy", strategy)
+
+    try:
+        yield getattr(strategy, "value")  # just(...)
+    except AttributeError:
+        # assume numbers strategy
+        yield strategy.start
+        yield strategy.stop
+
+
+@composite
+def standard_classification_datasets(
+    draw,
+    n_samples=integers(min_value=100, max_value=200),
+    n_features=integers(min_value=10, max_value=20),
+    *,
+    n_informative=None,
+    n_redundant=None,
+    n_repeated=just(0),
+    n_classes=just(2),
+    n_clusters_per_class=just(2),
+    weights=none(),
+    flip_y=just(0.01),
+    class_sep=just(1.0),
+    hypercube=just(True),
+    shift=just(0.0),
+    scale=just(1.0),
+    shuffle=just(True),
+    random_state=None,
+):
+    """
+    Returns a strategy to generate classification problem input datasets.
+    Note:
+    This function uses the sklearn.datasets.make_classification function to
+    generate the classification problem from the provided search strategies.
+
+    Credit: Carl Simon Adorf (@csadorf)
+    https://github.com/rapidsai/cuml/blob/447bded/python/cuml/testing/strategies.py
+
+    Parameters
+    ----------
+    draw:
+        Callback function, to be used internally by Hypothesis
+    n_samples: SearchStrategy[int]
+        Returned arrays will have number of rows drawn from these values.
+    n_features: SearchStrategy[int]
+        Returned arrays will have number of columns drawn from these values.
+    n_informative: SearchStrategy[int], default=none
+        A search strategy for the number of informative features. If none,
+        will use 10% of the actual number of features, but not less than 1
+        unless the number of features is zero.
+    n_redundant: SearchStrategy[int], default=none
+        A search strategy for the number of redundant features. Redundant features
+        will be generated as linear combinations of informative features. If none,
+        will use 10% of the actual number of features, but not less than 1
+        unless the number of features is zero.
+    n_repeated: SearchStrategy[int], default=just(0)
+        A search strategy for the number of duplicated features.
+    n_classes: SearchStrategy[int], default=just(2)
+        A search strategy for the number of classes in the classification problem.
+    n_clusters_per_class: SearchStrategy[int], default=just(2)
+        A search strategy for the number of clusters per class
+    weights: SearchStrategy[array], default=none
+        A search strategy for the proportions of samples assigned to each class. If
+        none, always generate classification problems with balanced classes.
+    flip_y: SearchStrategy[float], default=just(0.01)
+        A search strategy for the fraction of samples whose class is assigned randomly.
+        Larger value for this value introduces noise in the labels and make the
+        classification problem harder.
+    class_sep: SearchStrategy[float], default=just(1.0)
+        A search strategy for the parameter class_sep.
+        See sklearn.dataset.make_classification() for a detailed explanation of this
+        parameter.
+    hypercube: SearchStrategy[bool], default=just(True)
+        A search strategy for the parameter hypercube.
+        See sklearn.dataset.make_classification() for a detailed explanation of this
+        parameter.
+    shift: SearchStrategy[float], default=just(0.0)
+        A search strategy for the parameter shift.
+        See sklearn.dataset.make_classification() for a detailed explanation of this
+        parameter.
+    scale: SearchStrategy[float], default=just(1.0)
+        A search strategy for the parameter scale.
+        See sklearn.dataset.make_classification() for a detailed explanation of this
+        parameter.
+    shuffle: SearchStrategy[bool], default=just(True)
+        A boolean search strategy to determine whether samples and features
+        are shuffled.
+    random_state: int, RandomState instance or None, default=None
+        Pass a random state or integer to determine the random number
+        generation for data set generation.
+    Returns
+    -------
+    (X, y):  SearchStrategy[array], SearchStrategy[array]
+        A tuple of search strategies for arrays subject to the constraints of
+        the provided parameters.
+    """
+    n_features_ = draw(n_features)
+    if n_informative is None:
+        try:
+            # Try to meet:
+            #   log_2(n_classes * n_clusters_per_class) <= n_informative
+            n_classes_min = min(_get_limits(n_classes))
+            n_clusters_per_class_min = min(_get_limits(n_clusters_per_class))
+            n_informative_min = int(
+                np.ceil(np.log2(n_classes_min * n_clusters_per_class_min))
+            )
+        except AttributeError:
+            # Otherwise aim for 10% of n_features, but at least 1.
+            n_informative_min = max(1, int(0.1 * n_features_))
+
+        n_informative = just(min(n_features_, n_informative_min))
+    if n_redundant is None:
+        n_redundant = just(max(min(n_features_, 1), int(0.1 * n_features_)))
+
+    # Check whether the
+    #   log_2(n_classes * n_clusters_per_class) <= n_informative
+    # inequality can in principle be met.
+    try:
+        n_classes_min = min(_get_limits(n_classes))
+        n_clusters_per_class_min = min(_get_limits(n_clusters_per_class))
+        n_informative_max = max(_get_limits(n_informative))
+    except AttributeError:
+        pass  # unable to determine limits
+    else:
+        if np.log2(n_classes_min * n_clusters_per_class_min) > n_informative_max:
+            raise ValueError(
+                "Assumptions cannot be met, the following inequality must "
+                "hold: log_2(n_classes * n_clusters_per_class) "
+                "<= n_informative ."
+            )
+
+    # Check base assumption concerning the composition of feature vectors.
+    n_informative_ = draw(n_informative)
+    n_redundant_ = draw(n_redundant)
+    n_repeated_ = draw(n_repeated)
+    assume(n_informative_ + n_redundant_ + n_repeated_ <= n_features_)
+
+    # Check base assumption concerning relationship of number of clusters and
+    # informative features.
+    n_classes_ = draw(n_classes)
+    n_clusters_per_class_ = draw(n_clusters_per_class)
+    assume(np.log2(n_classes_ * n_clusters_per_class_) <= n_informative_)
+
+    X, y = make_classification(
+        n_samples=draw(n_samples),
+        n_features=n_features_,
+        n_informative=n_informative_,
+        n_redundant=n_redundant_,
+        n_repeated=n_repeated_,
+        n_classes=n_classes_,
+        n_clusters_per_class=n_clusters_per_class_,
+        weights=draw(weights),
+        flip_y=draw(flip_y),
+        class_sep=draw(class_sep),
+        hypercube=draw(hypercube),
+        shift=draw(shift),
+        scale=draw(scale),
+        shuffle=draw(shuffle),
+        random_state=random_state,
+    )
+    return X.astype(np.float32), y.astype(np.int32)
 
 
 @composite
@@ -34,6 +207,8 @@ def standard_regression_datasets(
 
     Parameters
     ----------
+    draw:
+        Callback function, to be used internally by Hypothesis
     n_samples: SearchStrategy[int]
         Returned arrays will have number of rows drawn from these values.
     n_features: SearchStrategy[int]
@@ -47,7 +222,7 @@ def standard_regression_datasets(
         columns of the returned y output array.
     bias: SearchStrategy[float], default=just(0.0)
         A search strategy for the bias term.
-    effective_rank=none()
+    effective_rank:
         If not None, a search strategy for the effective rank of the input data
         for the regression problem. See sklearn.dataset.make_regression() for a
         detailed explanation of this parameter.

--- a/tests/python/test_gtil.py
+++ b/tests/python/test_gtil.py
@@ -515,5 +515,5 @@ def test_lightgbm_sparse_categorical_model():
     # GTIL doesn't yet support sparse matrix; so use NaN to represent missing values
     Xa = X.toarray()
     Xa[Xa == 0] = "nan"
-    out_pred = treelite.gtil.predict(tl_model, Xa, pred_margin=True)
+    out_pred = treelite.gtil.predict(tl_model, Xa, predict_type="raw")
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)

--- a/tests/python/test_gtil.py
+++ b/tests/python/test_gtil.py
@@ -517,3 +517,30 @@ def test_lightgbm_sparse_categorical_model():
     Xa[Xa == 0] = "nan"
     out_pred = treelite.gtil.predict(tl_model, Xa, predict_type="raw")
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
+
+
+@pytest.mark.xfail
+def test_predict_leaf():
+    # pylint: disable=too-many-locals
+    """Test XGBoost with Iris data (multi-class classification)"""
+    X, y = load_iris(return_X_y=True)
+    dtrain = xgb.DMatrix(X, label=y)
+    num_class = 3
+    param = {
+        "max_depth": 6,
+        "eta": 0.05,
+        "num_class": num_class,
+        "verbosity": 0,
+        "objective": "multi:softprob",
+        "metric": "mlogloss",
+    }
+    num_round = 3
+    xgb_model = xgb.train(
+        param,
+        dtrain,
+        num_boost_round=num_round,
+        evals=[(dtrain, "train")],
+    )
+    model = treelite.Model.from_xgboost(xgb_model)
+    leaf_pred = treelite.gtil.predict(model, X, predict_type="leaf_id")
+    print(leaf_pred)

--- a/tests/python/test_gtil.py
+++ b/tests/python/test_gtil.py
@@ -520,89 +520,17 @@ def test_lightgbm_sparse_categorical_model():
 
 
 @given(
-    sample_size=integers(min_value=1, max_value=150),
-)
-@settings(**standard_settings())
-def test_predict_leaf_grove_per_class(sample_size):
-    # pylint: disable=too-many-locals
-    """Test predict_leaf with XGBoost multiclass classifier (grove-per-class)"""
-    X, y = load_iris(return_X_y=True)
-    dtrain = xgb.DMatrix(X, label=y)
-    num_class = 3
-    param = {
-        "max_depth": 6,
-        "eta": 0.05,
-        "num_class": num_class,
-        "verbosity": 0,
-        "objective": "multi:softprob",
-        "metric": "mlogloss",
-    }
-    num_round = 10
-    xgb_model = xgb.train(
-        param,
-        dtrain,
-        num_boost_round=num_round,
-        evals=[(dtrain, "train")],
-    )
-    model: treelite.Model = treelite.Model.from_xgboost(xgb_model)
-    assert model.num_tree == 30
-    X_sample = X[0:sample_size]
-    leaf_pred = treelite.gtil.predict(model, X_sample, predict_type="leaf_id")
-    xgb_leaf_pred = xgb_model.predict(xgb.DMatrix(X_sample), pred_leaf=True)
-    assert np.array_equal(leaf_pred, xgb_leaf_pred)
-
-
-@given(
-    sample_size=integers(min_value=1, max_value=150),
-)
-@settings(**standard_settings())
-def test_predict_bytree_multi_classifier_grove_per_class(sample_size):
-    # pylint: disable=too-many-locals
-    """Test predict_bytree with XGBoost multiclass classifier (grove-per-class)"""
-    X, y = load_iris(return_X_y=True)
-    dtrain = xgb.DMatrix(X, label=y)
-    num_class = 3
-    param = {
-        "max_depth": 10,
-        "eta": 0.05,
-        "num_class": num_class,
-        "verbosity": 0,
-        "objective": "multi:softprob",
-        "metric": "mlogloss",
-        "base_score": 0,
-    }
-    num_round = 10
-    xgb_model = xgb.train(
-        param,
-        dtrain,
-        num_boost_round=num_round,
-    )
-    model: treelite.Model = treelite.Model.from_xgboost(xgb_model)
-    assert model.num_tree == num_class * num_round
-
-    X_sample = X[0:sample_size]
-    pred_bytree = treelite.gtil.predict(model, X_sample, predict_type="score_per_tree")
-    assert pred_bytree.shape == (sample_size, model.num_tree)
-    sum_by_class = np.column_stack(
-        tuple(
-            np.sum(pred_bytree[:, class_id::num_class], axis=1)
-            for class_id in range(num_class)
-        )
-    )
-    pred = xgb_model.predict(xgb.DMatrix(X_sample), output_margin=True)
-    np.testing.assert_almost_equal(sum_by_class, pred, decimal=4)
-
-
-@given(
     dataset=standard_regression_datasets(),
+    predict_type=sampled_from(["leaf_id", "score_per_tree"]),
     sample_size=integers(min_value=1, max_value=150),
 )
 @settings(**standard_settings())
-def test_predict_bytree_regressor(dataset, sample_size):
+def test_predict_special_with_regressor(dataset, predict_type, sample_size):
     # pylint: disable=too-many-locals
-    """Test predict_bytree with XGBoost regressor"""
+    """Test predict_leaf / predict_bytree with XGBoost regressor"""
     X, y = dataset
     dtrain = xgb.DMatrix(X, label=y)
+    assume(sample_size < X.shape[0])
     param = {
         "max_depth": 8,
         "eta": 1,
@@ -610,7 +538,7 @@ def test_predict_bytree_regressor(dataset, sample_size):
         "objective": "reg:squarederror",
         "base_score": 0,
     }
-    num_round = 4
+    num_round = 10
     xgb_model = xgb.train(
         param,
         dtrain,
@@ -620,20 +548,29 @@ def test_predict_bytree_regressor(dataset, sample_size):
     assert model.num_tree == num_round
 
     X_sample = X[0:sample_size]
-    pred_bytree = treelite.gtil.predict(model, X_sample, predict_type="score_per_tree")
-    assert pred_bytree.shape == (sample_size, num_round)
-    pred = xgb_model.predict(xgb.DMatrix(X_sample), output_margin=True)
-    np.testing.assert_almost_equal(np.sum(pred_bytree, axis=1), pred, decimal=3)
+    if predict_type == "leaf_id":
+        leaf_pred = treelite.gtil.predict(model, X_sample, predict_type="leaf_id")
+        assert leaf_pred.shape == (sample_size, num_round)
+        xgb_leaf_pred = xgb_model.predict(xgb.DMatrix(X_sample), pred_leaf=True)
+        assert np.array_equal(leaf_pred, xgb_leaf_pred)
+    else:
+        pred_bytree = treelite.gtil.predict(
+            model, X_sample, predict_type="score_per_tree"
+        )
+        assert pred_bytree.shape == (sample_size, num_round)
+        pred = xgb_model.predict(xgb.DMatrix(X_sample), output_margin=True)
+        np.testing.assert_almost_equal(np.sum(pred_bytree, axis=1), pred, decimal=3)
 
 
 @given(
+    predict_type=sampled_from(["leaf_id", "score_per_tree"]),
     random_seed=integers(min_value=0, max_value=50),
     sample_size=integers(min_value=1, max_value=200),
 )
 @settings(**standard_settings())
-def test_predict_bytree_binary_classifier(random_seed, sample_size):
+def test_predict_special_with_binary_classifier(predict_type, random_seed, sample_size):
     # pylint: disable=too-many-locals
-    """Test predict_bytree with XGBoost binary classifier"""
+    """Test predict_leaf / predict_bytree with XGBoost binary classifier"""
     nrow = 200
     ncol = 8
     rng = np.random.default_rng(seed=random_seed)
@@ -659,10 +596,70 @@ def test_predict_bytree_binary_classifier(random_seed, sample_size):
     assert model.num_tree == num_round
 
     X_sample = X[0:sample_size]
-    pred_bytree = treelite.gtil.predict(model, X_sample, predict_type="score_per_tree")
-    assert pred_bytree.shape == (sample_size, num_round)
-    pred = xgb_model.predict(xgb.DMatrix(X_sample), output_margin=True)
-    np.testing.assert_almost_equal(np.sum(pred_bytree, axis=1), pred, decimal=3)
+    if predict_type == "leaf_id":
+        leaf_pred = treelite.gtil.predict(model, X_sample, predict_type="leaf_id")
+        assert leaf_pred.shape == (sample_size, num_round)
+        xgb_leaf_pred = xgb_model.predict(xgb.DMatrix(X_sample), pred_leaf=True)
+        assert np.array_equal(leaf_pred, xgb_leaf_pred)
+    else:
+        pred_bytree = treelite.gtil.predict(
+            model, X_sample, predict_type="score_per_tree"
+        )
+        assert pred_bytree.shape == (sample_size, num_round)
+        pred = xgb_model.predict(xgb.DMatrix(X_sample), output_margin=True)
+        np.testing.assert_almost_equal(np.sum(pred_bytree, axis=1), pred, decimal=3)
+
+
+@given(
+    predict_type=sampled_from(["leaf_id", "score_per_tree"]),
+    sample_size=integers(min_value=1, max_value=150),
+)
+@settings(**standard_settings())
+def test_predict_special_with_multi_classifier_grove_per_class(
+    predict_type, sample_size
+):
+    # pylint: disable=too-many-locals
+    """Test predict_leaf / predict_bytree with XGBoost multiclass classifier (grove-per-class)"""
+    X, y = load_iris(return_X_y=True)
+    dtrain = xgb.DMatrix(X, label=y)
+    num_class = 3
+    param = {
+        "max_depth": 10,
+        "eta": 0.05,
+        "num_class": num_class,
+        "verbosity": 0,
+        "objective": "multi:softprob",
+        "metric": "mlogloss",
+        "base_score": 0,
+    }
+    num_round = 10
+    xgb_model = xgb.train(
+        param,
+        dtrain,
+        num_boost_round=num_round,
+    )
+    model: treelite.Model = treelite.Model.from_xgboost(xgb_model)
+    assert model.num_tree == num_round * num_class
+
+    X_sample = X[0:sample_size]
+    if predict_type == "leaf_id":
+        leaf_pred = treelite.gtil.predict(model, X_sample, predict_type="leaf_id")
+        assert leaf_pred.shape == (sample_size, model.num_tree)
+        xgb_leaf_pred = xgb_model.predict(xgb.DMatrix(X_sample), pred_leaf=True)
+        assert np.array_equal(leaf_pred, xgb_leaf_pred)
+    else:
+        pred_bytree = treelite.gtil.predict(
+            model, X_sample, predict_type="score_per_tree"
+        )
+        assert pred_bytree.shape == (sample_size, model.num_tree)
+        sum_by_class = np.column_stack(
+            tuple(
+                np.sum(pred_bytree[:, class_id::num_class], axis=1)
+                for class_id in range(num_class)
+            )
+        )
+        pred = xgb_model.predict(xgb.DMatrix(X_sample), output_margin=True)
+        np.testing.assert_almost_equal(sum_by_class, pred, decimal=3)
 
 
 @given(
@@ -670,7 +667,9 @@ def test_predict_bytree_binary_classifier(random_seed, sample_size):
     sample_size=integers(min_value=1, max_value=150),
 )
 @settings(**standard_settings())
-def test_predict_bytree_multiclass_classifier_vector_leaf(n_estimators, sample_size):
+def test_predict_bytree_with_multiclass_classifier_vector_leaf(
+    n_estimators, sample_size
+):
     """Test predict_bytree with Scikit-learn multi-class classifier (vector leaf)"""
     num_class = 3
     X, y = load_iris(return_X_y=True)
@@ -684,4 +683,4 @@ def test_predict_bytree_multiclass_classifier_vector_leaf(n_estimators, sample_s
     assert pred_bytree.shape == (sample_size, n_estimators, num_class)
     avg_by_class = np.sum(pred_bytree, axis=1) / n_estimators
     expected_prob = clf.predict_proba(X_sample)
-    np.testing.assert_almost_equal(avg_by_class, expected_prob, decimal=5)
+    np.testing.assert_almost_equal(avg_by_class, expected_prob, decimal=3)

--- a/tests/python/test_gtil.py
+++ b/tests/python/test_gtil.py
@@ -154,14 +154,14 @@ def test_xgb_regression(objective, model_format, num_parallel_tree, dataset):
     )
     with TemporaryDirectory() as tmpdir:
         if model_format == "json":
-            model_name = "boston.json"
+            model_name = "model.json"
             model_path = os.path.join(tmpdir, model_name)
             xgb_model.save_model(model_path)
             tl_model = treelite.Model.load(
                 filename=model_path, model_format="xgboost_json"
             )
         else:
-            model_name = "boston.model"
+            model_name = "model.model"
             model_path = os.path.join(tmpdir, model_name)
             xgb_model.save_model(model_path)
             tl_model = treelite.Model.load(filename=model_path, model_format="xgboost")


### PR DESCRIPTION
* Implement `predict_leaf`. Closes #424
* Implement `predict_per_tree`. Closes #435

Usage:
```python
leaf_pred = treelite.gtil.predict_leaf(model, X_sample)
pred_bytree = treelite.gtil.predict_per_tree(model, X_sample)
```