### PR TITLE
[CI] Use Python 3.8

### DIFF
--- a/tests/ci_build/Dockerfile.cpu
+++ b/tests/ci_build/Dockerfile.cpu
@@ -21,7 +21,7 @@ ENV CPP=/opt/rh/devtoolset-8/root/usr/bin/cpp
 
 # Install Python packages
 RUN \
-    conda install -y -c conda-forge python=3.7 numpy pytest scipy scikit-learn wheel pandas pip
+    conda install -y -c conda-forge python=3.8 numpy pytest scipy scikit-learn wheel pandas pip
 
 ENV GOSU_VERSION 1.10
 


### PR DESCRIPTION
Python 3.7 is close to EOL, and some packages dropped support for it. As a result, the CI is experiencing a dependency conflict: https://github.com/dmlc/treelite/actions/runs/4794726975/jobs/8528429980