### PR TITLE
Next-generation model builder API, with focus on performance

### DIFF
--- a/include/treelite/base.h
+++ b/include/treelite/base.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2020 by Contributors
+ * Copyright (c) 2017-2023 by Contributors
  * \file base.h
  * \brief defines configuration macros of Treelite
  * \author Hyunsu Cho
@@ -7,6 +7,7 @@
 #ifndef TREELITE_BASE_H_
 #define TREELITE_BASE_H_
 
+#include <treelite/logging.h>
 #include <treelite/error.h>
 #include <treelite/typeinfo.h>
 #include <cstdint>
@@ -53,6 +54,28 @@ inline std::string OpName(Operator op) {
 }
 
 /*!
+ * \brief Build operator enum from a string representation
+ * \param name Name of operator
+ * \return Operator enum
+ */
+inline Operator LookupOperatorByName(const std::string& name) {
+  if (name == "==") {
+    return Operator::kEQ;
+  } else if (name == "<") {
+    return Operator::kLT;
+  } else if (name == "<=") {
+    return Operator::kLE;
+  } else if (name == ">") {
+    return Operator::kGT;
+  } else if (name == ">=") {
+    return Operator::kGE;
+  } else {
+    TREELITE_LOG(FATAL) << "Unknown operator: " << name;
+    return Operator::kNone;
+  }
+}
+
+/*!
  * \brief Get string representation of split type
  * \param type Type of a split
  * \return String representation
@@ -83,7 +106,7 @@ inline bool CompareWithOp(ElementType lhs, Operator op, ThresholdType rhs) {
     case Operator::kGT: return lhs >  rhs;
     case Operator::kGE: return lhs >= rhs;
     default:
-      throw Error("operator undefined");
+      TREELITE_LOG(FATAL) << "operator undefined: " << static_cast<int>(op);
       return false;
   }
 }

--- a/include/treelite/c_api.h
+++ b/include/treelite/c_api.h
@@ -301,7 +301,7 @@ TREELITE_DLL int TreeliteBuildModelFromArrays(
     const char* metadata_json, const int64_t* node_count, const int8_t** split_type,
     const int8_t** default_left, const int64_t** children_left, const int64_t** children_right,
     const int64_t** split_feature, const float** threshold, const float** leaf_value,
-    const uint32_t* categories_list, const int64_t** categories_list_offset_begin,
+    const uint32_t** categories_list, const int64_t** categories_list_offset_begin,
     const int64_t** categories_list_offset_end, const int8_t** categories_list_right_child,
     ModelHandle* out);
 

--- a/include/treelite/c_api.h
+++ b/include/treelite/c_api.h
@@ -225,9 +225,11 @@ TREELITE_DLL int TreeliteLoadLightGBMModelFromStringEx(const char* model_str,
 
 /*!
  * \brief Build a Treelite model from a collection of arrays. For this function, we prioritize
- *        performance and efficiency over the ease of use. For small models, you may want to
- *        consider using \ref TreeliteBuildModelFromJSONString instead. Note: The built model will
- *        use float32 to store thresholds and leaf values.
+ *        performance and efficiency over the ease of use. You must ensure that the nodes are
+ *        sorted in bredth-first order (so node 0 is the root and so on). This function will
+ *        exhibit an undefined behavior if the nodes are ordered incorrectly. For small models, you
+ *        may want to consider using \ref TreeliteBuildModelFromJSONString instead. Note: The built
+ *        model will use float32 to store thresholds and leaf values.
  * \param metadata_json a JSON string with the following fields:
  *   - "num_tree" (required): Number of trees in the tree ensemble
  *   - "num_feature" (required): Number of features in the training data
@@ -299,8 +301,8 @@ TREELITE_DLL int TreeliteLoadLightGBMModelFromStringEx(const char* model_str,
  */
 TREELITE_DLL int TreeliteBuildModelFromArrays(
     const char* metadata_json, const int64_t* node_count, const int8_t** split_type,
-    const int8_t** default_left, const int64_t** children_left, const int64_t** children_right,
-    const int64_t** split_feature, const float** threshold, const float** leaf_value,
+    const int8_t** default_left, const int32_t** children_left, const int32_t** children_right,
+    const uint32_t** split_feature, const float** threshold, const float** leaf_value,
     const uint32_t** categories_list, const int64_t** categories_list_offset_begin,
     const int64_t** categories_list_offset_end, const int8_t** categories_list_right_child,
     ModelHandle* out);

--- a/include/treelite/frontend.h
+++ b/include/treelite/frontend.h
@@ -86,9 +86,11 @@ std::unique_ptr<treelite::Model> LoadXGBoostJSONModelString(
 
 /*!
  * \brief Build a Treelite model from a collection of arrays. For this function, we prioritize
- *        performance and efficiency over the ease of use. For small models, you may want to
- *        consider using \ref BuildModelFromJSONString instead. Note: The built model will
- *        use float32 to store thresholds and leaf values.
+ *        performance and efficiency over the ease of use. You must ensure that the nodes are
+ *        sorted in bredth-first order (so node 0 is the root and so on). This function will
+ *        exhibit an undefined behavior if the nodes are ordered incorrectly. For small models, you
+ *        may want to consider using \ref BuildModelFromJSONString instead. Note: The built model
+ *        will use float32 to store thresholds and leaf values.
  * \param metadata Model metadata. Call \ref ParseMetadata to obtain it.
  * \param node_count node_count[i] stores the number of nodes in the i-th tree
  * \param split_type split_type[i][k] stores the split type of node k of the i-th tree. Currently,
@@ -129,8 +131,8 @@ std::unique_ptr<treelite::Model> LoadXGBoostJSONModelString(
  */
 std::unique_ptr<treelite::Model> BuildModelFromArrays(
     const Metadata& metadata, const std::int64_t* node_count, const std::int8_t** split_type,
-    const std::int8_t** default_left, const std::int64_t** children_left,
-    const std::int64_t** children_right, const std::int64_t** split_feature,
+    const std::int8_t** default_left, const std::int32_t** children_left,
+    const std::int32_t** children_right, const std::uint32_t** split_feature,
     const float** threshold, const float** leaf_value, const std::uint32_t** categories_list,
     const std::int64_t** categories_list_offset_begin,
     const std::int64_t** categories_list_offset_end,

--- a/include/treelite/frontend.h
+++ b/include/treelite/frontend.h
@@ -131,7 +131,7 @@ std::unique_ptr<treelite::Model> BuildModelFromArrays(
     const Metadata& metadata, const std::int64_t* node_count, const std::int8_t** split_type,
     const std::int8_t** default_left, const std::int64_t** children_left,
     const std::int64_t** children_right, const std::int64_t** split_feature,
-    const float** threshold, const float** leaf_value, const std::uint32_t* categories_list,
+    const float** threshold, const float** leaf_value, const std::uint32_t** categories_list,
     const std::int64_t** categories_list_offset_begin,
     const std::int64_t** categories_list_offset_end,
     const std::int8_t** categories_list_right_child);

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -9,6 +9,7 @@
 
 #include <treelite/base.h>
 #include <treelite/version.h>
+#include <treelite/logging.h>
 #include <algorithm>
 #include <map>
 #include <memory>
@@ -177,6 +178,21 @@ inline std::string TaskTypeToString(TaskType type) {
   }
 }
 
+inline TaskType StringToTaskType(const std::string& str) {
+  if (str == "BinaryClfRegr") {
+    return TaskType::kBinaryClfRegr;
+  } else if (str == "MultiClfGrovePerClass") {
+    return TaskType::kMultiClfGrovePerClass;
+  } else if (str == "MultiClfProbDistLeaf") {
+    return TaskType::kMultiClfProbDistLeaf;
+  } else if (str == "MultiClfCategLeaf") {
+    return TaskType::kMultiClfCategLeaf;
+  } else {
+    TREELITE_LOG(FATAL) << "Unknown task type: " << str;
+    return TaskType::kBinaryClfRegr;  // to avoid compiler warning
+  }
+}
+
 /*! \brief Group of parameters that are dependent on the choice of the task type. */
 struct TaskParam {
   enum class OutputType : uint8_t { kFloat = 0, kInt = 1 };
@@ -212,6 +228,17 @@ inline std::string OutputTypeToString(TaskParam::OutputType type) {
     case TaskParam::OutputType::kFloat: return "float";
     case TaskParam::OutputType::kInt: return "int";
     default: return "";
+  }
+}
+
+inline TaskParam::OutputType StringToOutputType(const std::string& str) {
+  if (str == "float") {
+    return TaskParam::OutputType::kFloat;
+  } else if (str == "int") {
+    return TaskParam::OutputType::kInt;
+  } else {
+    TREELITE_LOG(FATAL) << "Unrecognized output type: " << str;
+    return TaskParam::OutputType::kFloat;  // to avoid compiler warning
   }
 }
 

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -39,7 +39,12 @@
 
 namespace treelite {
 
-class GTILBridge;
+namespace unsafe {
+
+template<int>
+class InternalAccessor;
+
+}  // namespace unsafe
 
 template <typename ThresholdType, typename LeafOutputType>
 class ModelImpl;
@@ -429,7 +434,9 @@ class Tree {
   DeserializeTemplate(ScalarHandler scalar_handler, ArrayHandler array_handler,
       SkipOptFieldHandlerFunc skip_opt_field_handler);
 
-  friend class GTILBridge;  // bridge to enable optimized access to nodes from GTIL
+  template <int>
+  friend class unsafe::InternalAccessor;
+    // bridge to enable optimized access to nodes and other private fields
 
  public:
   /*! \brief number of nodes */

--- a/include/treelite/tree_impl.h
+++ b/include/treelite/tree_impl.h
@@ -1057,5 +1057,70 @@ inline void InitParamAndCheck(ModelParam* param,
   }
 }
 
+// Bridge to enable unsafe (but fast) access to internals of Treelite model objects.
+// Usage: unsafe::InternalAccessor<unsafe::HERE_COMES_THE_DRAGON>::SomeMethod()
+
+namespace unsafe {
+
+constexpr int HERE_COMES_THE_DRAGON = -100;
+
+template<int T>
+class InternalAccessor {
+};
+
+template<>
+class InternalAccessor<HERE_COMES_THE_DRAGON> {
+ public:
+  template <typename ThresholdType, typename LeafOutputType>
+  inline static const typename Tree<ThresholdType, LeafOutputType>::Node*
+  GetNode(const Tree<ThresholdType, LeafOutputType>& tree, int nid) {
+    return &tree.nodes_[nid];
+  }
+
+  template <typename ThresholdType, typename LeafOutputType>
+  inline static ContiguousArray<typename Tree<ThresholdType, LeafOutputType>::Node>&
+  GetNodeArray(Tree<ThresholdType, LeafOutputType>& tree) {
+    return tree.nodes_;
+  }
+
+  template <typename ThresholdType, typename LeafOutputType>
+  inline static ContiguousArray<LeafOutputType>&
+  GetLeafVector(Tree<ThresholdType, LeafOutputType>& tree) {
+    return tree.leaf_vector_;
+  }
+
+  template <typename ThresholdType, typename LeafOutputType>
+  inline static ContiguousArray<std::size_t>&
+  GetLeafVectorBegin(Tree<ThresholdType, LeafOutputType>& tree) {
+    return tree.leaf_vector_begin_;
+  }
+
+  template <typename ThresholdType, typename LeafOutputType>
+  inline static ContiguousArray<std::size_t>&
+  GetLeafVectorEnd(Tree<ThresholdType, LeafOutputType>& tree) {
+    return tree.leaf_vector_end_;
+  }
+
+  template <typename ThresholdType, typename LeafOutputType>
+  inline static ContiguousArray<std::uint32_t>&
+  GetMatchingCategories(Tree<ThresholdType, LeafOutputType>& tree) {
+    return tree.matching_categories_;
+  }
+
+  template <typename ThresholdType, typename LeafOutputType>
+  inline static ContiguousArray<std::size_t>&
+  GetMatchingCategoriesOffset(Tree<ThresholdType, LeafOutputType>& tree) {
+    return tree.matching_categories_offset_;
+  }
+
+  template <typename ThresholdType, typename LeafOutputType>
+  inline static void
+  SetCategoricalSplitFlag(Tree<ThresholdType, LeafOutputType>& tree, bool value) {
+    tree.has_categorical_split_ = value;
+  }
+};
+
+}  // namespace unsafe
+
 }  // namespace treelite
 #endif  // TREELITE_TREE_IMPL_H_

--- a/python/treelite/experimental/__init__.py
+++ b/python/treelite/experimental/__init__.py
@@ -1,0 +1,1 @@
+"""Experimental module"""

--- a/python/treelite/experimental/model_builder.py
+++ b/python/treelite/experimental/model_builder.py
@@ -138,6 +138,7 @@ class ModelSpec:
                     categories_list_offset_begin_l.append(len(categories_list_l))
                     categories_list_offset_end_l.append(len(categories_list_l))
                     categories_list_right_child_l.append(False)
+                    continue
                 node = tree.nodes[node_id]
                 if isinstance(node, LeafNode):
                     split_type_l.append(0)

--- a/python/treelite/experimental/model_builder.py
+++ b/python/treelite/experimental/model_builder.py
@@ -1,0 +1,225 @@
+"""
+Next-gen model builder, using dataclasses.
+
+Limitations
+* Only one kind of comparison op used throughout the model
+* float32 type only
+"""
+
+import ctypes
+import json
+from dataclasses import asdict, dataclass
+from typing import Dict, List, Literal, Union
+
+import numpy as np
+
+from ..core import _LIB, _check_call, c_array
+from ..frontend import Model
+from ..sklearn.importer import ArrayOfArrays
+from ..util import c_str
+
+
+@dataclass
+class TaskParam:
+    output_type: Literal["float", "int"]
+    grove_per_class: bool
+    num_class: int
+    leaf_vector_size: int
+
+
+@dataclass
+class ModelParam:
+    pred_transform: str
+    sigmoid_alpha: float = 1.0
+    ratio_c: float = 1.0
+    global_bias: float = 0.0
+
+
+@dataclass
+class NumericalSplitNode:
+    split_feature_id: int
+    default_left: bool
+    left_child: int
+    right_child: int
+    threshold: float
+    split_type: Literal["numerical"] = "numerical"
+
+
+@dataclass
+class CategoricalSplitNode:
+    split_feature_id: int
+    default_left: bool
+    left_child: int
+    right_child: int
+    categories_list_right_child: bool
+    categories_list: List[int]
+    split_type: Literal["categorical"] = "categorical"
+
+
+@dataclass
+class LeafNode:
+    leaf_value: Union[float, List[float]]
+
+
+@dataclass
+class Tree:
+    nodes: Dict[int, Union[NumericalSplitNode, CategoricalSplitNode, LeafNode]]
+
+
+@dataclass
+class ModelSpec:
+    num_feature: int
+    average_tree_output: bool
+    comparison_op: Literal["==", "<", "<=", ">", ">="]
+    task_type: Literal[
+        "BinaryClfRegr",
+        "MultiClfGrovePerClass",
+        "MultiClfProbDistLeaf",
+        "MultiClfCategLeaf",
+    ]
+    task_param: TaskParam
+    model_param: ModelParam
+    trees: List[Tree]
+
+    def commit(self) -> Model:
+        """Convert to Treelite model"""
+        # Marshal data into arrays and then invoke TreeliteBuildModelFromArrays
+        handle = ctypes.c_void_p()
+
+        metadata = {
+            "num_tree": len(self.trees),
+            "num_feature": self.num_feature,
+            "average_tree_output": self.average_tree_output,
+            "comparison_op": self.comparison_op,
+            "task_type": self.task_type,
+            "task_param": asdict(self.task_param),
+            "model_param": asdict(self.model_param),
+        }
+        metadata = json.dumps(metadata)
+
+        node_count = []
+        split_type = ArrayOfArrays(dtype=np.int8)
+        default_left = ArrayOfArrays(dtype=np.int8)
+        children_left = ArrayOfArrays(dtype=np.int64)
+        children_right = ArrayOfArrays(dtype=np.int64)
+        split_feature = ArrayOfArrays(dtype=np.int64)
+        threshold = ArrayOfArrays(dtype=np.float32)
+        leaf_value = ArrayOfArrays(dtype=np.float32)
+        categories_list = ArrayOfArrays(dtype=np.uint32)
+        categories_list_offset_begin = ArrayOfArrays(dtype=np.int64)
+        categories_list_offset_end = ArrayOfArrays(dtype=np.int64)
+        categories_list_right_child = ArrayOfArrays(dtype=np.int8)
+
+        for tree in self.trees:
+            max_node_id = max(tree.nodes)
+            node_count.append(max_node_id + 1)
+
+            split_type_l = []
+            default_left_l = []
+            children_left_l = []
+            children_right_l = []
+            split_feature_l = []
+            threshold_l = []
+            leaf_value_l = []
+            categories_list_l = []
+            categories_list_offset_begin_l = []
+            categories_list_offset_end_l = []
+            categories_list_right_child_l = []
+            for node_id in range(max_node_id + 1):
+                if node_id not in tree.nodes:
+                    # gap in node ID; fill it with empty node
+                    split_type_l.append(0)
+                    default_left_l.append(False)
+                    children_left_l.append(-1)
+                    children_right_l.append(-1)
+                    split_feature_l.append(-1)
+                    threshold_l.append(np.nan)
+                    leaf_value_l.append(np.nan)
+                    categories_list_offset_begin_l.append(len(categories_list_l))
+                    categories_list_offset_end_l.append(len(categories_list_l))
+                    categories_list_right_child_l.append(False)
+                node = tree.nodes[node_id]
+                if isinstance(node, LeafNode):
+                    split_type_l.append(0)
+                    default_left_l.append(False)
+                    children_left_l.append(-1)
+                    children_right_l.append(-1)
+                    split_feature_l.append(-1)
+                    threshold_l.append(np.nan)
+                    if isinstance(node.leaf_value, list):
+                        if len(node.leaf_value) != self.task_param.leaf_vector_size:
+                            raise ValueError(
+                                f"Leaf output must have length "
+                                f"{self.task_param.leaf_vector_size}"
+                            )
+                        leaf_value_l.extend(node.leaf_value)
+                    else:
+                        if self.task_param.leaf_vector_size != 1:
+                            raise ValueError(
+                                f"Leaf output must have length "
+                                f"{self.task_param.leaf_vector_size}"
+                            )
+                        leaf_value_l.append(node.leaf_value)
+                    categories_list_offset_begin_l.append(len(categories_list_l))
+                    categories_list_offset_end_l.append(len(categories_list_l))
+                    categories_list_right_child_l.append(False)
+                elif isinstance(node, NumericalSplitNode):
+                    split_type_l.append(1)
+                    default_left_l.append(node.default_left)
+                    children_left_l.append(node.left_child)
+                    children_right_l.append(node.right_child)
+                    split_feature_l.append(node.split_feature_id)
+                    threshold_l.append(node.threshold)
+                    leaf_value_l.append(np.nan)
+                    categories_list_offset_begin_l.append(len(categories_list_l))
+                    categories_list_offset_end_l.append(len(categories_list_l))
+                    categories_list_right_child_l.append(False)
+                elif isinstance(node, CategoricalSplitNode):
+                    split_type_l.append(2)
+                    default_left_l.append(node.default_left)
+                    children_left_l.append(node.left_child)
+                    children_right_l.append(node.right_child)
+                    split_feature_l.append(node.split_feature_id)
+                    threshold_l.append(np.nan)
+                    leaf_value_l.append(np.nan)
+                    categories_list_offset_begin_l.append(len(categories_list_l))
+                    categories_list_offset_end_l.append(
+                        len(categories_list_l) + len(node.categories_list)
+                    )
+                    categories_list_l.extend(node.categories_list)
+                    categories_list_right_child_l.append(
+                        node.categories_list_right_child
+                    )
+                else:
+                    raise ValueError(f"Unknown node type: {node.__class__.__name__}")
+            split_type.add(split_type_l)
+            default_left.add(default_left_l)
+            children_left.add(children_left_l)
+            children_right.add(children_right_l)
+            split_feature.add(split_type_l)
+            threshold.add(threshold_l)
+            leaf_value.add(leaf_value_l)
+            categories_list.add(categories_list_l)
+            categories_list_offset_begin.add(categories_list_offset_begin_l)
+            categories_list_offset_end.add(categories_list_offset_end_l)
+            categories_list_right_child.add(categories_list_right_child_l)
+
+        _check_call(
+            _LIB.TreeliteBuildModelFromArrays(
+                c_str(metadata),
+                c_array(ctypes.c_int64, node_count),
+                split_type.as_c_array(),
+                default_left.as_c_array(),
+                children_left.as_c_array(),
+                children_right.as_c_array(),
+                split_feature.as_c_array(),
+                threshold.as_c_array(),
+                leaf_value.as_c_array(),
+                categories_list.as_c_array(),
+                categories_list_offset_begin.as_c_array(),
+                categories_list_offset_end.as_c_array(),
+                categories_list_right_child.as_c_array(),
+                ctypes.byref(handle),
+            )
+        )
+        return Model(handle)

--- a/python/treelite/experimental/model_builder.py
+++ b/python/treelite/experimental/model_builder.py
@@ -100,9 +100,9 @@ class ModelSpec:
         node_count = []
         split_type = ArrayOfArrays(dtype=np.int8)
         default_left = ArrayOfArrays(dtype=np.int8)
-        children_left = ArrayOfArrays(dtype=np.int64)
-        children_right = ArrayOfArrays(dtype=np.int64)
-        split_feature = ArrayOfArrays(dtype=np.int64)
+        children_left = ArrayOfArrays(dtype=np.int32)
+        children_right = ArrayOfArrays(dtype=np.int32)
+        split_feature = ArrayOfArrays(dtype=np.uint32)
         threshold = ArrayOfArrays(dtype=np.float32)
         leaf_value = ArrayOfArrays(dtype=np.float32)
         categories_list = ArrayOfArrays(dtype=np.uint32)

--- a/python/treelite/sklearn/importer.py
+++ b/python/treelite/sklearn/importer.py
@@ -16,20 +16,23 @@ class ArrayOfArrays:
     """
     def __init__(self, *, dtype):
         int8_ptr_type = ctypes.POINTER(ctypes.c_int8)
+        int32_ptr_type = ctypes.POINTER(ctypes.c_int32)
         int64_ptr_type = ctypes.POINTER(ctypes.c_int64)
         uint32_ptr_type = ctypes.POINTER(ctypes.c_uint32)
         float32_ptr_type = ctypes.POINTER(ctypes.c_float)
         float64_ptr_type = ctypes.POINTER(ctypes.c_double)
-        if dtype == np.int64:
-            self.ptr_type = int64_ptr_type
-        elif dtype == np.float64:
-            self.ptr_type = float64_ptr_type
-        elif dtype == np.float32:
-            self.ptr_type = float32_ptr_type
-        elif dtype == np.int8:
+        if dtype == np.int8:
             self.ptr_type = int8_ptr_type
+        elif dtype == np.int32:
+            self.ptr_type = int32_ptr_type
+        elif dtype == np.int64:
+            self.ptr_type = int64_ptr_type
         elif dtype == np.uint32:
             self.ptr_type = uint32_ptr_type
+        elif dtype == np.float32:
+            self.ptr_type = float32_ptr_type
+        elif dtype == np.float64:
+            self.ptr_type = float64_ptr_type
         else:
             raise ValueError(f'dtype {dtype} is not supported')
         self.dtype = dtype

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,6 +106,7 @@ target_sources(objtreelite
     compiler/failsafe.cc
     compiler/pred_transform.cc
     compiler/pred_transform.h
+    frontend/array_builder.cc
     frontend/builder.cc
     frontend/lightgbm.cc
     frontend/sklearn.cc

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -211,8 +211,8 @@ int TreeliteLoadLightGBMModelFromStringEx(
 
 int TreeliteBuildModelFromArrays(
     const char* metadata_json, const int64_t* node_count, const int8_t** split_type,
-    const int8_t** default_left, const int64_t** children_left, const int64_t** children_right,
-    const int64_t** split_feature, const float** threshold, const float** leaf_value,
+    const int8_t** default_left, const int32_t** children_left, const int32_t** children_right,
+    const uint32_t** split_feature, const float** threshold, const float** leaf_value,
     const uint32_t** categories_list, const int64_t** categories_list_offset_begin,
     const int64_t** categories_list_offset_end, const int8_t** categories_list_right_child,
     ModelHandle* out) {

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -209,6 +209,23 @@ int TreeliteLoadLightGBMModelFromStringEx(
   API_END();
 }
 
+int TreeliteBuildModelFromArrays(
+    const char* metadata_json, const int64_t* node_count, const int8_t** split_type,
+    const int8_t** default_left, const int64_t** children_left, const int64_t** children_right,
+    const int64_t** split_feature, const float** threshold, const float** leaf_value,
+    const uint32_t* categories_list, const int64_t** categories_list_offset_begin,
+    const int64_t** categories_list_offset_end, const int8_t** categories_list_right_child,
+    ModelHandle* out) {
+  API_BEGIN();
+  auto parsed_metadata = frontend::ParseMetadata(metadata_json);
+  std::unique_ptr<Model> model = frontend::BuildModelFromArrays(
+      parsed_metadata, node_count, split_type, default_left, children_left, children_right,
+      split_feature, threshold, leaf_value, categories_list, categories_list_offset_begin,
+      categories_list_offset_end, categories_list_right_child);
+  *out = static_cast<ModelHandle>(model.release());
+  API_END();
+}
+
 int TreeliteLoadSKLearnRandomForestRegressor(
     int n_estimators, int n_features, const int64_t* node_count, const int64_t** children_left,
     const int64_t** children_right, const int64_t** feature, const double** threshold,

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -213,7 +213,7 @@ int TreeliteBuildModelFromArrays(
     const char* metadata_json, const int64_t* node_count, const int8_t** split_type,
     const int8_t** default_left, const int64_t** children_left, const int64_t** children_right,
     const int64_t** split_feature, const float** threshold, const float** leaf_value,
-    const uint32_t* categories_list, const int64_t** categories_list_offset_begin,
+    const uint32_t** categories_list, const int64_t** categories_list_offset_begin,
     const int64_t** categories_list_offset_end, const int8_t** categories_list_right_child,
     ModelHandle* out) {
   API_BEGIN();

--- a/src/frontend/array_builder.cc
+++ b/src/frontend/array_builder.cc
@@ -108,7 +108,6 @@ std::unique_ptr<treelite::Model> BuildModelFromArrays(
     auto thread_config = threading_utils::ConfigureThreadConfig(-1);
     auto sched = threading_utils::ParallelSchedule::Static();
     const auto leaf_vector_size = metadata.task_param.leaf_vector_size;
-    TREELITE_LOG(INFO) << "leaf_vector_size = " << leaf_vector_size;
 
     if (leaf_vector_size > 1) {
       // Special handling for leaf vectors
@@ -157,8 +156,6 @@ std::unique_ptr<treelite::Model> BuildModelFromArrays(
         ModelAccessor::SetCategoricalSplitFlag(tree, false);
       }
     }
-
-    TREELITE_LOG(INFO) << "n_nodes = " << n_nodes;
 
     threading_utils::ParallelFor(std::size_t(0), n_nodes, thread_config, sched,
                                  [&](std::size_t node_id, int) {

--- a/src/frontend/array_builder.cc
+++ b/src/frontend/array_builder.cc
@@ -121,14 +121,11 @@ std::unique_ptr<treelite::Model> BuildModelFromArrays(
       auto& leaf_vector_offset_end = ModelAccessor::GetLeafVectorEnd(tree);
       leaf_vector_offset_beg.Resize(n_nodes);
       leaf_vector_offset_end.Resize(n_nodes);
-      std::transform(&categories_list_offset_begin[tree_id][0],
-                     &categories_list_offset_begin[tree_id][n_nodes],
-                     leaf_vector_offset_beg.Data(),
-                     [](std::int64_t e) { return static_cast<std::size_t>(e); });
-      std::transform(&categories_list_offset_end[tree_id][0],
-                     &categories_list_offset_end[tree_id][n_nodes],
-                     leaf_vector_offset_end.Data(),
-                     [](std::int64_t e) { return static_cast<std::size_t>(e); });
+
+      for (std::size_t i = 0; i < n_nodes; ++i) {
+        leaf_vector_offset_beg[i] = i * leaf_vector_size;
+        leaf_vector_offset_end[i] = (i + 1) * leaf_vector_size;
+      }
     } else {
       auto& leaf_vector_offset_beg = ModelAccessor::GetLeafVectorBegin(tree);
       auto& leaf_vector_offset_end = ModelAccessor::GetLeafVectorEnd(tree);
@@ -154,6 +151,7 @@ std::unique_ptr<treelite::Model> BuildModelFromArrays(
                   categories_offset.Data() + static_cast<std::size_t>(n_nodes));
       } else {
         ModelAccessor::SetCategoricalSplitFlag(tree, false);
+        categories_offset.Resize(n_nodes + 1, 0);
       }
     }
 

--- a/src/frontend/array_builder.cc
+++ b/src/frontend/array_builder.cc
@@ -71,7 +71,7 @@ std::unique_ptr<treelite::Model> BuildModelFromArrays(
     const Metadata& metadata, const std::int64_t* node_count, const std::int8_t** split_type,
     const std::int8_t** default_left, const std::int64_t** children_left,
     const std::int64_t** children_right, const std::int64_t** split_feature,
-    const float** threshold, const float** leaf_value, const std::uint32_t* categories_list,
+    const float** threshold, const float** leaf_value, const std::uint32_t** categories_list,
     const std::int64_t** categories_list_offset_begin,
     const std::int64_t** categories_list_offset_end,
     const std::int8_t** categories_list_right_child) {
@@ -118,8 +118,8 @@ std::unique_ptr<treelite::Model> BuildModelFromArrays(
         } else {
           // categorical split
           std::vector<std::uint32_t> categories_list_{
-              &categories_list[categories_list_offset_begin[tree_id][node_id]],
-              &categories_list[categories_list_offset_end[tree_id][node_id]]
+              &categories_list[tree_id][categories_list_offset_begin[tree_id][node_id]],
+              &categories_list[tree_id][categories_list_offset_end[tree_id][node_id]]
           };
           tree.SetCategoricalSplit(new_node_id, split_feature[tree_id][node_id],
                                    static_cast<bool>(default_left[tree_id][node_id]),

--- a/src/frontend/array_builder.cc
+++ b/src/frontend/array_builder.cc
@@ -1,0 +1,175 @@
+/*!
+ * Copyright (c) 2023 by Contributors
+ * \file array_builder.cc
+ * \brief Model builder to build a Treelite model from a collection of arrays
+ * \author Hyunsu Cho
+ */
+
+#include <rapidjson/error/en.h>
+#include <rapidjson/document.h>
+
+#include <treelite/tree.h>
+#include <treelite/frontend.h>
+
+#include <queue>
+
+namespace {
+
+template <typename ObjectType>
+int ExpectInt(const ObjectType& doc, const char* key) {
+  auto itr = doc.FindMember(key);
+  TREELITE_CHECK(itr != doc.MemberEnd()) << "Expected key \"" << key << "\" but it does not exist";
+  TREELITE_CHECK(itr->value.IsInt()) << "Key \"" << key << "\" must be an int";
+  return itr->value.GetInt();
+}
+
+template <typename ObjectType>
+unsigned int ExpectUint(const ObjectType& doc, const char* key) {
+  auto itr = doc.FindMember(key);
+  TREELITE_CHECK(itr != doc.MemberEnd()) << "Expected key \"" << key << "\" but it does not exist";
+  TREELITE_CHECK(itr->value.IsUint()) << "Key \"" << key << "\" must be an unsigned int";
+  return itr->value.GetUint();
+}
+
+template <typename ObjectType>
+float ExpectFloat(const ObjectType& doc, const char* key) {
+  auto itr = doc.FindMember(key);
+  TREELITE_CHECK(itr != doc.MemberEnd()) << "Expected key \"" << key << "\" but it does not exist";
+  TREELITE_CHECK(itr->value.IsFloat()) << "Key \"" << key << "\" must be a single-precision float";
+  return itr->value.GetFloat();
+}
+
+template <typename ObjectType>
+bool ExpectBool(const ObjectType& doc, const char* key) {
+  auto itr = doc.FindMember(key);
+  TREELITE_CHECK(itr != doc.MemberEnd()) << "Expected key \"" << key << "\" but it does not exist";
+  TREELITE_CHECK(itr->value.IsBool()) << "Key \"" << key << "\" must be a boolean";
+  return itr->value.GetBool();
+}
+
+template <typename ObjectType>
+std::string ExpectString(const ObjectType& doc, const char* key) {
+  auto itr = doc.FindMember(key);
+  TREELITE_CHECK(itr != doc.MemberEnd()) << "Expected key \"" << key << "\" but it does not exist";
+  TREELITE_CHECK(itr->value.IsString()) << "Key \"" << key << "\" must be a string";
+  return {itr->value.GetString(), itr->value.GetStringLength()};
+}
+
+template <typename ObjectType>
+rapidjson::Value::ConstObject ExpectObject(const ObjectType& doc, const char* key) {
+  auto itr = doc.FindMember(key);
+  TREELITE_CHECK(itr != doc.MemberEnd()) << "Expected key \"" << key << "\" but it does not exist";
+  TREELITE_CHECK(itr->value.IsObject()) << "Key \"" << key << "\" must be an object";
+  return itr->value.GetObject();
+}
+
+}  // anonymous namespace
+
+namespace treelite::frontend {
+
+std::unique_ptr<treelite::Model> BuildModelFromArrays(
+    const Metadata& metadata, const std::int64_t* node_count, const std::int8_t** split_type,
+    const std::int8_t** default_left, const std::int64_t** children_left,
+    const std::int64_t** children_right, const std::int64_t** split_feature,
+    const float** threshold, const float** leaf_value, const std::uint32_t* categories_list,
+    const std::int64_t** categories_list_offset_begin,
+    const std::int64_t** categories_list_offset_end,
+    const std::int8_t** categories_list_right_child) {
+  std::unique_ptr<treelite::Model> model_ptr = treelite::Model::Create<float, float>();
+  auto* model = dynamic_cast<treelite::ModelImpl<float, float>*>(model_ptr.get());
+  model->num_feature = metadata.num_feature;
+  model->average_tree_output = metadata.average_tree_output;
+  model->task_type = metadata.task_type;
+  model->task_param = metadata.task_param;
+  model->param = metadata.model_param;
+
+  for (std::int32_t tree_id = 0; tree_id < metadata.num_tree; ++tree_id) {
+    model->trees.emplace_back();
+    treelite::Tree<float, float>& tree = model->trees.back();
+    tree.Init();
+
+    // Assign node ID's so that a breadth-wise traversal would yield
+    // the monotonic sequence 0, 1, 2, ...
+    std::queue<std::pair<std::int32_t, std::int32_t>> Q;  // (old ID, new ID) pair
+    Q.emplace(0, 0);
+    while (!Q.empty()) {
+      auto [node_id, new_node_id] = Q.front();
+      Q.pop();
+      const auto split_type_ = static_cast<SplitFeatureType>(split_type[tree_id][node_id]);
+      if (split_type_ == SplitFeatureType::kNone) {
+        // Leaf node
+        const auto leaf_vector_size = metadata.task_param.leaf_vector_size;
+        if (leaf_vector_size == 1) {
+          tree.SetLeaf(new_node_id, leaf_value[tree_id][node_id]);
+        } else {
+          std::vector<float> leaf_vector{&leaf_value[tree_id][node_id * leaf_vector_size],
+                                         &leaf_value[tree_id][(node_id + 1) * leaf_vector_size]};
+          tree.SetLeafVector(new_node_id, leaf_vector);
+        }
+      } else {
+        // internal (test) node
+        tree.AddChilds(new_node_id);
+        if (split_type_ == SplitFeatureType::kNumerical) {
+          // numerical split
+          tree.SetNumericalSplit(new_node_id, split_feature[tree_id][node_id],
+                                 threshold[tree_id][node_id],
+                                 static_cast<bool>(default_left[tree_id][node_id]),
+                                 metadata.comparison_op);
+        } else {
+          // categorical split
+          std::vector<std::uint32_t> categories_list_{
+              &categories_list[categories_list_offset_begin[tree_id][node_id]],
+              &categories_list[categories_list_offset_end[tree_id][node_id]]
+          };
+          tree.SetCategoricalSplit(new_node_id, split_feature[tree_id][node_id],
+                                   static_cast<bool>(default_left[tree_id][node_id]),
+                                   categories_list_, categories_list_right_child[tree_id][node_id]);
+        }
+
+        Q.emplace(children_left[tree_id][node_id], tree.LeftChild(new_node_id));
+        Q.emplace(children_right[tree_id][node_id], tree.RightChild(new_node_id));
+      }
+    }
+  }
+
+  return model_ptr;
+}
+
+Metadata ParseMetadata(const char* metadata_json) {
+  Metadata metadata;
+
+  rapidjson::Document metadata_obj;
+  metadata_obj.Parse(metadata_json);
+  TREELITE_CHECK(!metadata_obj.HasParseError())
+    << "Error when parsing JSON config: offset " << metadata_obj.GetErrorOffset()
+    << ", " << rapidjson::GetParseError_En(metadata_obj.GetParseError());
+  TREELITE_CHECK(metadata_obj.IsObject()) << "JSON string must have an object at the root level";
+
+  metadata.num_tree = ExpectInt(metadata_obj, "num_tree");
+  TREELITE_CHECK_GT(metadata.num_tree, 0) << "num_tree must be positive";
+  metadata.num_feature = ExpectInt(metadata_obj, "num_feature");
+  TREELITE_CHECK_GT(metadata.num_feature, 0) << "num_feature must be positive";
+  metadata.average_tree_output = ExpectBool(metadata_obj, "average_tree_output");
+  metadata.task_type = StringToTaskType(ExpectString(metadata_obj, "task_type"));
+  metadata.comparison_op = LookupOperatorByName(ExpectString(metadata_obj, "comparison_op"));
+
+  auto task_param_obj = ExpectObject(metadata_obj, "task_param");
+  metadata.task_param.output_type = TaskParam::OutputType::kFloat;
+  metadata.task_param.grove_per_class = ExpectBool(task_param_obj, "grove_per_class");
+  metadata.task_param.num_class = ExpectUint(task_param_obj, "num_class");
+  metadata.task_param.leaf_vector_size = ExpectUint(task_param_obj, "leaf_vector_size");
+
+  auto model_param_obj = ExpectObject(metadata_obj, "model_param");
+  std::string pred_transform = ExpectString(model_param_obj, "pred_transform");
+  constexpr std::size_t max_pred_transform_len = sizeof(metadata.model_param.pred_transform) - 1;
+  TREELITE_CHECK_LE(pred_transform.length(), max_pred_transform_len)
+    << "pred_transform cannot be longer than " << max_pred_transform_len << " characters";
+  std::strncpy(metadata.model_param.pred_transform, pred_transform.c_str(), max_pred_transform_len);
+  metadata.model_param.sigmoid_alpha = ExpectFloat(model_param_obj, "sigmoid_alpha");
+  metadata.model_param.ratio_c = ExpectFloat(model_param_obj, "ratio_c");
+  metadata.model_param.global_bias = ExpectFloat(model_param_obj, "global_bias");
+
+  return metadata;
+}
+
+}  // namespace treelite::frontend

--- a/src/json_serializer.cc
+++ b/src/json_serializer.cc
@@ -70,7 +70,7 @@ void WriteNode(WriterType& writer,
     } else if (split_type == treelite::SplitFeatureType::kCategorical) {
       writer.Key("categories_list_right_child");
       writer.Bool(tree.CategoriesListRightChild(node_id));
-      writer.Key("matching_categories");
+      writer.Key("categories_list");
       writer.StartArray();
       for (uint32_t e : tree.MatchingCategories(node_id)) {
         writer.Uint(e);


### PR DESCRIPTION
Create a new module `treelite.experimental.model_builder`, to eventually replace `treelite.ModelBuilder`.

Characteristics
* Fast, because it does not traverse trees while importing
* Only one call to the C API function (whereas the old model builder makes lots of calls to the C layer)
* Use of Python dataclasses makes it intuitive to build models
* The user must order tree nodes in breath-first order. Undefined behavior may result if nodes are ordered differently.

Current limitations
* All nodes currently share the same comparison op. It should be possible to specify separate comparison op for test nodes.
* User should be able to specify `nthread` when creating node objects. 