### PR TITLE
Rename byte serializer

### DIFF
--- a/include/treelite/c_api.h
+++ b/include/treelite/c_api.h
@@ -533,25 +533,25 @@ TREELITE_DLL int TreeliteSerializeModelToFile(ModelHandle handle, const char* fi
 TREELITE_DLL int TreeliteDeserializeModelFromFile(const char* filename, ModelHandle* out);
 
 /*!
- * \brief Serialize (persist) a model object to a (binary) string.
+ * \brief Serialize (persist) a model object to a byte sequence
  * \param handle Handle to the model object
- * \param out_str String containing serialized model
- * \param out_str_len Length of out_str
+ * \param out_bytes Byte sequence containing serialized model
+ * \param out_bytes_len Length of out_bytes
  * \return 0 for success, -1 for failure
  */
-TREELITE_DLL int TreeliteSerializeModelToString(
-    ModelHandle handle, const char** out_str, size_t* out_str_len);
+TREELITE_DLL int TreeliteSerializeModelToBytes(
+    ModelHandle handle, const char** out_bytes, size_t* out_bytes_len);
 
 /*!
- * \brief Deserialize (load) a model object from disk
- * \param str String containing serialized model. The string should be created by a call to
- *            \ref TreeliteSerializeModelToString.
- * \param str_len Length of str
+ * \brief Deserialize (load) a model object from a byte sequence
+ * \param bytes Byte sequence containing serialized model. The string should be created by a call to
+ *              \ref TreeliteSerializeModelToBytes.
+ * \param bytes_len Length of bytes
  * \param out Handle to the model object
  * \return 0 for success, -1 for failure
  */
-TREELITE_DLL int TreeliteDeserializeModelFromString(
-    const char* str, size_t str_len, ModelHandle* out);
+TREELITE_DLL int TreeliteDeserializeModelFromBytes(
+    const char* bytes, size_t bytes_len, ModelHandle* out);
 
 /*!
  * \brief Concatenate multiple model objects into a single model object by copying

--- a/python/treelite/frontend.py
+++ b/python/treelite/frontend.py
@@ -85,11 +85,11 @@ class Model:
             Please see :doc:`/notes-on-serialization`.
         """
         char_ptr_t = ctypes.POINTER(ctypes.c_char)
-        out_str = char_ptr_t()
-        out_str_len = ctypes.c_size_t()
-        _check_call(_LIB.TreeliteSerializeModelToString(
-            self.handle, ctypes.byref(out_str), ctypes.byref(out_str_len)))
-        return ctypes.string_at(out_str, out_str_len.value)
+        out_bytes = char_ptr_t()
+        out_bytes_len = ctypes.c_size_t()
+        _check_call(_LIB.TreeliteSerializeModelToBytes(
+            self.handle, ctypes.byref(out_bytes), ctypes.byref(out_bytes_len)))
+        return ctypes.string_at(out_bytes, out_bytes_len.value)
 
     def dump_as_json(self, *, pretty_print=True):
         """
@@ -168,7 +168,7 @@ class Model:
         handle = ctypes.c_void_p()
         model_bytes_len = len(model_bytes)
         buffer = ctypes.create_string_buffer(model_bytes, model_bytes_len)
-        _check_call(_LIB.TreeliteDeserializeModelFromString(
+        _check_call(_LIB.TreeliteDeserializeModelFromBytes(
             ctypes.POINTER(ctypes.c_char)(buffer),
             ctypes.c_size_t(model_bytes_len),
             ctypes.byref(handle)))

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -347,7 +347,8 @@ int TreeliteDeserializeModelFromFile(const char* filename, ModelHandle* out) {
   API_END();
 }
 
-int TreeliteSerializeModelToString(ModelHandle handle, const char** out_str, size_t* out_str_len) {
+int TreeliteSerializeModelToBytes(ModelHandle handle, const char** out_bytes,
+                                  size_t* out_bytes_len) {
   API_BEGIN();
   std::ostringstream oss;
   oss.exceptions(std::ios::failbit | std::ios::badbit);  // throw exception on failure
@@ -356,14 +357,14 @@ int TreeliteSerializeModelToString(ModelHandle handle, const char** out_str, siz
 
   std::string& ret_str = TreeliteAPIThreadLocalStore::Get()->ret_str;
   ret_str = oss.str();
-  *out_str = ret_str.data();
-  *out_str_len = ret_str.length();
+  *out_bytes = ret_str.data();
+  *out_bytes_len = ret_str.length();
   API_END();
 }
 
-int TreeliteDeserializeModelFromString(const char* str, size_t str_len, ModelHandle* out) {
+int TreeliteDeserializeModelFromBytes(const char* bytes, size_t bytes_len, ModelHandle* out) {
   API_BEGIN();
-  std::istringstream iss(std::string(str, str_len));
+  std::istringstream iss(std::string(bytes, bytes_len));
   iss.exceptions(std::ios::failbit | std::ios::badbit);  // throw exception on failure
   std::unique_ptr<Model> model = Model::DeserializeFromStream(iss);
   *out = static_cast<ModelHandle>(model.release());


### PR DESCRIPTION
Don't refer to strings; refer to byte sequences instead