### PR TITLE
Add tutorial for JSON import

### DIFF
--- a/docs/tutorials/builder.rst
+++ b/docs/tutorials/builder.rst
@@ -1,13 +1,11 @@
 Specifying models using model builder
 =====================================
 
-Since the scope of Treelite is limited to **prediction** only, one must use
-other machine learning packages to **train** decision tree ensemble models. In
-this document, we will show how to import an ensemble model that had been
-trained elsewhere.
-
-**Using XGBoost or LightGBM for training?** Read :doc:`this document <import>`
-instead.
+Treelite supports loading models from major tree libraries, such as XGBoost and
+scikit-learn. However, you may want to use models trained by other tree
+libraries that are not directly supported by Treelite. The model builder is
+useful in this use case. (Alternatively, consider
+:doc:`importing from JSON <json_import>` instead.)
 
 .. contents:: Contents
   :local:
@@ -24,7 +22,7 @@ tree ensembles programmatically. Each tree ensemble is represented as follows:
 * Each :py:class:`~treelite.ModelBuilder` object is a **list** of
   :py:class:`~treelite.ModelBuilder.Tree` objects.
 
-A toy example
+Toy example
 -------------
 Consider the following tree ensemble, consisting of two regression trees:
 
@@ -85,7 +83,7 @@ Consider the following tree ensemble, consisting of two regression trees:
 
 .. note:: Provision for missing data: default directions
 
-  Decision trees in treelite accomodate `missing data
+  Decision trees in Treelite accomodate `missing data
   <https://en.wikipedia.org/wiki/Missing_data>`_ by indicating the
   **default direction** for every test node. In the diagram above, the
   default direction is indicated by label "Missing." For instance, the root node

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -14,3 +14,4 @@ This page lists tutorials about Treelite.
  deploy
  deploy_java
  builder
+ json_import

--- a/docs/tutorials/json_import.rst
+++ b/docs/tutorials/json_import.rst
@@ -3,7 +3,7 @@ Specifying models using JSON string
 
 Treelite supports loading models from major tree libraries, such as XGBoost and
 scikit-learn. However, you may want to use models trained by other tree
-libraries that are not directly supported by Treelite. The model builder is
+libraries that are not directly supported by Treelite. The JSON importer is
 useful in this use case. (Alternatively, consider
 :doc:`using the model builder <builder>` instead.)
 
@@ -20,7 +20,7 @@ Consider the following tree ensemble, consisting of two regression trees:
 
   from graphviz import Source
   source = r"""
-    digraph toy1_1 {
+    digraph toy1 {
       graph [fontname = "helvetica"];
       node [fontname = "helvetica"];
       edge [fontname = "helvetica"];
@@ -43,7 +43,7 @@ Consider the following tree ensemble, consisting of two regression trees:
 
   from graphviz import Source
   source = r"""
-    digraph toy2_1 {
+    digraph toy2 {
       graph [fontname = "helvetica"];
       node [fontname = "helvetica"];
       edge [fontname = "helvetica"];

--- a/docs/tutorials/json_import.rst
+++ b/docs/tutorials/json_import.rst
@@ -75,19 +75,16 @@ Consider the following tree ensemble, consisting of two regression trees:
 where each node is assign a **unique integer key**, indicated in :red:`red`.
 Note that integer keys need to be unique only within the same tree.
 
-.. note:: Provision for missing data: default directions
-
-  Decision trees in Treelite accomodate `missing data
-  <https://en.wikipedia.org/wiki/Missing_data>`_ by indicating the
-  **default direction** for every test node. In the diagram above, the
-  default direction is indicated by label "Missing." For instance, the root node
-  of the first tree shown above will send to the left all data points that lack
-  values for feature 0.
-
 You can construct this tree ensemble by calling
 :py:meth:`~treelite.Model.import_from_json` with an appropriately formatted
 JSON string. We will give you the example code first; in the following section,
 we will explain the meaining of each field in the JSON string.
+
+.. note:: :py:meth:`~treelite.Model.dump_as_json` will NOT preserve the JSON string that's passed into :py:meth:`~treelite.Model.import_from_json`
+
+  The operation performed in :py:meth:`~treelite.Model.import_from_json` is strictly one-way.
+  So the output of :py:meth:`~treelite.Model.dump_as_json` will differ from the JSON string
+  you used in calling :py:meth:`~treelite.Model.import_from_json`.
 
 .. code-block:: python
   :linenos:

--- a/docs/tutorials/json_import.rst
+++ b/docs/tutorials/json_import.rst
@@ -98,7 +98,7 @@ we will explain the meaining of each field in the JSON string.
   json_str = """
   {
       "num_feature": 3,
-      "task_type": "BinaryClfRegr",
+      "task_type": "kBinaryClfRegr",
       "average_tree_output": false,
       "task_param": {
           "output_type": "float",

--- a/docs/tutorials/json_import.rst
+++ b/docs/tutorials/json_import.rst
@@ -267,5 +267,5 @@ For the categorical test, the test criterion is in the form of
 
 where the ``categories_list`` defines a (mathematical) set.
 When the test criteron is evaluated to be true, the prediction function
-traverses to the left child (if ``categories_list_right_child=false``)
-or to the right child (if ``categories_list_right_child=true``).
+traverses to the left child node (if ``categories_list_right_child=false``)
+or to the right child node (if ``categories_list_right_child=true``).

--- a/docs/tutorials/json_import.rst
+++ b/docs/tutorials/json_import.rst
@@ -1,0 +1,274 @@
+Specifying models using JSON string
+===================================
+
+Treelite supports loading models from major tree libraries, such as XGBoost and
+scikit-learn. However, you may want to use models trained by other tree
+libraries that are not directly supported by Treelite. The model builder is
+useful in this use case. (Alternatively, consider
+:doc:`using the model builder <builder>` instead.)
+
+.. contents:: Contents
+  :local:
+
+Toy Example
+-----------
+
+Consider the following tree ensemble, consisting of two regression trees:
+
+.. plot::
+  :nofigs:
+
+  from graphviz import Source
+  source = r"""
+    digraph toy1_1 {
+      graph [fontname = "helvetica"];
+      node [fontname = "helvetica"];
+      edge [fontname = "helvetica"];
+      0 [label=<<FONT COLOR="red">0:</FONT> Feature 1 ∈ {1, 2, 4} ?>, shape=box];
+      1 [label=<<FONT COLOR="red">1:</FONT> Feature 2 &lt; -3.0 ?>, shape=box];
+      2 [label=<<FONT COLOR="red">2:</FONT> +0.6>];
+      3 [label=<<FONT COLOR="red">3:</FONT> -0.4>];
+      4 [label=<<FONT COLOR="red">4:</FONT> +1.2>];
+      0 -> 1 [labeldistance=2.0, labelangle=45, headlabel="Yes/Missing           "];
+      0 -> 2 [labeldistance=2.0, labelangle=-45, headlabel="No"];
+      1 -> 3 [labeldistance=2.0, labelangle=45, headlabel="Yes"];
+      1 -> 4 [labeldistance=2.0, labelangle=-45, headlabel="           No/Missing"];
+    }
+  """
+  Source(source, format='png').render('../_static/json_import_toy1', view=False)
+  Source(source, format='svg').render('../_static/json_import_toy1', view=False)
+
+.. plot::
+  :nofigs:
+
+  from graphviz import Source
+  source = r"""
+    digraph toy2_1 {
+      graph [fontname = "helvetica"];
+      node [fontname = "helvetica"];
+      edge [fontname = "helvetica"];
+      0 [label=<<FONT COLOR="red">1:</FONT> Feature 0 &lt; 2.5 ?>, shape=box];
+      1 [label=<<FONT COLOR="red">2:</FONT> +1.6>];
+      2 [label=<<FONT COLOR="red">4:</FONT> Feature 2 &lt; -1.2 ?>, shape=box];
+      3 [label=<<FONT COLOR="red">6:</FONT> +0.1>];
+      4 [label=<<FONT COLOR="red">8:</FONT> -0.3>];
+      0 -> 1 [labeldistance=2.0, labelangle=45, headlabel="Yes"];
+      0 -> 2 [labeldistance=2.0, labelangle=-45, headlabel="           No/Missing"];
+      2 -> 3 [labeldistance=2.0, labelangle=45, headlabel="Yes/Missing           "];
+      2 -> 4 [labeldistance=2.0, labelangle=-45, headlabel="No"];
+    }
+  """
+  Source(source, format='png').render('../_static/json_import_toy2', view=False)
+  Source(source, format='svg').render('../_static/json_import_toy2', view=False)
+
+.. raw:: html
+
+  <p>
+  <img src="../_static/json_import_toy1.svg"
+       onerror="this.src='../_static/json_import_toy1.png'; this.onerror=null;">
+  <img src="../_static/json_import_toy2.svg"
+       onerror="this.src='../_static/json_import_toy2.png'; this.onerror=null;">
+  </p>
+
+.. role:: red
+
+where each node is assign a **unique integer key**, indicated in :red:`red`.
+Note that integer keys need to be unique only within the same tree.
+
+.. note:: Provision for missing data: default directions
+
+  Decision trees in Treelite accomodate `missing data
+  <https://en.wikipedia.org/wiki/Missing_data>`_ by indicating the
+  **default direction** for every test node. In the diagram above, the
+  default direction is indicated by label "Missing." For instance, the root node
+  of the first tree shown above will send to the left all data points that lack
+  values for feature 0.
+
+You can construct this tree ensemble by calling
+:py:meth:`~treelite.Model.import_from_json` with an appropriately formatted
+JSON string. We will give you the example code first; in the following section,
+we will explain the meaining of each field in the JSON string.
+
+.. code-block:: python
+  :linenos:
+  :emphasize-lines: 78
+
+  import treelite
+
+  json_str = """
+  {
+      "num_feature": 3,
+      "task_type": "BinaryClfRegr",
+      "average_tree_output": false,
+      "task_param": {
+          "output_type": "float",
+          "grove_per_class": false,
+          "num_class": 1,
+          "leaf_vector_size": 1
+      },
+      "model_param": {
+          "pred_transform": "identity",
+          "global_bias": 0.0
+      },
+      "trees": [
+          {
+              "root_id": 0,
+              "nodes": [
+                  {
+                      "node_id": 0,
+                      "split_feature_id": 1,
+                      "default_left": true,
+                      "split_type": "categorical",
+                      "categories_list": [1, 2, 4],
+                      "categories_list_right_child": false,
+                      "left_child": 1,
+                      "right_child": 2
+                  },
+                  {
+                      "node_id": 1,
+                      "split_feature_id": 2,
+                      "default_left": false,
+                      "split_type": "numerical",
+                      "comparison_op": "<",
+                      "threshold": -3.0,
+                      "left_child": 3,
+                      "right_child": 4
+                  },
+                  {"node_id": 2, "leaf_value": 0.6},
+                  {"node_id": 3, "leaf_value": -0.4},
+                  {"node_id": 4, "leaf_value": 1.2}
+              ]
+          },
+          {
+              "root_id": 1,
+              "nodes": [
+                  {
+                      "node_id": 1,
+                      "split_feature_id": 0,
+                      "default_left": false,
+                      "split_type": "numerical",
+                      "comparison_op": "<",
+                      "threshold": 2.5,
+                      "left_child": 2,
+                      "right_child": 4
+                  },
+                  {
+                      "node_id": 4,
+                      "split_feature_id": 2,
+                      "default_left": true,
+                      "split_type": "numerical",
+                      "comparison_op": "<",
+                      "threshold": -1.2,
+                      "left_child": 6,
+                      "right_child": 8
+                  },
+                  {"node_id": 2, "leaf_value": 1.6},
+                  {"node_id": 6, "leaf_value": 0.1},
+                  {"node_id": 8, "leaf_value": -0.3}
+              ]
+          }
+      ]
+  }
+  """
+  model = treelite.Model.import_from_json(json_str)
+
+
+Building model components using JSON
+------------------------------------
+
+Model metadata
+^^^^^^^^^^^^^^
+In the beginning, we must specify certain metadata of the model.
+
+* ``num_teature``: Number of features (columns) in the training data
+* ``average_tree_output``: Whether to average the outputs of trees. Set this to
+  True if the model is a random forest.
+* ``task_type`` / ``task_param``: :ref:`Parameters that together define a
+  machine learning task <task_param>`.
+* ``model_param``: :ref:`Other important parameters in the model <model_param>`.
+
+.. _task_param:
+
+Task Parameters: Define a machine learing task
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``task_type`` parameter is closely related to the content of ``task_param``.
+The ``task_param`` object has the following parameters:
+
+* ``output_type``: Type of leaf output. Either ``float`` or ``int``.
+* ``grove_per_class``: Boolean indicating a particular organization of multi-class
+  classifier.
+* ``num_class``: Number of targer classes in a multi-class classifier. Set this
+  to 1 if the model is a binary classifier or a non-classifier.
+* ``leaf_vector_size``: Length of leaf output. A value of 1 indicates scalar output.
+
+The docstring of :cpp:enum:`TaskType` explains the relationship between
+``task_type`` and the parameters in ``task_param``:
+
+.. doxygenenum:: TaskType
+  :project: treelite
+
+.. _model_param:
+
+Other Model Parameters
+~~~~~~~~~~~~~~~~~~~~~~
+The ``model_param`` field contains the parameters described in :doc:`../knobs/model_param`.
+You may safely omit a parameter as long as it has a default value.
+
+Tree nodes
+^^^^^^^^^^
+Each tree object must have ``root_id`` field to indicate which node is the root node.
+
+The ``nodes`` array must have node objects. Each node object must have ``node_id`` field.
+It will also have other fields, depending on the type of the node. A typical leaf node
+will be like this:
+
+.. code-block:: json
+
+  {"node_id": 2, "leaf_value": 0.6}
+
+To output a leaf vector, use a list instead.
+
+.. code-block:: json
+
+  {"node_id": 2, "leaf_value": [0.6, 0.4]}
+
+A typical internal node with numerical test:
+
+.. code-block:: json
+
+  {
+      "node_id": 1,
+      "split_feature_id": 2,
+      "default_left": false,
+      "split_type": "numerical",
+      "comparison_op": "<",
+      "threshold": -3.0,
+      "left_child": 3,
+      "right_child": 4
+  }
+
+A typical internal node with categorical test:
+
+.. code-block:: json
+
+  {
+      "node_id": 0,
+      "split_feature_id": 1,
+      "default_left": true,
+      "split_type": "categorical",
+      "categories_list": [1, 2, 4],
+      "categories_list_right_child": false,
+      "left_child": 1,
+      "right_child": 2
+  }
+
+For the categorical test, the test criterion is in the form of
+
+.. code-block:: none
+
+  [Feature value] \in [categories_list]
+
+where the ``categories_list`` defines a (mathematical) set.
+When the test criteron is evaluated to be true, the prediction function
+traverses to the left child (if ``categories_list_right_child=false``)
+or to the right child (if ``categories_list_right_child=true``).

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -142,8 +142,8 @@ enum class TaskType : uint8_t {
    * are combined via summing or averaging, depending on the value of the [average_tree_output]
    * field. In effect, each tree is casting a set of weighted (fractional) votes for the classes.
    *
-   * An example of kMultiClfProbDistLeaf task type is found in RandomForestClassifier of
-   * scikit-learn.
+   * Examples of kMultiClfProbDistLeaf task type are found in RandomForestClassifier of
+   * scikit-learn and RandomForestClassifier of cuML.
    *
    * The kMultiClfProbDistLeaf task type implies the following constraints on the task parameters:
    * output_type=float, grove_per_class=false, num_class>1, leaf_vector_size=num_class.
@@ -159,8 +159,6 @@ enum class TaskType : uint8_t {
    * with 1 in index [x] and 0 everywhere else, and tree(i) is the output from the i-th tree.
    * Models of type kMultiClfCategLeaf can be converted into the kMultiClfProbDistLeaf type, by
    * converting the output of every leaf node into the equivalent one-hot-encoded vector.
-   *
-   * An example of kMultiClfCategLeaf task type is found in RandomForestClassifier of cuML.
    *
    * The kMultiClfCategLeaf task type implies the following constraints on the task parameters:
    * output_type=int, grove_per_class=false, num_class>1, leaf_vector_size=1.

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -102,7 +102,7 @@ class ContiguousArray {
 /*!
  * \brief Enum type representing the task type.
  *
- * The task type places constraints on the parameters of TaskParameter. See the docstring for each
+ * The task type places constraints on the parameters of TaskParam. See the docstring for each
  * enum constants for more details.
  */
 enum class TaskType : uint8_t {

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -170,22 +170,22 @@ enum class TaskType : uint8_t {
 
 inline std::string TaskTypeToString(TaskType type) {
   switch (type) {
-    case TaskType::kBinaryClfRegr: return "BinaryClfRegr";
-    case TaskType::kMultiClfGrovePerClass: return "MultiClfGrovePerClass";
-    case TaskType::kMultiClfProbDistLeaf: return "MultiClfProbDistLeaf";
-    case TaskType::kMultiClfCategLeaf: return "MultiClfCategLeaf";
+    case TaskType::kBinaryClfRegr: return "kBinaryClfRegr";
+    case TaskType::kMultiClfGrovePerClass: return "kMultiClfGrovePerClass";
+    case TaskType::kMultiClfProbDistLeaf: return "kMultiClfProbDistLeaf";
+    case TaskType::kMultiClfCategLeaf: return "kMultiClfCategLeaf";
     default: return "";
   }
 }
 
 inline TaskType StringToTaskType(const std::string& str) {
-  if (str == "BinaryClfRegr") {
+  if (str == "kBinaryClfRegr") {
     return TaskType::kBinaryClfRegr;
-  } else if (str == "MultiClfGrovePerClass") {
+  } else if (str == "kMultiClfGrovePerClass") {
     return TaskType::kMultiClfGrovePerClass;
-  } else if (str == "MultiClfProbDistLeaf") {
+  } else if (str == "kMultiClfProbDistLeaf") {
     return TaskType::kMultiClfProbDistLeaf;
-  } else if (str == "MultiClfCategLeaf") {
+  } else if (str == "kMultiClfCategLeaf") {
     return TaskType::kMultiClfCategLeaf;
   } else {
     TREELITE_LOG(FATAL) << "Unknown task type: " << str;

--- a/python/treelite/frontend.py
+++ b/python/treelite/frontend.py
@@ -558,7 +558,7 @@ class Model:
         """
         Import a tree ensemble model from a JSON string.
 
-        TODO(hcho3): Add link to JSON spec of a valid Treelite model
+        See :doc:`tutorials/json_import` for details.
 
         Parameters
         ----------

--- a/python/treelite/frontend.py
+++ b/python/treelite/frontend.py
@@ -80,6 +80,13 @@ class Model:
         Dump the model as a JSON string. This is useful for inspecting details of the tree ensemble
         model.
 
+        .. note::
+
+            The operation performed in :py:meth:`~treelite.Model.dump_as_json`
+            is strictly one-way. So the output of
+            :py:meth:`~treelite.Model.dump_as_json` will differ from the JSON
+            string you used in calling :py:meth:`~treelite.Model.import_from_json`.
+
         Parameters
         ----------
         pretty_print : :py:class:`bool <python:bool>`, optional
@@ -559,6 +566,13 @@ class Model:
         Import a tree ensemble model from a JSON string.
 
         See :doc:`tutorials/json_import` for details.
+
+        .. note::
+
+            The operation performed in :py:meth:`~treelite.Model.import_from_json`
+            is strictly one-way. So the output of
+            :py:meth:`~treelite.Model.dump_as_json` will differ from the JSON
+            string you used in calling :py:meth:`~treelite.Model.import_from_json`.
 
         Parameters
         ----------

--- a/src/frontend/json_importer.cc
+++ b/src/frontend/json_importer.cc
@@ -75,6 +75,16 @@ rapidjson::Value::ConstArray ExpectArray(const ObjectType& doc, const char* key)
   return itr->value.GetArray();
 }
 
+template <typename ObjectType>
+void ExpectFloatOptional(const ObjectType& doc, const char* key, float& result) {
+  auto itr = doc.FindMember(key);
+  if (itr != doc.MemberEnd()) {
+    TREELITE_CHECK(itr->value.IsFloat())
+      << "Key \"" << key << "\" must be a single-precision float";
+    result = itr->value.GetFloat();
+  }
+}
+
 treelite::TaskParam ParseTaskParam(const rapidjson::Value::ConstObject& object) {
   treelite::TaskParam param;
   param.output_type = treelite::StringToOutputType(ExpectString(object, "output_type"));
@@ -95,9 +105,9 @@ treelite::ModelParam ParseModelParam(const rapidjson::Value::ConstObject& object
     << "pred_transform cannot be longer than " << max_pred_transform_len << " characters";
   std::strncpy(param.pred_transform, pred_transform.c_str(), max_pred_transform_len);
 
-  param.sigmoid_alpha = ExpectFloat(object, "sigmoid_alpha");
-  param.ratio_c = ExpectFloat(object, "ratio_c");
-  param.global_bias = ExpectFloat(object, "global_bias");
+  ExpectFloatOptional(object, "sigmoid_alpha", param.sigmoid_alpha);
+  ExpectFloatOptional(object, "ratio_c", param.ratio_c);
+  ExpectFloatOptional(object, "global_bias", param.global_bias);
 
   return param;
 }

--- a/src/frontend/json_importer.cc
+++ b/src/frontend/json_importer.cc
@@ -126,8 +126,8 @@ void ParseInternalNode(
   } else if (split_type == treelite::SplitFeatureType::kCategorical) {  // categorical split
     const bool categories_list_right_child = ExpectBool(node, "categories_list_right_child");
     std::vector<std::uint32_t> categories_list;
-    for (const auto& e : ExpectArray(node, "matching_categories")) {
-      TREELITE_CHECK(e.IsUint()) << "Expected an unsigned in matching_categories field";
+    for (const auto& e : ExpectArray(node, "categories_list")) {
+      TREELITE_CHECK(e.IsUint()) << "Expected an unsigned integer in categories_list field";
       categories_list.push_back(e.GetUint());
     }
     tree.SetCategoricalSplit(new_node_id, split_index, default_left, categories_list,

--- a/src/json_serializer.cc
+++ b/src/json_serializer.cc
@@ -70,7 +70,7 @@ void WriteNode(WriterType& writer,
     } else if (split_type == treelite::SplitFeatureType::kCategorical) {
       writer.Key("categories_list_right_child");
       writer.Bool(tree.CategoriesListRightChild(node_id));
-      writer.Key("matching_categories");
+      writer.Key("categories_list");
       writer.StartArray();
       for (uint32_t e : tree.MatchingCategories(node_id)) {
         writer.Uint(e);

--- a/tests/cpp/test_serializer.cc
+++ b/tests/cpp/test_serializer.cc
@@ -263,7 +263,7 @@ void PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit(
   TestRoundTrip(model.get());
 
   /* Test correctness of JSON dump */
-  std::string matching_categories_str;
+  std::string categories_list_str;
   {
     std::ostringstream oss;
     rapidjson::OStreamWrapper os_wrapper(oss);
@@ -273,7 +273,7 @@ void PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit(
       writer.Uint(static_cast<unsigned int>(e));
     }
     writer.EndArray();
-    matching_categories_str = oss.str();
+    categories_list_str = oss.str();
   }
   std::string expected_json_dump_str = fmt::format(R"JSON(
   {{
@@ -301,7 +301,7 @@ void PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit(
                     "default_left": false,
                     "split_type": "categorical",
                     "categories_list_right_child": false,
-                    "matching_categories": {matching_categories},
+                    "categories_list": {categories_list},
                     "left_child": 1,
                     "right_child": 2
                 }}, {{
@@ -316,7 +316,7 @@ void PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit(
   )JSON",
     "leaf_value0"_a = static_cast<LeafOutputType>(2),
     "leaf_value1"_a = static_cast<LeafOutputType>(3),
-    "matching_categories"_a = matching_categories_str
+    "categories_list"_a = categories_list_str
   );
 
   rapidjson::Document json_dump;
@@ -416,7 +416,7 @@ void PyBufferInterfaceRoundTrip_TreeDepth2() {
                     "default_left": true,
                     "split_type": "categorical",
                     "categories_list_right_child": false,
-                    "matching_categories": [0, 1],
+                    "categories_list": [0, 1],
                     "left_child": 3,
                     "right_child": 4
                 }}, {{
@@ -425,7 +425,7 @@ void PyBufferInterfaceRoundTrip_TreeDepth2() {
                     "default_left": true,
                     "split_type": "categorical",
                     "categories_list_right_child": false,
-                    "matching_categories": [0],
+                    "categories_list": [0],
                     "left_child": 5,
                     "right_child": 6
                 }}, {{
@@ -459,7 +459,7 @@ void PyBufferInterfaceRoundTrip_TreeDepth2() {
                     "default_left": true,
                     "split_type": "categorical",
                     "categories_list_right_child": false,
-                    "matching_categories": [0, 1],
+                    "categories_list": [0, 1],
                     "left_child": 3,
                     "right_child": 4
                 }}, {{
@@ -468,7 +468,7 @@ void PyBufferInterfaceRoundTrip_TreeDepth2() {
                     "default_left": true,
                     "split_type": "categorical",
                     "categories_list_right_child": false,
-                    "matching_categories": [0],
+                    "categories_list": [0],
                     "left_child": 5,
                     "right_child": 6
                 }}, {{
@@ -502,7 +502,7 @@ void PyBufferInterfaceRoundTrip_TreeDepth2() {
                     "default_left": true,
                     "split_type": "categorical",
                     "categories_list_right_child": false,
-                    "matching_categories": [0, 1],
+                    "categories_list": [0, 1],
                     "left_child": 3,
                     "right_child": 4
                 }}, {{
@@ -511,7 +511,7 @@ void PyBufferInterfaceRoundTrip_TreeDepth2() {
                     "default_left": true,
                     "split_type": "categorical",
                     "categories_list_right_child": false,
-                    "matching_categories": [0],
+                    "categories_list": [0],
                     "left_child": 5,
                     "right_child": 6
                 }}, {{

--- a/tests/cpp/test_serializer.cc
+++ b/tests/cpp/test_serializer.cc
@@ -82,7 +82,7 @@ void PyBufferInterfaceRoundTrip_TreeStump() {
   std::string expected_json_dump_str = fmt::format(R"JSON(
   {{
     "num_feature": 2,
-    "task_type": "BinaryClfRegr",
+    "task_type": "kBinaryClfRegr",
     "average_tree_output": false,
     "task_param": {{
         "output_type": "float",
@@ -171,7 +171,7 @@ void PyBufferInterfaceRoundTrip_TreeStumpLeafVec() {
   std::string expected_json_dump_str = fmt::format(R"JSON(
   {{
     "num_feature": 2,
-    "task_type": "MultiClfProbDistLeaf",
+    "task_type": "kMultiClfProbDistLeaf",
     "average_tree_output": true,
     "task_param": {{
         "output_type": "float",
@@ -278,7 +278,7 @@ void PyBufferInterfaceRoundTrip_TreeStumpCategoricalSplit(
   std::string expected_json_dump_str = fmt::format(R"JSON(
   {{
     "num_feature": 2,
-    "task_type": "BinaryClfRegr",
+    "task_type": "kBinaryClfRegr",
     "average_tree_output": false,
     "task_param": {{
         "output_type": "float",
@@ -384,7 +384,7 @@ void PyBufferInterfaceRoundTrip_TreeDepth2() {
   std::string expected_json_dump_str = fmt::format(R"JSON(
   {{
     "num_feature": 2,
-    "task_type": "BinaryClfRegr",
+    "task_type": "kBinaryClfRegr",
     "average_tree_output": false,
     "task_param": {{
         "output_type": "float",

--- a/tests/python/test_json_import.py
+++ b/tests/python/test_json_import.py
@@ -1,0 +1,74 @@
+import json
+
+import numpy as np
+
+import treelite
+
+
+def test_json_import():
+    """Test ability to add and remove nodes"""
+    model_obj = {
+        "num_feature": 3,
+        "task_type": "BinaryClfRegr",
+        "average_tree_output": False,
+        "task_param": {
+            "output_type": "float",
+            "grove_per_class": False,
+            "num_class": 1,
+            "leaf_vector_size": 1,
+        },
+        "model_param": {"pred_transform": "identity", "global_bias": 0.0},
+        "trees": [
+            {
+                "root_id": 5,
+                "nodes": [
+                    {
+                        "node_id": 5,
+                        "split_feature_id": 1,
+                        "default_left": True,
+                        "split_type": "categorical",
+                        "categories_list": [1, 2, 4],
+                        "categories_list_right_child": False,
+                        "left_child": 20,
+                        "right_child": 10,
+                    },
+                    {"node_id": 20, "leaf_value": 2.0},
+                    {
+                        "node_id": 10,
+                        "split_feature_id": 0,
+                        "default_left": False,
+                        "split_type": "numerical",
+                        "comparison_op": "<=",
+                        "threshold": 0.5,
+                        "left_child": 7,
+                        "right_child": 8,
+                    },
+                    {"node_id": 7, "leaf_value": 0.0},
+                    {"node_id": 8, "leaf_value": 1.0},
+                ],
+            }
+        ],
+    }
+    model_json = json.dumps(model_obj)
+
+    model = treelite.Model.import_from_json(model_json)
+    assert model.num_feature == 3
+    assert model.num_class == 1
+    assert model.num_tree == 1
+
+    for f0 in [-0.5, 0.5, 1.5, np.nan]:
+        for f1 in [0, 1, 2, 3, 4, np.nan]:
+            for f2 in [-1.0, -0.5, 1.0, np.nan]:
+                x = np.array([[f0, f1, f2]], dtype=np.float32)
+                pred = treelite.gtil.predict(model, x)
+                if f1 in [1, 2, 4] or np.isnan(f1):
+                    expected_pred = 2.0
+                elif f0 <= 0.5 and not np.isnan(f0):
+                    expected_pred = 0.0
+                else:
+                    expected_pred = 1.0
+                if pred != expected_pred:
+                    raise ValueError(
+                        f"Prediction wrong for f0={f0}, f1={f1}, f2={f2}: "
+                        + f"expected_pred = {expected_pred} vs actual_pred = {pred}"
+                    )

--- a/tests/python/test_json_import.py
+++ b/tests/python/test_json_import.py
@@ -1,23 +1,41 @@
 import json
 
 import numpy as np
+import pytest
 
 import treelite
 
 
-def test_json_import():
-    """Test ability to add and remove nodes"""
+@pytest.mark.parametrize("use_vector_leaf", [True, False])
+def test_json_import(use_vector_leaf):
+    """Test JSON import feature"""
+    if use_vector_leaf:
+        task_type = "MultiClfProbDistLeaf"
+        num_class = 3
+        leaf_vector_size = 3
+        pred_transform = "softmax"
+    else:
+        task_type = "BinaryClfRegr"
+        num_class = 1
+        leaf_vector_size = 1
+        pred_transform = "sigmoid"
+
+    def get_leaf_value(leaf_val):
+        if use_vector_leaf:
+            return [leaf_val] * leaf_vector_size
+        return leaf_val
+
     model_obj = {
         "num_feature": 3,
-        "task_type": "BinaryClfRegr",
+        "task_type": task_type,
         "average_tree_output": False,
         "task_param": {
             "output_type": "float",
             "grove_per_class": False,
-            "num_class": 1,
-            "leaf_vector_size": 1,
+            "num_class": num_class,
+            "leaf_vector_size": leaf_vector_size,
         },
-        "model_param": {"pred_transform": "identity", "global_bias": 0.0},
+        "model_param": {"pred_transform": pred_transform, "global_bias": 0.0},
         "trees": [
             {
                 "root_id": 5,
@@ -32,7 +50,7 @@ def test_json_import():
                         "left_child": 20,
                         "right_child": 10,
                     },
-                    {"node_id": 20, "leaf_value": 2.0},
+                    {"node_id": 20, "leaf_value": get_leaf_value(2.0)},
                     {
                         "node_id": 10,
                         "split_feature_id": 0,
@@ -43,8 +61,8 @@ def test_json_import():
                         "left_child": 7,
                         "right_child": 8,
                     },
-                    {"node_id": 7, "leaf_value": 0.0},
-                    {"node_id": 8, "leaf_value": 1.0},
+                    {"node_id": 7, "leaf_value": get_leaf_value(0.0)},
+                    {"node_id": 8, "leaf_value": get_leaf_value(1.0)},
                 ],
             }
         ],
@@ -53,7 +71,7 @@ def test_json_import():
 
     model = treelite.Model.import_from_json(model_json)
     assert model.num_feature == 3
-    assert model.num_class == 1
+    assert model.num_class == num_class
     assert model.num_tree == 1
 
     for f0 in [-0.5, 0.5, 1.5, np.nan]:
@@ -62,12 +80,12 @@ def test_json_import():
                 x = np.array([[f0, f1, f2]], dtype=np.float32)
                 pred = treelite.gtil.predict(model, x)
                 if f1 in [1, 2, 4] or np.isnan(f1):
-                    expected_pred = 2.0
+                    expected_pred = get_leaf_value(2.0)
                 elif f0 <= 0.5 and not np.isnan(f0):
-                    expected_pred = 0.0
+                    expected_pred = get_leaf_value(0.0)
                 else:
-                    expected_pred = 1.0
-                if pred != expected_pred:
+                    expected_pred = get_leaf_value(1.0)
+                if np.array_equal(pred, expected_pred):
                     raise ValueError(
                         f"Prediction wrong for f0={f0}, f1={f1}, f2={f2}: "
                         + f"expected_pred = {expected_pred} vs actual_pred = {pred}"

--- a/tests/python/test_json_import.py
+++ b/tests/python/test_json_import.py
@@ -10,12 +10,12 @@ import treelite
 def test_json_import(use_vector_leaf):
     """Test JSON import feature"""
     if use_vector_leaf:
-        task_type = "MultiClfProbDistLeaf"
+        task_type = "kMultiClfProbDistLeaf"
         num_class = 3
         leaf_vector_size = 3
         pred_transform = "softmax"
     else:
-        task_type = "BinaryClfRegr"
+        task_type = "kBinaryClfRegr"
         num_class = 1
         leaf_vector_size = 1
         pred_transform = "sigmoid"

--- a/tests/python/test_json_import.py
+++ b/tests/python/test_json_import.py
@@ -1,3 +1,4 @@
+"""Test importing from JSON"""
 import json
 
 import numpy as np


### PR DESCRIPTION
Closes #453 

Also:
* Allow users to specify arbitrary node IDs; to list nodes in arbitrary order.
* Some model parameter are made optional
* Rename `matching_categories` -> `categories_list`, to be consistent with `categories_list_right_child`
* Add a pytest for JSON import 