### PR TITLE
Use std::variant in treelite::Model

### DIFF
--- a/include/treelite/typeinfo.h
+++ b/include/treelite/typeinfo.h
@@ -96,65 +96,6 @@ inline auto DispatchWithTypeInfo(TypeInfo type, Args&&... args) {
   return Dispatcher<double>::Dispatch(std::forward<Args>(args)...);  // avoid missing return error
 }
 
-/*!
- * \brief Given the types for thresholds and leaf outputs, validate that they consist of a valid
- *        combination for a model and then dispatch a function with the corresponding template args.
- *        More precisely, we shall call Dispatcher<ThresholdType, LeafOutputType>::Dispatch() where
- *        the template args ThresholdType and LeafOutputType correspond to the parameters
- *        `threshold_type` and `leaf_output_type`, respectively.
- * \tparam Dispatcher Function object that takes in two template args.
- *         It must have a Dispatch() static function.
- * \tparam Parameter pack, to forward an arbitrary number of args to Dispatcher::Dispatch()
- * \param threshold_type TypeInfo indicating the type of thresholds
- * \param leaf_output_type TypeInfo indicating the type of leaf outputs
- * \param args Other extra parameters to pass to Dispatcher::Dispatch()
- * \return Whatever that's returned by the dispatcher
- */
-template <template <class, class> class Dispatcher, typename... Args>
-inline auto DispatchWithModelTypes(
-    TypeInfo threshold_type, TypeInfo leaf_output_type, Args&&... args) {
-  auto error_threshold_type = [threshold_type]() {
-    std::ostringstream oss;
-    oss << "Invalid threshold type: " << treelite::TypeInfoToString(threshold_type);
-    return oss.str();
-  };
-  auto error_leaf_output_type = [threshold_type, leaf_output_type]() {
-    std::ostringstream oss;
-    oss << "Cannot use leaf output type " << treelite::TypeInfoToString(leaf_output_type)
-        << " with threshold type " << treelite::TypeInfoToString(threshold_type);
-    return oss.str();
-  };
-  switch (threshold_type) {
-  case treelite::TypeInfo::kFloat32:
-    switch (leaf_output_type) {
-    case treelite::TypeInfo::kUInt32:
-      return Dispatcher<float, uint32_t>::Dispatch(std::forward<Args>(args)...);
-    case treelite::TypeInfo::kFloat32:
-      return Dispatcher<float, float>::Dispatch(std::forward<Args>(args)...);
-    default:
-      throw Error(error_leaf_output_type());
-      break;
-    }
-    break;
-  case treelite::TypeInfo::kFloat64:
-    switch (leaf_output_type) {
-    case treelite::TypeInfo::kUInt32:
-      return Dispatcher<double, uint32_t>::Dispatch(std::forward<Args>(args)...);
-    case treelite::TypeInfo::kFloat64:
-      return Dispatcher<double, double>::Dispatch(std::forward<Args>(args)...);
-    default:
-      throw Error(error_leaf_output_type());
-      break;
-    }
-    break;
-  default:
-    throw Error(error_threshold_type());
-    break;
-  }
-  return Dispatcher<double, double>::Dispatch(std::forward<Args>(args)...);
-  // avoid missing return value warning
-}
-
 }  // namespace treelite
 
 #endif  // TREELITE_TYPEINFO_H_

--- a/src/frontend/builder.cc
+++ b/src/frontend/builder.cc
@@ -64,8 +64,7 @@ struct TreeDraft {
 
 }  // anonymous namespace
 
-namespace treelite {
-namespace frontend {
+namespace treelite::frontend {
 
 struct TreeBuilderImpl {
   TreeDraft tree;
@@ -97,9 +96,6 @@ struct ModelBuilderImpl {
     TREELITE_CHECK(leaf_output_type != TypeInfo::kInvalid)
         << "ModelBuilder: leaf_output_type can't be invalid";
   }
-  // Templatized implementation of CommitModel()
-  template <typename ThresholdType, typename LeafOutputType>
-  void CommitModelImpl(ModelImpl<ThresholdType, LeafOutputType>* out_model);
 };
 
 template <typename ThresholdType, typename LeafOutputType>
@@ -404,133 +400,137 @@ void ModelBuilder::DeleteTree(int index) {
 }
 
 std::unique_ptr<Model> ModelBuilder::CommitModel() {
-  std::unique_ptr<Model> model_ptr
-      = Model::Create(pimpl_->threshold_type, pimpl_->leaf_output_type);
-  model_ptr->Dispatch([this](auto& model) { this->pimpl_->CommitModelImpl(&model); });
-  return model_ptr;
-}
-
-template <typename ThresholdType, typename LeafOutputType>
-void ModelBuilderImpl::CommitModelImpl(ModelImpl<ThresholdType, LeafOutputType>* out_model) {
-  ModelImpl<ThresholdType, LeafOutputType>& model = *out_model;
-  model.num_feature = this->num_feature;
-  model.average_tree_output = this->average_tree_output;
-  model.task_param.output_type = TaskParam::OutputType::kFloat;
-  model.task_param.num_class = this->num_class;
+  std::unique_ptr<Model> model = Model::Create(pimpl_->threshold_type, pimpl_->leaf_output_type);
+  model->num_feature = pimpl_->num_feature;
+  model->average_tree_output = pimpl_->average_tree_output;
+  model->task_param.output_type = TaskParam::OutputType::kFloat;
+  model->task_param.num_class = pimpl_->num_class;
   // extra parameters
-  InitParamAndCheck(&model.param, this->cfg);
+  InitParamAndCheck(&model->param, pimpl_->cfg);
 
   // flag to check consistent use of leaf vector
   // 0: no leaf should use leaf vector
   // 1: every leaf should use leaf vector
   // -1: indeterminate
-  int8_t flag_leaf_vector = -1;
+  std::int8_t flag_leaf_vector = -1;
 
-  for (auto const& tree_builder : this->trees) {
-    auto const& _tree = tree_builder.pimpl_->tree;
-    TREELITE_CHECK(_tree.root) << "CommitModel: a tree has no root node";
-    TREELITE_CHECK(_tree.root->status != NodeDraft::Status::kEmpty)
-        << "SetRootNode: cannot set an empty node as root";
-    model.trees.emplace_back();
-    Tree<ThresholdType, LeafOutputType>& tree = model.trees.back();
-    tree.Init();
+  std::visit(
+      [&](auto&& concrete_model) {
+        using ModelType =
+            typename std::remove_const_t<std::remove_reference_t<decltype(concrete_model)>>;
+        using ThresholdType = typename ModelType::threshold_type;
+        using LeafOutputType = typename ModelType::leaf_output_type;
+        for (auto const& tree_builder : pimpl_->trees) {
+          auto const& _tree = tree_builder.pimpl_->tree;
+          TREELITE_CHECK(_tree.root) << "CommitModel: a tree has no root node";
+          TREELITE_CHECK(_tree.root->status != NodeDraft::Status::kEmpty)
+              << "SetRootNode: cannot set an empty node as root";
+          concrete_model.trees.emplace_back();
+          auto& tree = concrete_model.trees.back();
+          tree.Init();
 
-    // assign node ID's so that a breadth-wise traversal would yield
-    // the monotonic sequence 0, 1, 2, ...
-    std::queue<std::pair<NodeDraft const*, int>> Q;  // (internal pointer, ID)
-    Q.push({_tree.root, 0});  // assign 0 to root
-    while (!Q.empty()) {
-      NodeDraft const* node;
-      int nid;
-      std::tie(node, nid) = Q.front();
-      Q.pop();
-      TREELITE_CHECK(node->status != NodeDraft::Status::kEmpty)
-          << "CommitModel: encountered an empty node in the middle of a tree";
-      if (node->status == NodeDraft::Status::kNumericalTest) {
-        TREELITE_CHECK(node->left_child) << "CommitModel: a test node lacks a left child";
-        TREELITE_CHECK(node->right_child) << "CommitModel: a test node lacks a right child";
-        TREELITE_CHECK(node->left_child->parent == node)
-            << "CommitModel: left child has wrong parent";
-        TREELITE_CHECK(node->right_child->parent == node)
-            << "CommitModel: right child has wrong parent";
-        tree.AddChilds(nid);
-        TREELITE_CHECK(node->threshold.GetValueType() == TypeToInfo<ThresholdType>())
-            << "CommitModel: The specified threshold has incorrect type. Expected: "
-            << TypeInfoToString(TypeToInfo<ThresholdType>())
-            << " Given: " << TypeInfoToString(node->threshold.GetValueType());
-        ThresholdType threshold = node->threshold.Get<ThresholdType>();
-        tree.SetNumericalSplit(nid, node->feature_id, threshold, node->default_left, node->op);
-        Q.push({node->left_child, tree.LeftChild(nid)});
-        Q.push({node->right_child, tree.RightChild(nid)});
-      } else if (node->status == NodeDraft::Status::kCategoricalTest) {
-        TREELITE_CHECK(node->left_child) << "CommitModel: a test node lacks a left child";
-        TREELITE_CHECK(node->right_child) << "CommitModel: a test node lacks a right child";
-        TREELITE_CHECK(node->left_child->parent == node)
-            << "CommitModel: left child has wrong parent";
-        TREELITE_CHECK(node->right_child->parent == node)
-            << "CommitModel: right child has wrong parent";
-        tree.AddChilds(nid);
-        tree.SetCategoricalSplit(
-            nid, node->feature_id, node->default_left, node->left_categories, false);
-        Q.push({node->left_child, tree.LeftChild(nid)});
-        Q.push({node->right_child, tree.RightChild(nid)});
-      } else {  // leaf node
-        TREELITE_CHECK(node->left_child == nullptr && node->right_child == nullptr)
-            << "CommitModel: a leaf node cannot have children";
-        if (!node->leaf_vector.empty()) {  // leaf vector exists
-          TREELITE_CHECK_NE(flag_leaf_vector, 0) << "CommitModel: Inconsistent use of leaf vector: "
-                                                    "if one leaf node uses a leaf vector, "
-                                                 << "*every* leaf node must use a leaf vector";
-          flag_leaf_vector = 1;  // now every leaf must use leaf vector
-          TREELITE_CHECK_EQ(node->leaf_vector.size(), model.task_param.num_class)
-              << "CommitModel: The length of leaf vector must be identical to the number of output "
-              << "groups";
-          SetLeafVector(&tree, nid, node->leaf_vector);
-        } else {  // ordinary leaf
-          TREELITE_CHECK_NE(flag_leaf_vector, 1)
-              << "CommitModel: Inconsistent use of leaf vector: if one leaf node does not use a "
-                 "leaf "
-              << "vector, *no other* leaf node can use a leaf vector";
-          flag_leaf_vector = 0;  // now no leaf can use leaf vector
-          TREELITE_CHECK(node->leaf_value.GetValueType() == TypeToInfo<LeafOutputType>())
-              << "CommitModel: The specified leaf value has incorrect type. Expected: "
-              << TypeInfoToString(TypeToInfo<LeafOutputType>())
-              << " Given: " << TypeInfoToString(node->leaf_value.GetValueType());
-          LeafOutputType leaf_value = node->leaf_value.Get<LeafOutputType>();
-          tree.SetLeaf(nid, leaf_value);
+          // assign node ID's so that a breadth-wise traversal would yield
+          // the monotonic sequence 0, 1, 2, ...
+          std::queue<std::pair<NodeDraft const*, int>> Q;  // (internal pointer, ID)
+          Q.emplace(_tree.root, 0);  // assign 0 to root
+          while (!Q.empty()) {
+            NodeDraft const* node;
+            int nid;
+            std::tie(node, nid) = Q.front();
+            Q.pop();
+            TREELITE_CHECK(node->status != NodeDraft::Status::kEmpty)
+                << "CommitModel: encountered an empty node in the middle of a tree";
+            if (node->status == NodeDraft::Status::kNumericalTest) {
+              TREELITE_CHECK(node->left_child) << "CommitModel: a test node lacks a left child";
+              TREELITE_CHECK(node->right_child) << "CommitModel: a test node lacks a right child";
+              TREELITE_CHECK(node->left_child->parent == node)
+                  << "CommitModel: left child has wrong parent";
+              TREELITE_CHECK(node->right_child->parent == node)
+                  << "CommitModel: right child has wrong parent";
+              tree.AddChilds(nid);
+              TREELITE_CHECK(node->threshold.GetValueType() == TypeToInfo<ThresholdType>())
+                  << "CommitModel: The specified threshold has incorrect type. Expected: "
+                  << TypeInfoToString(TypeToInfo<ThresholdType>())
+                  << " Given: " << TypeInfoToString(node->threshold.GetValueType());
+              ThresholdType threshold = node->threshold.Get<ThresholdType>();
+              tree.SetNumericalSplit(
+                  nid, node->feature_id, threshold, node->default_left, node->op);
+              Q.push({node->left_child, tree.LeftChild(nid)});
+              Q.push({node->right_child, tree.RightChild(nid)});
+            } else if (node->status == NodeDraft::Status::kCategoricalTest) {
+              TREELITE_CHECK(node->left_child) << "CommitModel: a test node lacks a left child";
+              TREELITE_CHECK(node->right_child) << "CommitModel: a test node lacks a right child";
+              TREELITE_CHECK(node->left_child->parent == node)
+                  << "CommitModel: left child has wrong parent";
+              TREELITE_CHECK(node->right_child->parent == node)
+                  << "CommitModel: right child has wrong parent";
+              tree.AddChilds(nid);
+              tree.SetCategoricalSplit(
+                  nid, node->feature_id, node->default_left, node->left_categories, false);
+              Q.push({node->left_child, tree.LeftChild(nid)});
+              Q.push({node->right_child, tree.RightChild(nid)});
+            } else {  // leaf node
+              TREELITE_CHECK(node->left_child == nullptr && node->right_child == nullptr)
+                  << "CommitModel: a leaf node cannot have children";
+              if (!node->leaf_vector.empty()) {  // leaf vector exists
+                TREELITE_CHECK_NE(flag_leaf_vector, 0)
+                    << "CommitModel: Inconsistent use of leaf vector: "
+                       "if one leaf node uses a leaf vector, "
+                    << "*every* leaf node must use a leaf vector";
+                flag_leaf_vector = 1;  // now every leaf must use leaf vector
+                TREELITE_CHECK_EQ(node->leaf_vector.size(), model->task_param.num_class)
+                    << "CommitModel: The length of leaf vector must be identical to the number of "
+                       "output "
+                    << "groups";
+                SetLeafVector(&tree, nid, node->leaf_vector);
+              } else {  // ordinary leaf
+                TREELITE_CHECK_NE(flag_leaf_vector, 1)
+                    << "CommitModel: Inconsistent use of leaf vector: if one leaf node does not "
+                       "use a "
+                       "leaf "
+                    << "vector, *no other* leaf node can use a leaf vector";
+                flag_leaf_vector = 0;  // now no leaf can use leaf vector
+                TREELITE_CHECK(node->leaf_value.GetValueType() == TypeToInfo<LeafOutputType>())
+                    << "CommitModel: The specified leaf value has incorrect type. Expected: "
+                    << TypeInfoToString(TypeToInfo<LeafOutputType>())
+                    << " Given: " << TypeInfoToString(node->leaf_value.GetValueType());
+                LeafOutputType leaf_value = node->leaf_value.Get<LeafOutputType>();
+                tree.SetLeaf(nid, leaf_value);
+              }
+            }
+          }
         }
-      }
-    }
-  }
+      },
+      model->variant_);
   if (flag_leaf_vector == 0) {
-    model.task_param.leaf_vector_size = 1;
-    if (model.task_param.num_class > 1) {
+    model->task_param.leaf_vector_size = 1;
+    if (model->task_param.num_class > 1) {
       // multi-class classifier, XGBoost/LightGBM style
-      model.task_type = TaskType::kMultiClfGrovePerClass;
-      model.task_param.grove_per_class = true;
-      TREELITE_CHECK_EQ(this->trees.size() % model.task_param.num_class, 0)
+      model->task_type = TaskType::kMultiClfGrovePerClass;
+      model->task_param.grove_per_class = true;
+      TREELITE_CHECK_EQ(model->GetNumTree() % model->task_param.num_class, 0)
           << "For multi-class classifiers with gradient boosted trees, the number of trees must be "
           << "evenly divisible by the number of output groups";
     } else {
       // binary classifier or regressor
-      model.task_type = TaskType::kBinaryClfRegr;
-      model.task_param.grove_per_class = false;
+      model->task_type = TaskType::kBinaryClfRegr;
+      model->task_param.grove_per_class = false;
     }
   } else if (flag_leaf_vector == 1) {
     // multi-class classifier, sklearn RF style
-    model.task_type = TaskType::kMultiClfProbDistLeaf;
-    model.task_param.grove_per_class = false;
-    TREELITE_CHECK_GT(model.task_param.num_class, 1)
+    model->task_type = TaskType::kMultiClfProbDistLeaf;
+    model->task_param.grove_per_class = false;
+    TREELITE_CHECK_GT(model->task_param.num_class, 1)
         << "Expected leaf vectors with length exceeding 1";
-    model.task_param.leaf_vector_size = model.task_param.num_class;
+    model->task_param.leaf_vector_size = model->task_param.num_class;
   } else {
     TREELITE_LOG(FATAL) << "Impossible thing happened: model has no leaf node!";
   }
+  return model;
 }
 
 template Value Value::Create(uint32_t init_value);
 template Value Value::Create(float init_value);
 template Value Value::Create(double init_value);
 
-}  // namespace frontend
-}  // namespace treelite
+}  // namespace treelite::frontend

--- a/src/frontend/json_importer.cc
+++ b/src/frontend/json_importer.cc
@@ -229,8 +229,7 @@ std::unique_ptr<treelite::Model> BuildModelFromJSONString(
 
   TREELITE_CHECK(model_spec.IsObject()) << "JSON string must have an object at the root level";
 
-  std::unique_ptr<Model> model_ptr = Model::Create<float, float>();
-  auto* model = dynamic_cast<treelite::ModelImpl<float, float>*>(model_ptr.get());
+  std::unique_ptr<Model> model = Model::Create<float, float>();
   model->num_feature = ExpectInt(model_spec, "num_feature");
   model->average_tree_output = ExpectBool(model_spec, "average_tree_output");
   model->task_type = StringToTaskType(ExpectString(model_spec, "task_type"));
@@ -240,13 +239,14 @@ std::unique_ptr<treelite::Model> BuildModelFromJSONString(
   model->param = ParseModelParam(ExpectObject(model_spec, "model_param"));
 
   auto const tree_array = ExpectArray(model_spec, "trees");
+  auto& trees = std::get<ModelPreset<float, float>>(model->variant_).trees;
   for (auto const& e : tree_array) {
     TREELITE_CHECK(e.IsObject()) << "Expected a JSON object in \"trees\" array";
-    model->trees.emplace_back();
-    ParseTree(e.GetObject(), model->trees.back());
+    trees.emplace_back();
+    ParseTree(e.GetObject(), trees.back());
   }
 
-  return model_ptr;
+  return model;
 }
 
 }  // namespace treelite::frontend

--- a/src/frontend/sklearn.cc
+++ b/src/frontend/sklearn.cc
@@ -9,53 +9,54 @@
 #include <treelite/tree.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <numeric>
 #include <queue>
 #include <tuple>
 
-namespace treelite {
-namespace frontend {
+namespace treelite::frontend {
 
 template <typename MetaHandlerFunc, typename LeafHandlerFunc>
 std::unique_ptr<treelite::Model> LoadSKLearnModel(int n_trees, int n_features, int n_classes,
-    int64_t const* node_count, int64_t const** children_left, int64_t const** children_right,
-    int64_t const** feature, double const** threshold, double const** value,
-    int64_t const** n_node_samples, double const** weighted_n_node_samples, double const** impurity,
-    MetaHandlerFunc meta_handler, LeafHandlerFunc leaf_handler) {
+    std::int64_t const* node_count, std::int64_t const** children_left,
+    std::int64_t const** children_right, std::int64_t const** feature, double const** threshold,
+    double const** value, std::int64_t const** n_node_samples,
+    double const** weighted_n_node_samples, double const** impurity, MetaHandlerFunc meta_handler,
+    LeafHandlerFunc leaf_handler) {
   TREELITE_CHECK_GT(n_trees, 0);
   TREELITE_CHECK_GT(n_features, 0);
 
-  std::unique_ptr<treelite::Model> model_ptr = treelite::Model::Create<double, double>();
-  meta_handler(model_ptr.get(), n_features, n_classes);
-  auto* model = dynamic_cast<treelite::ModelImpl<double, double>*>(model_ptr.get());
+  std::unique_ptr<treelite::Model> model = treelite::Model::Create<double, double>();
+  meta_handler(model.get(), n_features, n_classes);
 
+  auto& trees = std::get<ModelPreset<double, double>>(model->variant_).trees;
   for (int tree_id = 0; tree_id < n_trees; ++tree_id) {
-    model->trees.emplace_back();
-    treelite::Tree<double, double>& tree = model->trees.back();
+    trees.emplace_back();
+    treelite::Tree<double, double>& tree = trees.back();
     tree.Init();
 
     // Assign node ID's so that a breadth-wise traversal would yield
     // the monotonic sequence 0, 1, 2, ...
-    std::queue<std::pair<int64_t, int>> Q;  // (old ID, new ID) pair
-    Q.push({0, 0});
-    const int64_t total_sample_cnt = n_node_samples[tree_id][0];
+    std::queue<std::pair<std::int64_t, int>> Q;  // (old ID, new ID) pair
+    Q.emplace(0, 0);
+    const std::int64_t total_sample_cnt = n_node_samples[tree_id][0];
     while (!Q.empty()) {
-      int64_t node_id;
+      std::int64_t node_id;
       int new_node_id;
       std::tie(node_id, new_node_id) = Q.front();
       Q.pop();
-      const int64_t left_child_id = children_left[tree_id][node_id];
-      const int64_t right_child_id = children_right[tree_id][node_id];
-      const int64_t sample_cnt = n_node_samples[tree_id][node_id];
+      const std::int64_t left_child_id = children_left[tree_id][node_id];
+      const std::int64_t right_child_id = children_right[tree_id][node_id];
+      const std::int64_t sample_cnt = n_node_samples[tree_id][node_id];
       double const weighted_sample_cnt = weighted_n_node_samples[tree_id][node_id];
       if (left_child_id == -1) {  // leaf node
         leaf_handler(tree_id, node_id, new_node_id, value, n_classes, tree);
       } else {
-        const int64_t split_index = feature[tree_id][node_id];
+        const std::int64_t split_index = feature[tree_id][node_id];
         double const split_cond = threshold[tree_id][node_id];
-        const int64_t left_child_sample_cnt = n_node_samples[tree_id][left_child_id];
-        const int64_t right_child_sample_cnt = n_node_samples[tree_id][right_child_id];
+        const std::int64_t left_child_sample_cnt = n_node_samples[tree_id][left_child_id];
+        const std::int64_t right_child_sample_cnt = n_node_samples[tree_id][right_child_id];
         double const gain
             = sample_cnt
               * (impurity[tree_id][node_id]
@@ -66,50 +67,50 @@ std::unique_ptr<treelite::Model> LoadSKLearnModel(int n_trees, int n_features, i
         tree.AddChilds(new_node_id);
         tree.SetNumericalSplit(new_node_id, split_index, split_cond, true, treelite::Operator::kLE);
         tree.SetGain(new_node_id, gain);
-        Q.push({left_child_id, tree.LeftChild(new_node_id)});
-        Q.push({right_child_id, tree.RightChild(new_node_id)});
+        Q.emplace(left_child_id, tree.LeftChild(new_node_id));
+        Q.emplace(right_child_id, tree.RightChild(new_node_id));
       }
       tree.SetDataCount(new_node_id, sample_cnt);
       tree.SetSumHess(new_node_id, weighted_sample_cnt);
     }
   }
-  return model_ptr;
+  return model;
 }
 
 template <typename MetaHandlerFunc, typename LeafHandlerFunc>
 std::unique_ptr<treelite::Model> LoadSKLearnHistGradientBoosting(int n_trees, int n_features,
     int n_classes, std::int64_t const* node_count, std::int64_t const** children_left,
     std::int64_t const** children_right, std::int64_t const** feature, double const** threshold,
-    std::int8_t const** default_left, double const** value, int64_t const** n_node_samples,
+    std::int8_t const** default_left, double const** value, std::int64_t const** n_node_samples,
     double const** gain, MetaHandlerFunc meta_handler, LeafHandlerFunc leaf_handler) {
   TREELITE_CHECK_GT(n_trees, 0);
   TREELITE_CHECK_GT(n_features, 0);
 
-  std::unique_ptr<treelite::Model> model_ptr = treelite::Model::Create<double, double>();
-  meta_handler(model_ptr.get(), n_features, n_classes);
-  auto* model = dynamic_cast<treelite::ModelImpl<double, double>*>(model_ptr.get());
+  std::unique_ptr<treelite::Model> model = treelite::Model::Create<double, double>();
+  meta_handler(model.get(), n_features, n_classes);
 
+  auto& trees = std::get<ModelPreset<double, double>>(model->variant_).trees;
   for (int tree_id = 0; tree_id < n_trees; ++tree_id) {
-    model->trees.emplace_back();
-    treelite::Tree<double, double>& tree = model->trees.back();
+    trees.emplace_back();
+    treelite::Tree<double, double>& tree = trees.back();
     tree.Init();
 
     // Assign node ID's so that a breadth-wise traversal would yield
     // the monotonic sequence 0, 1, 2, ...
-    std::queue<std::pair<int64_t, int>> Q;  // (old ID, new ID) pair
+    std::queue<std::pair<std::int64_t, int>> Q;  // (old ID, new ID) pair
     Q.emplace(0, 0);
     while (!Q.empty()) {
-      int64_t node_id;
+      std::int64_t node_id;
       int new_node_id;
       std::tie(node_id, new_node_id) = Q.front();
       Q.pop();
-      const int64_t left_child_id = children_left[tree_id][node_id];
-      const int64_t right_child_id = children_right[tree_id][node_id];
-      const int64_t sample_cnt = n_node_samples[tree_id][node_id];
+      const std::int64_t left_child_id = children_left[tree_id][node_id];
+      const std::int64_t right_child_id = children_right[tree_id][node_id];
+      const std::int64_t sample_cnt = n_node_samples[tree_id][node_id];
       if (left_child_id == -1) {  // leaf node
         leaf_handler(tree_id, node_id, new_node_id, value, n_classes, tree);
       } else {
-        const int64_t split_index = feature[tree_id][node_id];
+        const std::int64_t split_index = feature[tree_id][node_id];
         double const split_cond = threshold[tree_id][node_id];
         tree.AddChilds(new_node_id);
         tree.SetNumericalSplit(new_node_id, split_index, split_cond,
@@ -121,14 +122,14 @@ std::unique_ptr<treelite::Model> LoadSKLearnHistGradientBoosting(int n_trees, in
       tree.SetDataCount(new_node_id, sample_cnt);
     }
   }
-  return model_ptr;
+  return model;
 }
 
 std::unique_ptr<treelite::Model> LoadSKLearnRandomForestRegressor(int n_estimators, int n_features,
-    int64_t const* node_count, int64_t const** children_left, int64_t const** children_right,
-    int64_t const** feature, double const** threshold, double const** value,
-    int64_t const** n_node_samples, double const** weighted_n_node_samples,
-    double const** impurity) {
+    std::int64_t const* node_count, std::int64_t const** children_left,
+    std::int64_t const** children_right, std::int64_t const** feature, double const** threshold,
+    double const** value, std::int64_t const** n_node_samples,
+    double const** weighted_n_node_samples, double const** impurity) {
   auto meta_handler = [](treelite::Model* model, int n_features, int n_classes) {
     model->num_feature = n_features;
     model->average_tree_output = true;
@@ -140,7 +141,7 @@ std::unique_ptr<treelite::Model> LoadSKLearnRandomForestRegressor(int n_estimato
     std::strncpy(model->param.pred_transform, "identity", sizeof(model->param.pred_transform));
     model->param.global_bias = 0.0f;
   };
-  auto leaf_handler = [](int tree_id, int64_t node_id, int new_node_id, double const** value,
+  auto leaf_handler = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
                           int n_classes, treelite::Tree<double, double>& dest_tree) {
     const double leaf_value = value[tree_id][node_id];
     dest_tree.SetLeaf(new_node_id, leaf_value);
@@ -151,10 +152,10 @@ std::unique_ptr<treelite::Model> LoadSKLearnRandomForestRegressor(int n_estimato
 }
 
 std::unique_ptr<treelite::Model> LoadSKLearnIsolationForest(int n_estimators, int n_features,
-    int64_t const* node_count, int64_t const** children_left, int64_t const** children_right,
-    int64_t const** feature, double const** threshold, double const** value,
-    int64_t const** n_node_samples, double const** weighted_n_node_samples, double const** impurity,
-    double const ratio_c) {
+    std::int64_t const* node_count, std::int64_t const** children_left,
+    std::int64_t const** children_right, std::int64_t const** feature, double const** threshold,
+    double const** value, std::int64_t const** n_node_samples,
+    double const** weighted_n_node_samples, double const** impurity, double const ratio_c) {
   auto meta_handler = [ratio_c](treelite::Model* model, int n_features, int n_classes) {
     model->num_feature = n_features;
     model->average_tree_output = true;
@@ -167,7 +168,7 @@ std::unique_ptr<treelite::Model> LoadSKLearnIsolationForest(int n_estimators, in
         sizeof(model->param.pred_transform));
     model->param.ratio_c = ratio_c;
   };
-  auto leaf_handler = [](int tree_id, int64_t node_id, int new_node_id, double const** value,
+  auto leaf_handler = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
                           int n_classes, treelite::Tree<double, double>& dest_tree) {
     const double leaf_value = value[tree_id][node_id];
     dest_tree.SetLeaf(new_node_id, leaf_value);
@@ -178,9 +179,10 @@ std::unique_ptr<treelite::Model> LoadSKLearnIsolationForest(int n_estimators, in
 }
 
 std::unique_ptr<treelite::Model> LoadSKLearnRandomForestClassifierBinary(int n_estimators,
-    int n_features, int n_classes, int64_t const* node_count, int64_t const** children_left,
-    int64_t const** children_right, int64_t const** feature, double const** threshold,
-    double const** value, int64_t const** n_node_samples, double const** weighted_n_node_samples,
+    int n_features, int n_classes, std::int64_t const* node_count,
+    std::int64_t const** children_left, std::int64_t const** children_right,
+    std::int64_t const** feature, double const** threshold, double const** value,
+    std::int64_t const** n_node_samples, double const** weighted_n_node_samples,
     double const** impurity) {
   auto meta_handler = [](treelite::Model* model, int n_features, int n_classes) {
     model->num_feature = n_features;
@@ -193,7 +195,7 @@ std::unique_ptr<treelite::Model> LoadSKLearnRandomForestClassifierBinary(int n_e
     std::strncpy(model->param.pred_transform, "identity", sizeof(model->param.pred_transform));
     model->param.global_bias = 0.0f;
   };
-  auto leaf_handler = [](int tree_id, int64_t node_id, int new_node_id, double const** value,
+  auto leaf_handler = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
                           int n_classes, treelite::Tree<double, double>& dest_tree) {
     // Get counts for each label (+/-) at this leaf node
     const double* leaf_count = &value[tree_id][node_id * 2];
@@ -207,9 +209,10 @@ std::unique_ptr<treelite::Model> LoadSKLearnRandomForestClassifierBinary(int n_e
 }
 
 std::unique_ptr<treelite::Model> LoadSKLearnRandomForestClassifierMulticlass(int n_estimators,
-    int n_features, int n_classes, int64_t const* node_count, int64_t const** children_left,
-    int64_t const** children_right, int64_t const** feature, double const** threshold,
-    double const** value, int64_t const** n_node_samples, double const** weighted_n_node_samples,
+    int n_features, int n_classes, std::int64_t const* node_count,
+    std::int64_t const** children_left, std::int64_t const** children_right,
+    std::int64_t const** feature, double const** threshold, double const** value,
+    std::int64_t const** n_node_samples, double const** weighted_n_node_samples,
     double const** impurity) {
   auto meta_handler = [](treelite::Model* model, int n_features, int n_classes) {
     model->num_feature = n_features;
@@ -223,7 +226,7 @@ std::unique_ptr<treelite::Model> LoadSKLearnRandomForestClassifierMulticlass(int
         model->param.pred_transform, "identity_multiclass", sizeof(model->param.pred_transform));
     model->param.global_bias = 0.0f;
   };
-  auto leaf_handler = [](int tree_id, int64_t node_id, int new_node_id, double const** value,
+  auto leaf_handler = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
                           int n_classes, treelite::Tree<double, double>& dest_tree) {
     // Get counts for each label class at this leaf node
     std::vector<double> prob_distribution(
@@ -241,10 +244,10 @@ std::unique_ptr<treelite::Model> LoadSKLearnRandomForestClassifierMulticlass(int
 }
 
 std::unique_ptr<treelite::Model> LoadSKLearnRandomForestClassifier(int n_estimators, int n_features,
-    int n_classes, int64_t const* node_count, int64_t const** children_left,
-    int64_t const** children_right, int64_t const** feature, double const** threshold,
-    double const** value, int64_t const** n_node_samples, double const** weighted_n_node_samples,
-    double const** impurity) {
+    int n_classes, std::int64_t const* node_count, std::int64_t const** children_left,
+    std::int64_t const** children_right, std::int64_t const** feature, double const** threshold,
+    double const** value, std::int64_t const** n_node_samples,
+    double const** weighted_n_node_samples, double const** impurity) {
   TREELITE_CHECK_GE(n_classes, 2) << "Number of classes must be at least 2";
   if (n_classes == 2) {
     return LoadSKLearnRandomForestClassifierBinary(n_estimators, n_features, n_classes, node_count,
@@ -258,10 +261,10 @@ std::unique_ptr<treelite::Model> LoadSKLearnRandomForestClassifier(int n_estimat
 }
 
 std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingRegressor(int n_iter, int n_features,
-    int64_t const* node_count, int64_t const** children_left, int64_t const** children_right,
-    int64_t const** feature, double const** threshold, double const** value,
-    int64_t const** n_node_samples, double const** weighted_n_node_samples,
-    double const** impurity) {
+    std::int64_t const* node_count, std::int64_t const** children_left,
+    std::int64_t const** children_right, std::int64_t const** feature, double const** threshold,
+    double const** value, std::int64_t const** n_node_samples,
+    double const** weighted_n_node_samples, double const** impurity) {
   auto meta_handler = [](treelite::Model* model, int n_features, int n_classes) {
     model->num_feature = n_features;
     model->average_tree_output = false;
@@ -273,7 +276,7 @@ std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingRegressor(int n_iter
     std::strncpy(model->param.pred_transform, "identity", sizeof(model->param.pred_transform));
     model->param.global_bias = 0.0f;
   };
-  auto leaf_handler = [](int tree_id, int64_t node_id, int new_node_id, double const** value,
+  auto leaf_handler = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
                           int n_classes, treelite::Tree<double, double>& dest_tree) {
     const double leaf_value = value[tree_id][node_id];
     dest_tree.SetLeaf(new_node_id, leaf_value);
@@ -284,9 +287,10 @@ std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingRegressor(int n_iter
 }
 
 std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingClassifierBinary(int n_iter,
-    int n_features, int n_classes, int64_t const* node_count, int64_t const** children_left,
-    int64_t const** children_right, int64_t const** feature, double const** threshold,
-    double const** value, int64_t const** n_node_samples, double const** weighted_n_node_samples,
+    int n_features, int n_classes, std::int64_t const* node_count,
+    std::int64_t const** children_left, std::int64_t const** children_right,
+    std::int64_t const** feature, double const** threshold, double const** value,
+    std::int64_t const** n_node_samples, double const** weighted_n_node_samples,
     double const** impurity) {
   auto meta_handler = [](treelite::Model* model, int n_features, int n_classes) {
     model->num_feature = n_features;
@@ -299,7 +303,7 @@ std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingClassifierBinary(int
     std::strncpy(model->param.pred_transform, "sigmoid", sizeof(model->param.pred_transform));
     model->param.global_bias = 0.0f;
   };
-  auto leaf_handler = [](int tree_id, int64_t node_id, int new_node_id, double const** value,
+  auto leaf_handler = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
                           int n_classes, treelite::Tree<double, double>& dest_tree) {
     const double leaf_value = value[tree_id][node_id];
     dest_tree.SetLeaf(new_node_id, leaf_value);
@@ -310,9 +314,10 @@ std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingClassifierBinary(int
 }
 
 std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingClassifierMulticlass(int n_iter,
-    int n_features, int n_classes, int64_t const* node_count, int64_t const** children_left,
-    int64_t const** children_right, int64_t const** feature, double const** threshold,
-    double const** value, int64_t const** n_node_samples, double const** weighted_n_node_samples,
+    int n_features, int n_classes, std::int64_t const* node_count,
+    std::int64_t const** children_left, std::int64_t const** children_right,
+    std::int64_t const** feature, double const** threshold, double const** value,
+    std::int64_t const** n_node_samples, double const** weighted_n_node_samples,
     double const** impurity) {
   auto meta_handler = [](treelite::Model* model, int n_features, int n_classes) {
     model->num_feature = n_features;
@@ -325,7 +330,7 @@ std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingClassifierMulticlass
     std::strncpy(model->param.pred_transform, "softmax", sizeof(model->param.pred_transform));
     model->param.global_bias = 0.0f;
   };
-  auto leaf_handler = [](int tree_id, int64_t node_id, int new_node_id, double const** value,
+  auto leaf_handler = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
                           int n_classes, treelite::Tree<double, double>& dest_tree) {
     const double leaf_value = value[tree_id][node_id];
     dest_tree.SetLeaf(new_node_id, leaf_value);
@@ -336,10 +341,10 @@ std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingClassifierMulticlass
 }
 
 std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingClassifier(int n_iter, int n_features,
-    int n_classes, int64_t const* node_count, int64_t const** children_left,
-    int64_t const** children_right, int64_t const** feature, double const** threshold,
-    double const** value, int64_t const** n_node_samples, double const** weighted_n_node_samples,
-    double const** impurity) {
+    int n_classes, std::int64_t const* node_count, std::int64_t const** children_left,
+    std::int64_t const** children_right, std::int64_t const** feature, double const** threshold,
+    double const** value, std::int64_t const** n_node_samples,
+    double const** weighted_n_node_samples, double const** impurity) {
   TREELITE_CHECK_GE(n_classes, 2) << "Number of classes must be at least 2";
   if (n_classes == 2) {
     return LoadSKLearnGradientBoostingClassifierBinary(n_iter, n_features, n_classes, node_count,
@@ -369,7 +374,7 @@ std::unique_ptr<treelite::Model> LoadSKLearnHistGradientBoostingRegressor(int n_
     std::strncpy(model->param.pred_transform, "identity", sizeof(model->param.pred_transform));
     model->param.global_bias = global_bias;
   };
-  auto leaf_handler = [](int tree_id, int64_t node_id, int new_node_id, double const** value,
+  auto leaf_handler = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
                           int n_classes, treelite::Tree<double, double>& dest_tree) {
     const double leaf_value = value[tree_id][node_id];
     dest_tree.SetLeaf(new_node_id, leaf_value);
@@ -397,7 +402,7 @@ std::unique_ptr<treelite::Model> LoadSKLearnHistGradientBoostingClassifierBinary
     std::strncpy(model->param.pred_transform, "sigmoid", sizeof(model->param.pred_transform));
     model->param.global_bias = global_bias;
   };
-  auto leaf_handler = [](int tree_id, int64_t node_id, int new_node_id, double const** value,
+  auto leaf_handler = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
                           int n_classes, treelite::Tree<double, double>& dest_tree) {
     const double leaf_value = value[tree_id][node_id];
     dest_tree.SetLeaf(new_node_id, leaf_value);
@@ -425,5 +430,4 @@ std::unique_ptr<treelite::Model> LoadSKLearnHistGradientBoostingClassifier(int n
   }
 }
 
-}  // namespace frontend
-}  // namespace treelite
+}  // namespace treelite::frontend

--- a/src/frontend/xgboost/xgboost_json.h
+++ b/src/frontend/xgboost/xgboost_json.h
@@ -336,8 +336,7 @@ class ArrayHandler : public OutputHandler<std::vector<ElemType>> {
 };
 
 struct ParsedXGBoostModel {
-  std::unique_ptr<treelite::Model> model_ptr;
-  treelite::ModelImpl<float, float>* model;
+  std::unique_ptr<treelite::Model> model;
   std::vector<unsigned> version;
   std::vector<int> tree_info;
   std::string objective_name;
@@ -423,9 +422,9 @@ class ObjectiveHandler : public OutputHandler<std::string> {
 };
 
 /*! \brief handler for LearnerParam objects from XGBoost schema*/
-class LearnerParamHandler : public OutputHandler<treelite::ModelImpl<float, float>> {
+class LearnerParamHandler : public OutputHandler<treelite::Model> {
  public:
-  using OutputHandler<treelite::ModelImpl<float, float>>::OutputHandler;
+  using OutputHandler<treelite::Model>::OutputHandler;
   bool String(char const* str, std::size_t length, bool copy) override;
 
  protected:
@@ -537,10 +536,8 @@ class DelegatedHandler :
  private:
   explicit DelegatedHandler(rapidjson::Document const& handler_config)
       : delegates{},
-        result{treelite::Model::Create<float, float>(), nullptr, {}, {}, ""},
-        handler_config_{handler_config} {
-    result.model = dynamic_cast<treelite::ModelImpl<float, float>*>(result.model_ptr.get());
-  }
+        result{treelite::Model::Create<float, float>(), {}, {}, ""},
+        handler_config_{handler_config} {}
 
   std::stack<std::shared_ptr<BaseHandler>> delegates;
   ParsedXGBoostModel result;

--- a/src/model_concat.cc
+++ b/src/model_concat.cc
@@ -11,38 +11,40 @@
 #include <algorithm>
 #include <memory>
 #include <type_traits>
+#include <variant>
 
 namespace treelite {
 
 std::unique_ptr<Model> ConcatenateModelObjects(std::vector<Model const*> const& objs) {
   if (objs.empty()) {
-    return std::unique_ptr<Model>();
+    return {};
   }
   const TypeInfo threshold_type = objs[0]->GetThresholdType();
   const TypeInfo leaf_output_type = objs[0]->GetLeafOutputType();
-  return objs[0]->Dispatch([&objs, threshold_type, leaf_output_type](auto const& first_model_obj) {
-    using ModelType = std::remove_const_t<std::remove_reference_t<decltype(first_model_obj)>>;
-    std::unique_ptr<Model> concatenated_model = Model::Create(threshold_type, leaf_output_type);
-    auto* concatenated_model_concrete = dynamic_cast<ModelType*>(concatenated_model.get());
-    for (std::size_t i = 0; i < objs.size(); ++i) {
-      auto* casted = dynamic_cast<const ModelType*>(objs[i]);
-      if (casted) {
-        std::transform(casted->trees.begin(), casted->trees.end(),
-            std::back_inserter(concatenated_model_concrete->trees),
-            [](const auto& tree) { return tree.Clone(); });
-      } else {
-        TREELITE_LOG(FATAL) << "Model object at index " << i
-                            << " has a different type than the first model object (at index 0)";
-      }
-    }
-    /* Copy model metadata */
-    concatenated_model->num_feature = first_model_obj.num_feature;
-    concatenated_model->task_type = first_model_obj.task_type;
-    concatenated_model->average_tree_output = first_model_obj.average_tree_output;
-    concatenated_model->task_param = first_model_obj.task_param;
-    concatenated_model->param = first_model_obj.param;
-    return concatenated_model;
-  });
+  return std::visit(
+      [&objs, threshold_type, leaf_output_type](auto&& first_model_obj) {
+        using ModelType = std::remove_const_t<std::remove_reference_t<decltype(first_model_obj)>>;
+        std::unique_ptr<Model> concatenated_model = Model::Create(threshold_type, leaf_output_type);
+        ModelType& concatenated_model_concrete = std::get<ModelType>(concatenated_model->variant_);
+        for (std::size_t i = 0; i < objs.size(); ++i) {
+          if (!std::holds_alternative<ModelType>(objs[i]->variant_)) {
+            TREELITE_LOG(FATAL) << "Model object at index " << i
+                                << " has a different type than the first model object (at index 0)";
+          }
+          auto& casted = std::get<ModelType>(objs[i]->variant_);
+          std::transform(casted.trees.begin(), casted.trees.end(),
+              std::back_inserter(concatenated_model_concrete.trees),
+              [](const auto& tree) { return tree.Clone(); });
+        }
+        /* Copy model metadata */
+        concatenated_model->num_feature = objs[0]->num_feature;
+        concatenated_model->task_type = objs[0]->task_type;
+        concatenated_model->average_tree_output = objs[0]->average_tree_output;
+        concatenated_model->task_param = objs[0]->task_param;
+        concatenated_model->param = objs[0]->param;
+        return concatenated_model;
+      },
+      objs[0]->variant_);
 }
 
 }  // namespace treelite

--- a/tests/cpp/test_frontend.cc
+++ b/tests/cpp/test_frontend.cc
@@ -438,8 +438,7 @@ TEST(GBTreeModelHandlerSuite, GBTreeModelHandler) {
   auto input_stream = rapidjson::MemoryStream(json_str.c_str(), json_str.size());
   std::shared_ptr<MockDelegator> delegator = std::make_shared<MockDelegator>();
 
-  details::ParsedXGBoostModel output{Model::Create<float, float>(), nullptr, {}, {}, ""};
-  output.model = dynamic_cast<ModelImpl<float, float>*>(output.model_ptr.get());
+  details::ParsedXGBoostModel output{Model::Create<float, float>(), {}, {}, ""};
   details::GBTreeModelHandler wrapped_handler{delegator, output};
   MockObjectStarter handler{delegator, wrapped_handler};
 
@@ -463,9 +462,7 @@ TEST(GBTreeModelHandlerSuite, TreeInfoField) {
   handler_config.Parse(R"({"allow_unknown_fields": false})");
   auto handler = details::DelegatedHandler::create_empty(handler_config);
   auto wrapped_handler = std::make_shared<GBTreeModelHandlerWrapper>(handler);
-  wrapped_handler->output.model_ptr = Model::Create<float, float>();
-  wrapped_handler->output.model
-      = dynamic_cast<ModelImpl<float, float>*>(wrapped_handler->output.model_ptr.get());
+  wrapped_handler->output.model = Model::Create<float, float>();
   handler->push_delegate(wrapped_handler);
   rapidjson::Reader reader;
 
@@ -485,8 +482,7 @@ TEST(GradientBoosterHandlerSuite, GradientBoosterHandler) {
   auto input_stream = rapidjson::MemoryStream(json_str.c_str(), json_str.size());
   std::shared_ptr<MockDelegator> delegator = std::make_shared<MockDelegator>();
 
-  details::ParsedXGBoostModel output{Model::Create<float, float>(), nullptr, {}, {}, ""};
-  output.model = dynamic_cast<ModelImpl<float, float>*>(output.model_ptr.get());
+  details::ParsedXGBoostModel output{Model::Create<float, float>(), {}, {}, ""};
   details::GradientBoosterHandler wrapped_handler{delegator, output};
   MockObjectStarter handler{delegator, wrapped_handler};
 
@@ -524,8 +520,8 @@ TEST(LearnerParamHandlerSuite, LearnerParamHandler) {
   auto input_stream = rapidjson::MemoryStream(json_str.c_str(), json_str.size());
   std::shared_ptr<MockDelegator> delegator = std::make_shared<MockDelegator>();
 
-  ModelImpl<float, float> output;
-  details::LearnerParamHandler wrapped_handler{delegator, output};
+  std::unique_ptr<Model> output = Model::Create<float, float>();
+  details::LearnerParamHandler wrapped_handler{delegator, *output};
   MockObjectStarter handler{delegator, wrapped_handler};
 
   rapidjson::Reader reader;
@@ -533,9 +529,9 @@ TEST(LearnerParamHandlerSuite, LearnerParamHandler) {
 
   ASSERT_TRUE(result);
 
-  ASSERT_FLOAT_EQ(output.param.global_bias, 0.5);
-  ASSERT_EQ(output.task_param.num_class, 5);
-  ASSERT_EQ(output.num_feature, 12);
+  ASSERT_FLOAT_EQ(output->param.global_bias, 0.5);
+  ASSERT_EQ(output->task_param.num_class, 5);
+  ASSERT_EQ(output->num_feature, 12);
 }
 
 /******************************************************************************
@@ -546,8 +542,7 @@ TEST(XGBoostModelHandlerSuite, XGBoostModelHandler) {
   auto input_stream = rapidjson::MemoryStream(json_str.c_str(), json_str.size());
   std::shared_ptr<MockDelegator> delegator = std::make_shared<MockDelegator>();
 
-  details::ParsedXGBoostModel output{Model::Create<float, float>(), nullptr, {}, {}, ""};
-  output.model = dynamic_cast<ModelImpl<float, float>*>(output.model_ptr.get());
+  details::ParsedXGBoostModel output{Model::Create<float, float>(), {}, {}, ""};
   details::XGBoostModelHandler wrapped_handler{delegator, output};
   MockObjectStarter handler{delegator, wrapped_handler};
 

--- a/tests/cpp/test_model_concat.cc
+++ b/tests/cpp/test_model_concat.cc
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <memory>
 #include <sstream>
+#include <variant>
 #include <vector>
 
 namespace {
@@ -62,10 +63,9 @@ TEST(ModelConcatenation, TreeStump) {
   std::unique_ptr<Model> concatenated_model = ConcatenateModelObjects(model_obj_refs);
   ASSERT_EQ(concatenated_model->GetNumTree(), kNumModelObjs);
   TestRoundTrip(concatenated_model.get());
-  auto const* concatenated_model_casted
-      = dynamic_cast<ModelImpl<float, float> const*>(concatenated_model.get());
+  auto& trees = std::get<ModelPreset<float, float>>(concatenated_model->variant_).trees;
   for (int i = 0; i < kNumModelObjs; ++i) {
-    auto const& tree = concatenated_model_casted->trees[i];
+    auto const& tree = trees[i];
     ASSERT_FALSE(tree.IsLeaf(0));
     ASSERT_TRUE(tree.IsLeaf(1));
     ASSERT_TRUE(tree.IsLeaf(2));

--- a/tests/cython/setup.py
+++ b/tests/cython/setup.py
@@ -14,7 +14,7 @@ extensions = [
         # runtime_library_dirs=[os.path.join(os.sys.prefix, 'lib')],
         libraries=["treelite"],
         language="c++",
-        extra_compile_args=["--std=c++14"],
+        extra_compile_args=["--std=c++17"],
     )
 ]
 


### PR DESCRIPTION
Use `std::variant` to implement type dispatching in `treelite::Model`. Previously, type dispatching was implemented with inheritance, leading to non-idiomatic boilerplates. Closes https://github.com/dmlc/treelite/issues/472