### PR TITLE
Add additional metadata for trees

### DIFF
--- a/docs/serialization/v4.rst
+++ b/docs/serialization/v4.rst
@@ -77,7 +77,7 @@ written to the byte sequence in the exact order they appear in the following lis
 
    * Per-tree Metadata
 
-     - ``target_id``: an array of ``int32_t``. ``target[i]`` indicates the target for which the ``i``-th tree produces output.  If the tree is a multi-target tree (i.e. it yields output for all targets), ``target[i]`` is set to -1.
+     - ``target_id``: an array of ``int32_t``. ``target_id[i]`` indicates the target for which the ``i``-th tree produces output.  If the tree is a multi-target tree (i.e. it yields output for all targets), ``target_id[i]`` is set to -1.
        This array is expected to have length ``num_tree``.
      - ``class_id``: an array of ``int32_t``. ``class_id[i]`` indicates the class for which the ``i``-th tree produces output. For vector-leaf trees that produce outputs for multiple classes,
        the corresponding ``class_id[i]`` is set to -1. The ``class_id`` array is expected to have length ``num_tree``.

--- a/docs/serialization/v4.rst
+++ b/docs/serialization/v4.rst
@@ -75,11 +75,14 @@ written to the byte sequence in the exact order they appear in the following lis
      - ``pred_transform``: 256-character long ``char`` array. Stores a human-readable name of the transformation function that's applied to prediction outputs. The unused elements in the array should be padded with null characters (``\0``).
      - ``sigmoid_alpha``: single ``float`` scalar. This model parameter is relevant when ``pred_transform="sigmoid"``.
      - ``ratio_c``: single ``float`` scalar. This model parameter is relevant when ``pred_transform="exponential_standard_ratio"``.
+
    * Per-tree Metadata
+
      - ``target_id``: an array of ``int32_t``. ``target[i]`` indicates the target for which the ``i``-th tree produces output.  If the tree is a multi-target tree (i.e. it yields output for all targets), ``target[i]`` is set to -1.
-        This array is expected to have length ``num_tree``.
+       This array is expected to have length ``num_tree``.
      - ``class_id``: an array of ``int32_t``. ``class_id[i]`` indicates the class for which the ``i``-th tree produces output. For multi-target trees, the corresponding ``class_id[i]`` is set to -1.
-        If ``task_type == kMultiClfGrovePerClass``, the ``class_id`` array will have length ``num_tree``; if ``task_type != kMultiClfGrovePerClass``, the ``class_id`` array will be empty.
+       If ``task_type == kMultiClfGrovePerClass``, the ``class_id`` array will have length ``num_tree``; if ``task_type != kMultiClfGrovePerClass``, the ``class_id`` array will be empty.
+
    * ``base_scores``: an array of ``LeafOutputType``. This vector is expected to have length ``num_target * max(num_class)``. The elements will be laid out in the row-major layout.
      The predicted margin scores of all data points will be adjusted by this vector.
 

--- a/docs/serialization/v4.rst
+++ b/docs/serialization/v4.rst
@@ -78,8 +78,8 @@ written to the byte sequence in the exact order they appear in the following lis
    * Per-tree Metadata
      - ``target_id``: an array of ``int32_t``. ``target[i]`` indicates the target for which the ``i``-th tree produces output.  If the tree is a multi-target tree (i.e. it yields output for all targets), ``target[i]`` is set to -1.
         This array is expected to have length ``num_tree``.
-     - ``grove_id``: an array of ``int32_t``. ``grove[i]`` indicates the class for which the ``i``-th tree produces output. If ``task_type == kMultiClfGrovePerClass``, the ``grove_id`` array will have length ``num_tree``;
-       if ``task_type != kMultiClfGrovePerClass``, the ``grove_id`` array will be empty. For multi-target trees, the corresponding ``grove_id[i]`` is set to -1.
+     - ``class_id``: an array of ``int32_t``. ``class_id[i]`` indicates the class for which the ``i``-th tree produces output. For multi-target trees, the corresponding ``class_id[i]`` is set to -1.
+        If ``task_type == kMultiClfGrovePerClass``, the ``class_id`` array will have length ``num_tree``; if ``task_type != kMultiClfGrovePerClass``, the ``class_id`` array will be empty.
    * ``base_scores``: an array of ``LeafOutputType``. This vector is expected to have length ``num_target * max(num_class)``. The elements will be laid out in the row-major layout.
      The predicted margin scores of all data points will be adjusted by this vector.
 

--- a/docs/serialization/v4.rst
+++ b/docs/serialization/v4.rst
@@ -57,11 +57,11 @@ written to the byte sequence in the exact order they appear in the following lis
    * Threshold type: single ``uint8_t`` scalar representing enum ``TypeInfo``.
    * Leaf output type: single ``uint8_t`` scalar representing enum ``TypeInfo``.
 
-#. Number of trees: single ``uint64_t`` scalar.
+#. Number of trees (``num_tree``): single ``uint64_t`` scalar.
 #. Header 2
 
    * Number of features in data: single ``int32_t`` scalar.
-   * Task type: single ``uint8_t`` scalar representing enum ``TaskType``.
+   * Task type (``task_type``): single ``uint8_t`` scalar representing enum ``TaskType``.
    * Whether to average tree outputs: single ``bool`` scalar.
    * Task parameters
 
@@ -75,6 +75,11 @@ written to the byte sequence in the exact order they appear in the following lis
      - ``pred_transform``: 256-character long ``char`` array. Stores a human-readable name of the transformation function that's applied to prediction outputs. The unused elements in the array should be padded with null characters (``\0``).
      - ``sigmoid_alpha``: single ``float`` scalar. This model parameter is relevant when ``pred_transform="sigmoid"``.
      - ``ratio_c``: single ``float`` scalar. This model parameter is relevant when ``pred_transform="exponential_standard_ratio"``.
+   * Per-tree Metadata
+     - ``target_id``: an array of ``int32_t``. ``target[i]`` indicates the target for which the ``i``-th tree produces output.  If the tree is a multi-target tree (i.e. it yields output for all targets), ``target[i]`` is set to -1.
+        This array is expected to have length ``num_tree``.
+     - ``grove_id``: an array of ``int32_t``. ``grove[i]`` indicates the class for which the ``i``-th tree produces output. If ``task_type == kMultiClfGrovePerClass``, the ``grove_id`` array will have length ``num_tree``;
+       if ``task_type != kMultiClfGrovePerClass``, the ``grove_id`` array will be empty. For multi-target trees, the corresponding ``grove_id[i]`` is set to -1.
    * ``base_scores``: an array of ``LeafOutputType``. This vector is expected to have length ``num_target * max(num_class)``. The elements will be laid out in the row-major layout.
      The predicted margin scores of all data points will be adjusted by this vector.
 

--- a/docs/serialization/v4.rst
+++ b/docs/serialization/v4.rst
@@ -21,10 +21,9 @@ We first define a set of enum types to be used in the serialization format.
 
   - ``kBinaryClf`` (0): binary classifier
   - ``kRegressor`` (1): regressor
-  - ``kLearningToRank`` (2): learning-to-rank
-  - ``kMultiClfGrovePerClass`` (3): multi-class classifier with grove-per-class
-  - ``kMultiClfProbDistLeaf`` (4): multi-class classifier with vector leaf outputs producing probability distribution
-  - ``kIsolationForest`` (5): isolation forest
+  - ``kMultiClf`` (2): multi-class classifier
+  - ``kLearningToRank`` (3): learning-to-rank
+  - ``kIsolationForest`` (4): isolation forest
 
 * ``Operator``: underlying type ``int8_t``. Indicates the comparison operator used in an internal test node in a tree.
 
@@ -80,8 +79,8 @@ written to the byte sequence in the exact order they appear in the following lis
 
      - ``target_id``: an array of ``int32_t``. ``target[i]`` indicates the target for which the ``i``-th tree produces output.  If the tree is a multi-target tree (i.e. it yields output for all targets), ``target[i]`` is set to -1.
        This array is expected to have length ``num_tree``.
-     - ``class_id``: an array of ``int32_t``. ``class_id[i]`` indicates the class for which the ``i``-th tree produces output. For multi-target trees, the corresponding ``class_id[i]`` is set to -1.
-       If ``task_type == kMultiClfGrovePerClass``, the ``class_id`` array will have length ``num_tree``; if ``task_type != kMultiClfGrovePerClass``, the ``class_id`` array will be empty.
+     - ``class_id``: an array of ``int32_t``. ``class_id[i]`` indicates the class for which the ``i``-th tree produces output. For vector-leaf trees that produce outputs for multiple classes,
+       the corresponding ``class_id[i]`` is set to -1. The ``class_id`` array is expected to have length ``num_tree``.
 
    * ``base_scores``: an array of ``LeafOutputType``. This vector is expected to have length ``num_target * max(num_class)``. The elements will be laid out in the row-major layout.
      The predicted margin scores of all data points will be adjusted by this vector.


### PR DESCRIPTION
The latest XGBoost (dev version) supports two strategies for multi-target models:
* Fit one model per target (fit a group of trees for each target)
* Fit trees that output a vector leaf.
(From https://xgboost.readthedocs.io/en/latest/tutorials/multioutput.html).

It is possible in an XGBoost model to have a mixture of two strategies. For example, to fit a model for three targets, you can fit three (single-output) trees in the first boosting iteration, and fit a single multi-output tree in the second boosting iteration.
To handle this kind of model, **we should clearly annotate each tree to indicate which target/class it belongs to**.

As a corollary, `task_type` is now simpler: there is no more need for distinguishing different types of multiclass classifiers.

Rendered output: https://treelite--510.org.readthedocs.build/en/510/serialization/v4.html

@trivialfis Can you review this revision to the serialization format?