### PR TITLE
Improve pytest coverage for GTIL

### DIFF
--- a/tests/python/test_gtil.py
+++ b/tests/python/test_gtil.py
@@ -11,7 +11,7 @@ import scipy
 from hypothesis import assume, given, settings
 from hypothesis.strategies import data as hypothesis_callback
 from hypothesis.strategies import integers, just, sampled_from
-from sklearn.datasets import load_breast_cancer, load_iris, load_svmlight_file
+from sklearn.datasets import load_svmlight_file
 from sklearn.ensemble import (
     ExtraTreesClassifier,
     ExtraTreesRegressor,
@@ -51,12 +51,13 @@ except ImportError:
         [RandomForestRegressor, ExtraTreesRegressor, GradientBoostingRegressor]
     ),
     dataset=standard_regression_datasets(),
+    n_estimators=integers(min_value=5, max_value=50),
 )
 @settings(**standard_settings())
-def test_skl_regressor(clazz, dataset):
+def test_skl_regressor(clazz, dataset, n_estimators):
     """Scikit-learn regressor"""
     X, y = dataset
-    kwargs = {"max_depth": 3, "random_state": 0, "n_estimators": 10}
+    kwargs = {"max_depth": 3, "random_state": 0, "n_estimators": n_estimators}
     if clazz == GradientBoostingRegressor:
         kwargs["init"] = "zero"
     clf = clazz(**kwargs)
@@ -65,16 +66,21 @@ def test_skl_regressor(clazz, dataset):
 
     tl_model = treelite.sklearn.import_model(clf)
     out_pred = treelite.gtil.predict(tl_model, X)
-    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=4)
+    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=3)
 
 
-@pytest.mark.parametrize(
-    "clazz", [RandomForestClassifier, ExtraTreesClassifier, GradientBoostingClassifier]
+@given(
+    clazz=sampled_from(
+        [RandomForestClassifier, ExtraTreesClassifier, GradientBoostingClassifier]
+    ),
+    dataset=standard_classification_datasets(n_classes=just(2)),
+    n_estimators=integers(min_value=5, max_value=50),
 )
-def test_skl_binary_classifier(clazz):
+@settings(**standard_settings())
+def test_skl_binary_classifier(clazz, dataset, n_estimators):
     """Scikit-learn binary classifier"""
-    X, y = load_breast_cancer(return_X_y=True)
-    kwargs = {"max_depth": 3, "random_state": 0, "n_estimators": 10}
+    X, y = dataset
+    kwargs = {"max_depth": 3, "random_state": 0, "n_estimators": n_estimators}
     if clazz == GradientBoostingClassifier:
         kwargs["init"] = "zero"
     clf = clazz(**kwargs)
@@ -86,13 +92,20 @@ def test_skl_binary_classifier(clazz):
     np.testing.assert_almost_equal(out_prob, expected_prob, decimal=5)
 
 
-@pytest.mark.parametrize(
-    "clazz", [RandomForestClassifier, ExtraTreesClassifier, GradientBoostingClassifier]
+@given(
+    clazz=sampled_from(
+        [RandomForestClassifier, ExtraTreesClassifier, GradientBoostingClassifier]
+    ),
+    dataset=standard_classification_datasets(
+        n_classes=integers(min_value=3, max_value=10), n_informative=just(5)
+    ),
+    n_estimators=integers(min_value=5, max_value=50),
 )
-def test_skl_multiclass_classifier(clazz):
+@settings(**standard_settings())
+def test_skl_multiclass_classifier(clazz, dataset, n_estimators):
     """Scikit-learn multi-class classifier"""
-    X, y = load_iris(return_X_y=True)
-    kwargs = {"max_depth": 3, "random_state": 0, "n_estimators": 10}
+    X, y = dataset
+    kwargs = {"max_depth": 3, "random_state": 0, "n_estimators": n_estimators}
     if clazz == GradientBoostingClassifier:
         kwargs["init"] = "zero"
     clf = clazz(**kwargs)
@@ -119,6 +132,7 @@ def test_skl_converter_iforest(dataset):
 
 
 @given(
+    dataset=standard_regression_datasets(),
     objective=sampled_from(
         [
             "reg:linear",
@@ -128,11 +142,13 @@ def test_skl_converter_iforest(dataset):
         ]
     ),
     model_format=sampled_from(["binary", "json"]),
-    num_parallel_tree=integers(min_value=1, max_value=10),
-    dataset=standard_regression_datasets(),
+    num_boost_round=integers(min_value=5, max_value=50),
+    num_parallel_tree=integers(min_value=1, max_value=5),
 )
 @settings(**standard_settings())
-def test_xgb_regression(objective, model_format, num_parallel_tree, dataset):
+def test_xgb_regression(
+    dataset, objective, model_format, num_boost_round, num_parallel_tree
+):
     # pylint: disable=too-many-locals
     """Test XGBoost with regression data"""
     X, y = dataset
@@ -150,11 +166,10 @@ def test_xgb_regression(objective, model_format, num_parallel_tree, dataset):
         "objective": objective,
         "num_parallel_tree": num_parallel_tree,
     }
-    num_round = 10
     xgb_model = xgb.train(
         param,
         dtrain,
-        num_boost_round=num_round,
+        num_boost_round=num_boost_round,
         evals=[(dtrain, "train"), (dtest, "test")],
     )
     with TemporaryDirectory() as tmpdir:
@@ -172,7 +187,7 @@ def test_xgb_regression(objective, model_format, num_parallel_tree, dataset):
             tl_model = treelite.Model.load(filename=model_path, model_format="xgboost")
         assert (
             len(json.loads(tl_model.dump_as_json())["trees"])
-            == num_round * num_parallel_tree
+            == num_boost_round * num_parallel_tree
         )
 
         out_pred = treelite.gtil.predict(tl_model, X_test)
@@ -180,19 +195,28 @@ def test_xgb_regression(objective, model_format, num_parallel_tree, dataset):
         np.testing.assert_almost_equal(out_pred, expected_pred, decimal=3)
 
 
-@pytest.mark.parametrize("num_parallel_tree", [1, 3, 5])
-@pytest.mark.parametrize("model_format", ["binary", "json"])
-@pytest.mark.parametrize("objective", ["multi:softmax", "multi:softprob"])
-def test_xgb_iris(tmpdir, objective, model_format, num_parallel_tree):
+@given(
+    dataset=standard_classification_datasets(
+        n_classes=integers(min_value=3, max_value=10), n_informative=just(5)
+    ),
+    objective=sampled_from(["multi:softmax", "multi:softprob"]),
+    model_format=sampled_from(["binary", "json"]),
+    num_boost_round=integers(min_value=5, max_value=50),
+    num_parallel_tree=integers(min_value=1, max_value=5),
+)
+@settings(**standard_settings())
+def test_xgb_multiclass_classifier(
+    dataset, objective, model_format, num_boost_round, num_parallel_tree
+):
     # pylint: disable=too-many-locals
     """Test XGBoost with Iris data (multi-class classification)"""
-    X, y = load_iris(return_X_y=True)
+    X, y = dataset
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.2, shuffle=False
     )
     dtrain = xgb.DMatrix(X_train, label=y_train)
     dtest = xgb.DMatrix(X_test, label=y_test)
-    num_class = 3
+    num_class = np.max(y) + 1
     param = {
         "max_depth": 6,
         "eta": 0.05,
@@ -202,73 +226,72 @@ def test_xgb_iris(tmpdir, objective, model_format, num_parallel_tree):
         "metric": "mlogloss",
         "num_parallel_tree": num_parallel_tree,
     }
-    num_round = 3
     xgb_model = xgb.train(
         param,
         dtrain,
-        num_boost_round=num_round,
+        num_boost_round=num_boost_round,
         evals=[(dtrain, "train"), (dtest, "test")],
     )
 
-    if model_format == "json":
-        model_name = "iris.json"
-        model_path = os.path.join(tmpdir, model_name)
-        xgb_model.save_model(model_path)
-        tl_model = treelite.Model.load(filename=model_path, model_format="xgboost_json")
-    else:
-        model_name = "iris.model"
-        model_path = os.path.join(tmpdir, model_name)
-        xgb_model.save_model(model_path)
-        tl_model = treelite.Model.load(filename=model_path, model_format="xgboost")
-    expected_num_tree = num_class * num_round * num_parallel_tree
-    assert len(json.loads(tl_model.dump_as_json())["trees"]) == expected_num_tree
+    with TemporaryDirectory() as tmpdir:
+        if model_format == "json":
+            model_name = "iris.json"
+            model_path = os.path.join(tmpdir, model_name)
+            xgb_model.save_model(model_path)
+            tl_model = treelite.Model.load(
+                filename=model_path, model_format="xgboost_json"
+            )
+        else:
+            model_name = "iris.model"
+            model_path = os.path.join(tmpdir, model_name)
+            xgb_model.save_model(model_path)
+            tl_model = treelite.Model.load(filename=model_path, model_format="xgboost")
+        expected_num_tree = num_class * num_boost_round * num_parallel_tree
+        assert len(json.loads(tl_model.dump_as_json())["trees"]) == expected_num_tree
 
-    out_pred = treelite.gtil.predict(tl_model, X_test)
-    expected_pred = xgb_model.predict(dtest)
-    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
+        out_pred = treelite.gtil.predict(tl_model, X_test)
+        expected_pred = xgb_model.predict(dtest)
+        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
-@pytest.mark.parametrize("model_format", ["binary", "json"])
-@pytest.mark.parametrize(
-    "objective,max_label",
-    [
-        ("binary:logistic", 2),
-        ("binary:hinge", 2),
-        ("binary:logitraw", 2),
-        ("count:poisson", 4),
-        ("rank:pairwise", 5),
-        ("rank:ndcg", 5),
-        ("rank:map", 5),
-    ],
-    ids=[
-        "binary:logistic",
-        "binary:hinge",
-        "binary:logitraw",
-        "count:poisson",
-        "rank:pairwise",
-        "rank:ndcg",
-        "rank:map",
-    ],
+@given(
+    objective_pair=sampled_from(
+        [
+            ("binary:logistic", 2),
+            ("binary:hinge", 2),
+            ("binary:logitraw", 2),
+            ("count:poisson", 4),
+            ("rank:pairwise", 5),
+            ("rank:ndcg", 5),
+            ("rank:map", 5),
+        ],
+    ),
+    model_format=sampled_from(["binary", "json"]),
+    num_boost_round=integers(min_value=5, max_value=50),
+    callback=hypothesis_callback(),
 )
-def test_xgb_nonlinear_objective(tmpdir, objective, max_label, model_format):
+@settings(**standard_settings())
+def test_xgb_nonlinear_objective(
+    objective_pair, model_format, num_boost_round, callback
+):
     # pylint: disable=too-many-locals
-    """Test XGBoost with non-linear objectives with dummy data"""
-    nrow = 16
-    ncol = 8
-    rng = np.random.default_rng(seed=0)
-    X = rng.standard_normal(size=(nrow, ncol), dtype=np.float32)
-    y = rng.integers(0, max_label, size=nrow)
+    """Test XGBoost with non-linear objectives with synthetic data"""
+    objective, num_class = objective_pair
+    X, y = callback.draw(
+        standard_classification_datasets(
+            n_classes=just(num_class), n_informative=just(5)
+        )
+    )
     assert np.min(y) == 0
-    assert np.max(y) == max_label - 1
+    assert np.max(y) == num_class - 1
 
-    num_round = 4
     dtrain = xgb.DMatrix(X, label=y)
     if objective.startswith("rank:"):
-        dtrain.set_group([nrow])
+        dtrain.set_group([X.shape[0]])
     xgb_model = xgb.train(
         {"objective": objective, "base_score": 0.5, "seed": 0},
         dtrain=dtrain,
-        num_boost_round=num_round,
+        num_boost_round=num_boost_round,
     )
 
     objective_tag = objective.replace(":", "_")
@@ -276,17 +299,18 @@ def test_xgb_nonlinear_objective(tmpdir, objective, max_label, model_format):
         model_name = f"nonlinear_{objective_tag}.json"
     else:
         model_name = f"nonlinear_{objective_tag}.bin"
-    model_path = os.path.join(tmpdir, model_name)
-    xgb_model.save_model(model_path)
+    with TemporaryDirectory() as tmpdir:
+        model_path = os.path.join(tmpdir, model_name)
+        xgb_model.save_model(model_path)
 
-    tl_model = treelite.Model.load(
-        filename=model_path,
-        model_format=("xgboost_json" if model_format == "json" else "xgboost"),
-    )
+        tl_model = treelite.Model.load(
+            filename=model_path,
+            model_format=("xgboost_json" if model_format == "json" else "xgboost"),
+        )
 
-    out_pred = treelite.gtil.predict(tl_model, X)
-    expected_pred = xgb_model.predict(dtrain)
-    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
+        out_pred = treelite.gtil.predict(tl_model, X)
+        expected_pred = xgb_model.predict(dtrain)
+        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
 @pytest.mark.parametrize("in_memory", [True, False])
@@ -307,19 +331,17 @@ def test_xgb_categorical_split(in_memory):
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
-@pytest.mark.parametrize("model_format", ["binary", "json"])
-def test_xgb_dart(tmpdir, model_format):
+@given(
+    dataset=standard_classification_datasets(n_classes=just(2)),
+    model_format=sampled_from(["binary", "json"]),
+    num_boost_round=integers(min_value=5, max_value=50),
+)
+@settings(**standard_settings())
+def test_xgb_dart(dataset, model_format, num_boost_round):
     # pylint: disable=too-many-locals
     """Test XGBoost DART model with dummy data"""
-    nrow = 16
-    ncol = 8
-    rng = np.random.default_rng(seed=0)
-    X = rng.standard_normal(size=(nrow, ncol))
-    y = rng.integers(0, 2, size=nrow)
-    assert np.min(y) == 0
-    assert np.max(y) == 1
+    X, y = dataset
 
-    num_round = 50
     dtrain = xgb.DMatrix(X, label=y)
     param = {
         "booster": "dart",
@@ -331,18 +353,21 @@ def test_xgb_dart(tmpdir, model_format):
         "rate_drop": 0.1,
         "skip_drop": 0.5,
     }
-    xgb_model = xgb.train(param, dtrain=dtrain, num_boost_round=num_round)
+    xgb_model = xgb.train(param, dtrain=dtrain, num_boost_round=num_boost_round)
 
-    if model_format == "json":
-        model_name = "dart.json"
-        model_path = os.path.join(tmpdir, model_name)
-        xgb_model.save_model(model_path)
-        tl_model = treelite.Model.load(filename=model_path, model_format="xgboost_json")
-    else:
-        tl_model = treelite.Model.from_xgboost(xgb_model)
-    out_pred = treelite.gtil.predict(tl_model, X)
-    expected_pred = xgb_model.predict(dtrain)
-    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
+    with TemporaryDirectory() as tmpdir:
+        if model_format == "json":
+            model_name = "dart.json"
+            model_path = os.path.join(tmpdir, model_name)
+            xgb_model.save_model(model_path)
+            tl_model = treelite.Model.load(
+                filename=model_path, model_format="xgboost_json"
+            )
+        else:
+            tl_model = treelite.Model.from_xgboost(xgb_model)
+        out_pred = treelite.gtil.predict(tl_model, X)
+        expected_pred = xgb_model.predict(dtrain)
+        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
 @given(
@@ -387,12 +412,16 @@ def test_lightgbm_regression(objective, reg_sqrt, dataset):
         np.testing.assert_almost_equal(out_pred, expected_pred, decimal=4)
 
 
-@pytest.mark.parametrize("objective", ["binary", "xentlambda", "xentropy"])
-def test_lightgbm_binary_classification(tmpdir, objective):
+@given(
+    dataset=standard_classification_datasets(n_classes=just(2)),
+    objective=sampled_from(["binary", "xentlambda", "xentropy"]),
+    num_boost_round=integers(min_value=5, max_value=50),
+)
+@settings(**standard_settings())
+def test_lightgbm_binary_classification(dataset, objective, num_boost_round):
     # pylint: disable=too-many-locals
     """Test LightGBM binary classifier"""
-    lgb_model_path = os.path.join(tmpdir, "breast_cancer_lightgbm.txt")
-    X, y = load_breast_cancer(return_X_y=True)
+    X, y = dataset
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.2, shuffle=False
     )
@@ -409,25 +438,37 @@ def test_lightgbm_binary_classification(tmpdir, objective):
     lgb_model = lgb.train(
         param,
         dtrain,
-        num_boost_round=10,
+        num_boost_round=num_boost_round,
         valid_sets=[dtrain, dtest],
         valid_names=["train", "test"],
     )
     expected_prob = lgb_model.predict(X_test)
-    lgb_model.save_model(lgb_model_path)
 
-    tl_model = treelite.Model.load(lgb_model_path, model_format="lightgbm")
-    out_prob = treelite.gtil.predict(tl_model, X_test)
-    np.testing.assert_almost_equal(out_prob, expected_prob, decimal=5)
+    with TemporaryDirectory() as tmpdir:
+        lgb_model_path = os.path.join(tmpdir, "breast_cancer_lightgbm.txt")
+        lgb_model.save_model(lgb_model_path)
+
+        tl_model = treelite.Model.load(lgb_model_path, model_format="lightgbm")
+        out_prob = treelite.gtil.predict(tl_model, X_test)
+        np.testing.assert_almost_equal(out_prob, expected_prob, decimal=5)
 
 
-@pytest.mark.parametrize("boosting_type", ["gbdt", "rf"])
-@pytest.mark.parametrize("objective", ["multiclass", "multiclassova"])
-def test_lightgbm_multiclass_classification(tmpdir, objective, boosting_type):
+@given(
+    dataset=standard_classification_datasets(
+        n_classes=integers(min_value=3, max_value=10), n_informative=just(5)
+    ),
+    objective=sampled_from(["multiclass", "multiclassova"]),
+    boosting_type=sampled_from(["gbdt", "rf"]),
+    num_boost_round=integers(min_value=5, max_value=50),
+)
+@settings(**standard_settings())
+def test_lightgbm_multiclass_classification(
+    dataset, objective, boosting_type, num_boost_round
+):
     # pylint: disable=too-many-locals
     """Test LightGBM multi-class classifier"""
-    lgb_model_path = os.path.join(tmpdir, "iris_lightgbm.txt")
-    X, y = load_iris(return_X_y=True)
+    X, y = dataset
+    num_class = np.max(y) + 1
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.2, shuffle=False
     )
@@ -438,7 +479,7 @@ def test_lightgbm_multiclass_classification(tmpdir, objective, boosting_type):
         "boosting": boosting_type,
         "objective": objective,
         "metric": "multi_logloss",
-        "num_class": 3,
+        "num_class": num_class,
         "num_leaves": 31,
         "learning_rate": 0.05,
     }
@@ -447,16 +488,19 @@ def test_lightgbm_multiclass_classification(tmpdir, objective, boosting_type):
     lgb_model = lgb.train(
         param,
         dtrain,
-        num_boost_round=10,
+        num_boost_round=num_boost_round,
         valid_sets=[dtrain, dtest],
         valid_names=["train", "test"],
     )
     expected_pred = lgb_model.predict(X_test)
-    lgb_model.save_model(lgb_model_path)
 
-    tl_model = treelite.Model.load(lgb_model_path, model_format="lightgbm")
-    out_pred = treelite.gtil.predict(tl_model, X_test)
-    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
+    with TemporaryDirectory() as tmpdir:
+        lgb_model_path = os.path.join(tmpdir, "iris_lightgbm.txt")
+        lgb_model.save_model(lgb_model_path)
+
+        tl_model = treelite.Model.load(lgb_model_path, model_format="lightgbm")
+        out_pred = treelite.gtil.predict(tl_model, X_test)
+        np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
 def test_lightgbm_categorical_data():
@@ -527,10 +571,13 @@ def test_lightgbm_sparse_categorical_model():
 @given(
     dataset=standard_regression_datasets(),
     predict_type=sampled_from(["leaf_id", "score_per_tree"]),
+    num_boost_round=integers(min_value=5, max_value=50),
     callback=hypothesis_callback(),
 )
 @settings(**standard_settings())
-def test_predict_special_with_regressor(dataset, predict_type, callback):
+def test_predict_special_with_regressor(
+    dataset, predict_type, num_boost_round, callback
+):
     # pylint: disable=too-many-locals
     """Test predict_leaf / predict_per_tree with XGBoost regressor"""
     X, y = dataset
@@ -543,24 +590,23 @@ def test_predict_special_with_regressor(dataset, predict_type, callback):
         "objective": "reg:squarederror",
         "base_score": 0,
     }
-    num_round = 10
     xgb_model = xgb.train(
         param,
         dtrain,
-        num_boost_round=num_round,
+        num_boost_round=num_boost_round,
     )
     model: treelite.Model = treelite.Model.from_xgboost(xgb_model)
-    assert model.num_tree == num_round
+    assert model.num_tree == num_boost_round
 
     X_sample = X[0:sample_size]
     if predict_type == "leaf_id":
         leaf_pred = treelite.gtil.predict_leaf(model, X_sample)
-        assert leaf_pred.shape == (sample_size, num_round)
+        assert leaf_pred.shape == (sample_size, num_boost_round)
         xgb_leaf_pred = xgb_model.predict(xgb.DMatrix(X_sample), pred_leaf=True)
         assert np.array_equal(leaf_pred, xgb_leaf_pred)
     else:
         pred_per_tree = treelite.gtil.predict_per_tree(model, X_sample)
-        assert pred_per_tree.shape == (sample_size, num_round)
+        assert pred_per_tree.shape == (sample_size, num_boost_round)
         pred = xgb_model.predict(xgb.DMatrix(X_sample), output_margin=True)
         np.testing.assert_almost_equal(np.sum(pred_per_tree, axis=1), pred, decimal=3)
 
@@ -568,16 +614,18 @@ def test_predict_special_with_regressor(dataset, predict_type, callback):
 @given(
     predict_type=sampled_from(["leaf_id", "score_per_tree"]),
     dataset=standard_classification_datasets(n_classes=just(2)),
+    num_boost_round=integers(min_value=5, max_value=50),
     callback=hypothesis_callback(),
 )
 @settings(**standard_settings())
-def test_predict_special_with_binary_classifier(predict_type, dataset, callback):
+def test_predict_special_with_binary_classifier(
+    predict_type, dataset, num_boost_round, callback
+):
     # pylint: disable=too-many-locals
     """Test predict_leaf / predict_per_tree with XGBoost binary classifier"""
     X, y = dataset
     sample_size = callback.draw(integers(min_value=1, max_value=X.shape[0]))
 
-    num_round = 10
     dtrain = xgb.DMatrix(X, label=y)
     param = {
         "objective": "binary:logistic",
@@ -588,20 +636,20 @@ def test_predict_special_with_binary_classifier(predict_type, dataset, callback)
     xgb_model = xgb.train(
         param,
         dtrain=dtrain,
-        num_boost_round=num_round,
+        num_boost_round=num_boost_round,
     )
     model: treelite.Model = treelite.Model.from_xgboost(xgb_model)
-    assert model.num_tree == num_round
+    assert model.num_tree == num_boost_round
 
     X_sample = X[0:sample_size]
     if predict_type == "leaf_id":
         leaf_pred = treelite.gtil.predict_leaf(model, X_sample)
-        assert leaf_pred.shape == (sample_size, num_round)
+        assert leaf_pred.shape == (sample_size, num_boost_round)
         xgb_leaf_pred = xgb_model.predict(xgb.DMatrix(X_sample), pred_leaf=True)
         assert np.array_equal(leaf_pred, xgb_leaf_pred)
     else:
         pred_per_tree = treelite.gtil.predict_per_tree(model, X_sample)
-        assert pred_per_tree.shape == (sample_size, num_round)
+        assert pred_per_tree.shape == (sample_size, num_boost_round)
         pred = xgb_model.predict(xgb.DMatrix(X_sample), output_margin=True)
         np.testing.assert_almost_equal(np.sum(pred_per_tree, axis=1), pred, decimal=3)
 
@@ -611,11 +659,12 @@ def test_predict_special_with_binary_classifier(predict_type, dataset, callback)
     dataset=standard_classification_datasets(
         n_classes=integers(min_value=3, max_value=10), n_informative=just(5)
     ),
+    num_boost_round=integers(min_value=5, max_value=50),
     callback=hypothesis_callback(),
 )
 @settings(**standard_settings())
 def test_predict_special_with_multi_classifier_grove_per_class(
-    predict_type, dataset, callback
+    predict_type, dataset, num_boost_round, callback
 ):
     # pylint: disable=too-many-locals
     """
@@ -635,14 +684,13 @@ def test_predict_special_with_multi_classifier_grove_per_class(
         "metric": "mlogloss",
         "base_score": 0,
     }
-    num_round = 10
     xgb_model = xgb.train(
         param,
         dtrain,
-        num_boost_round=num_round,
+        num_boost_round=num_boost_round,
     )
     model: treelite.Model = treelite.Model.from_xgboost(xgb_model)
-    assert model.num_tree == num_round * num_class
+    assert model.num_tree == num_boost_round * num_class
 
     X_sample = X[0:sample_size]
     if predict_type == "leaf_id":


### PR DESCRIPTION
* Use randomly generated data to test classifiers; don't use toy data from sklearn
* Randomize `n_estimators` and `num_boost_round`

Extracted from #444 