### PR TITLE
Replace deprecated pkg_resources

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -268,7 +268,7 @@ if __name__ == '__main__':
     setup(name='treelite',
           version=version,
           description='Treelite: model compiler for decision trees',
-          install_requires=['numpy', 'scipy'],
+          install_requires=['numpy', 'scipy', 'packaging'],
           ext_modules=[CMakeExtension('libtreelite')],
           cmdclass={
               'build_ext': BuildExt,

--- a/python/treelite/contrib/msvc.py
+++ b/python/treelite/contrib/msvc.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import as _abs
 import os
 import glob
 import re
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 from .util import _create_shared_base, _libext
 
 LIBEXT = _libext()

--- a/python/treelite/frontend.py
+++ b/python/treelite/frontend.py
@@ -10,7 +10,7 @@ import json
 from tempfile import TemporaryDirectory
 from typing import Union, List, Optional
 
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 import numpy as np
 


### PR DESCRIPTION
```
pkg_resources\__init__.py:121: DeprecationWarning: pkg_resources is deprecated as an API
    warnings.warn("pkg_resources is deprecated as an API", DeprecationWarning)
```