### PR TITLE
Add warning when loading from newer minor version

### DIFF
--- a/include/treelite/c_api_common.h
+++ b/include/treelite/c_api_common.h
@@ -37,13 +37,21 @@ typedef void* DMatrixHandle;
 TREELITE_DLL const char* TreeliteGetLastError(void);
 
 /*!
- * \brief register callback function for LOG(INFO) messages -- helpful messages
+ * \brief Register callback function for LOG(INFO) messages -- helpful messages
  *        that are not errors.
- * Note: this function can be called by multiple threads. The callback function
+ * Note: This function can be called by multiple threads. The callback function
  *       will run on the thread that registered it
  * \return 0 for success, -1 for failure
  */
 TREELITE_DLL int TreeliteRegisterLogCallback(void (*callback)(const char*));
+
+/*!
+ * \brief Register callback function for LOG(WARNING) messages
+ * Note: This function can be called by multiple threads. The callback function
+ *       will run on the thread that registered it
+ * \return 0 for success, -1 for failure
+ */
+TREELITE_DLL int TreeliteRegisterWarningCallback(void (*callback)(const char*));
 
 /*!
  * \brief Get the version string for the Treelite library.

--- a/include/treelite/tree_impl.h
+++ b/include/treelite/tree_impl.h
@@ -878,14 +878,21 @@ Model::DeserializeTemplate(HeaderPrimitiveFieldHandlerFunc header_primitive_fiel
   header_primitive_field_handler(&minor_ver);
   header_primitive_field_handler(&patch_ver);
   if (major_ver != TREELITE_VER_MAJOR && !(major_ver == 2 && minor_ver == 4)) {
-    std::ostringstream oss;
-    oss << "Cannot deserialize model from a different major Treelite version or "
+    TREELITE_LOG(FATAL)
+        << "Cannot load model from a different major Treelite version or "
         << "a version before 2.4.0." << std::endl
         << "Currently running Treelite version " << TREELITE_VER_MAJOR << "."
         << TREELITE_VER_MINOR << "." << TREELITE_VER_PATCH << std::endl
         << "The model checkpoint was generated from Treelite version " << major_ver << "."
         << minor_ver << "." << patch_ver;
-    throw Error(oss.str());
+  } else if (major_ver == TREELITE_VER_MAJOR && minor_ver > TREELITE_VER_MINOR) {
+    TREELITE_LOG(WARNING)
+        << "The model you are loading originated from a newer Treelite version; some "
+        << "functionalities may be unavailable." << std::endl
+        << "Currently running Treelite version " << TREELITE_VER_MAJOR << "."
+        << TREELITE_VER_MINOR << "." << TREELITE_VER_PATCH << std::endl
+        << "The model checkpoint was generated from Treelite version " << major_ver << "."
+        << minor_ver << "." << patch_ver;
   }
   header_primitive_field_handler(&threshold_type);
   header_primitive_field_handler(&leaf_output_type);

--- a/python/treelite/core.py
+++ b/python/treelite/core.py
@@ -6,7 +6,7 @@ import sys
 import os
 import ctypes
 
-from .util import py_str, _log_callback, TreeliteError
+from .util import py_str, _log_callback, _warn_callback, TreeliteError
 from .libpath import find_lib_path, TreeliteLibraryNotFound
 
 
@@ -18,8 +18,11 @@ def _load_lib():
         os.add_dll_directory(os.path.join(os.path.normpath(sys.prefix), 'Library', 'bin'))
     lib = ctypes.cdll.LoadLibrary(lib_path[0])
     lib.TreeliteGetLastError.restype = ctypes.c_char_p
-    lib.callback = _log_callback
-    if lib.TreeliteRegisterLogCallback(lib.callback) != 0:
+    lib.log_callback = _log_callback
+    lib.warn_callback = _warn_callback
+    if lib.TreeliteRegisterLogCallback(lib.log_callback) != 0:
+        raise TreeliteError(py_str(lib.TreeliteGetLastError()))
+    if lib.TreeliteRegisterWarningCallback(lib.warn_callback) != 0:
         raise TreeliteError(py_str(lib.TreeliteGetLastError()))
     return lib
 

--- a/python/treelite/util.py
+++ b/python/treelite/util.py
@@ -5,6 +5,8 @@ Miscellaneous utilities
 import inspect
 import ctypes
 import time
+import warnings
+
 import numpy as np
 
 _CTYPES_TYPE_TABLE = {
@@ -51,7 +53,13 @@ def py_str(string):
 @ctypes.CFUNCTYPE(None, ctypes.c_char_p)
 def _log_callback(msg: bytes) -> None:
     """Redirect logs from native library into Python console"""
-    print("{0:s}".format(py_str(msg)))
+    print(py_str(msg))
+
+
+@ctypes.CFUNCTYPE(None, ctypes.c_char_p)
+def _warn_callback(msg: bytes) -> None:
+    """Redirect warnings from native library into Python console"""
+    warnings.warn(py_str(msg))
 
 
 def lineno():

--- a/src/c_api/c_api_common.cc
+++ b/src/c_api/c_api_common.cc
@@ -16,7 +16,14 @@ using namespace treelite;
 int TreeliteRegisterLogCallback(void (*callback)(const char*)) {
   API_BEGIN();
   LogCallbackRegistry* registry = LogCallbackRegistryStore::Get();
-  registry->Register(callback);
+  registry->RegisterCallBackLogInfo(callback);
+  API_END();
+}
+
+int TreeliteRegisterWarningCallback(void (*callback)(const char*)) {
+  API_BEGIN();
+    LogCallbackRegistry* registry = LogCallbackRegistryStore::Get();
+    registry->RegisterCallBackLogWarning(callback);
   API_END();
 }
 

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2021 by Contributors
+ * Copyright (c) 2017-2023 by Contributors
  * \file logging.cc
  * \author Hyunsu Cho
  * \brief logging facility for treelite
@@ -7,9 +7,18 @@
 
 #include <treelite/logging.h>
 
-// Override logging mechanism
-void treelite::LogMessage::Log(const std::string& msg) {
-  const treelite::LogCallbackRegistry* registry = treelite::LogCallbackRegistryStore::Get();
-  auto callback = registry->Get();
+namespace treelite {
+
+void LogMessage::Log(const std::string& msg) {
+  const LogCallbackRegistry *registry = LogCallbackRegistryStore::Get();
+  auto callback = registry->GetCallbackLogInfo();
   callback(msg.c_str());
 }
+
+void LogMessageWarning::Log(const std::string& msg) {
+  const LogCallbackRegistry *registry = LogCallbackRegistryStore::Get();
+  auto callback = registry->GetCallbackLogWarning();
+  callback(msg.c_str());
+}
+
+}  // namespace treelite


### PR DESCRIPTION
Also propagate C++ warnings as Python warnings too.

Closes https://github.com/triton-inference-server/fil_backend/issues/288
Closes https://github.com/dmlc/treelite/issues/441

Example of warning:
```
C:\Users\noble\Desktop\workspace\treelite\python\treelite\util.py:62: UserWarning:
    [21:54:54] C:\Users\noble\Desktop\workspace\treelite\src\c_api\c_api.cc:121:
    TreeliteLoadLightGBMModel() is deprecated. Please use TreeliteLoadLightGBMModelEx() instead.
```