### PR TITLE
Fix loading from XGBoost 2.0 dev

### DIFF
--- a/src/frontend/xgboost_json.cc
+++ b/src/frontend/xgboost_json.cc
@@ -382,7 +382,8 @@ bool GBTreeModelHandler::StartArray() {
   auto& trees = std::get<ModelPreset<float, float>>(output.model->variant_).trees;
   return (push_key_handler<ArrayHandler<treelite::Tree<float, float>, RegTreeHandler>,
               std::vector<treelite::Tree<float, float>>>("trees", trees)
-          || push_key_handler<ArrayHandler<int>, std::vector<int>>("tree_info", output.tree_info));
+          || push_key_handler<ArrayHandler<int>, std::vector<int>>("tree_info", output.tree_info)
+          || push_key_handler<IgnoreHandler>("iteration_indptr"));
 }
 
 bool GBTreeModelHandler::StartObject() {


### PR DESCRIPTION
* Handle parameter `size_leaf_vector` correctly in XGBoost 2.0+. XGBoost versions prior to 0.82 had an experimental support for leaf vector outputs. In versions between 0.82 and 1.7.5, XGBoost did not support leaf vector outputs. Now XGBoost 2.0 is adding support again for leaf vector outputs. The parameter `size_leaf_vector` is being re-used with a slightly different semantics.
* Handle iteration_indptr field in JSON

Closes #492
