### PR TITLE
Fix compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,26 @@
+cmake_policy(SET CMP0025 NEW)
 cmake_policy(SET CMP0091 NEW)
 set(CMAKE_FIND_NO_INSTALL_PREFIX TRUE FORCE)
 cmake_minimum_required (VERSION 3.16)
 project(treelite LANGUAGES CXX C VERSION 4.0.0)
 
-# check MSVC version
+# Check compiler versions
+# Use latest compilers to ensure that std::filesystem is available
 if(MSVC)
   if(MSVC_VERSION LESS 1920)
-    message(FATAL_ERROR "Need Visual Studio 2019 or newer to compile Treelite")
+    message(FATAL_ERROR "Need Visual Studio 2019 or newer to build Treelite")
+  endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.1")
+    message(FATAL_ERROR "Need GCC 8.1 or newer to build Treelite")
+  endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11.0")
+    message(FATAL_ERROR "Need Xcode 11.0 (AppleClang 11.0) or newer to build Treelite")
+  endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
+    message(FATAL_ERROR "Need Clang 9.0 or newer to build Treelite")
   endif()
 endif()
 

--- a/include/treelite/data.h
+++ b/include/treelite/data.h
@@ -9,6 +9,8 @@
 
 #include <treelite/typeinfo.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <type_traits>
 #include <vector>
@@ -19,9 +21,9 @@ enum class DMatrixType : uint8_t { kDense = 0, kSparseCSR = 1 };
 
 class DMatrix {
  public:
-  virtual size_t GetNumRow() const = 0;
-  virtual size_t GetNumCol() const = 0;
-  virtual size_t GetNumElem() const = 0;
+  virtual std::size_t GetNumRow() const = 0;
+  virtual std::size_t GetNumCol() const = 0;
+  virtual std::size_t GetNumElem() const = 0;
   virtual DMatrixType GetType() const = 0;
   virtual TypeInfo GetElementType() const = 0;
   DMatrix() = default;
@@ -34,16 +36,16 @@ class DenseDMatrix : public DMatrix {
 
  public:
   template <typename ElementType>
-  static std::unique_ptr<DenseDMatrix> Create(
-      std::vector<ElementType> data, ElementType missing_value, size_t num_row, size_t num_col);
+  static std::unique_ptr<DenseDMatrix> Create(std::vector<ElementType> data,
+      ElementType missing_value, std::size_t num_row, std::size_t num_col);
   template <typename ElementType>
   static std::unique_ptr<DenseDMatrix> Create(
-      void const* data, void const* missing_value, size_t num_row, size_t num_col);
-  static std::unique_ptr<DenseDMatrix> Create(
-      TypeInfo type, void const* data, void const* missing_value, size_t num_row, size_t num_col);
-  size_t GetNumRow() const override = 0;
-  size_t GetNumCol() const override = 0;
-  size_t GetNumElem() const override = 0;
+      void const* data, void const* missing_value, std::size_t num_row, std::size_t num_col);
+  static std::unique_ptr<DenseDMatrix> Create(TypeInfo type, void const* data,
+      void const* missing_value, std::size_t num_row, std::size_t num_col);
+  std::size_t GetNumRow() const override = 0;
+  std::size_t GetNumCol() const override = 0;
+  std::size_t GetNumElem() const override = 0;
   DMatrixType GetType() const override = 0;
   TypeInfo GetElementType() const override;
 };
@@ -56,28 +58,28 @@ class DenseDMatrixImpl : public DenseDMatrix {
   /*! \brief value representing the missing value (usually NaN) */
   ElementType missing_value;
   /*! \brief number of rows */
-  size_t num_row;
+  std::size_t num_row;
   /*! \brief number of columns (i.e. # of features used) */
-  size_t num_col;
+  std::size_t num_col;
 
   DenseDMatrixImpl() = delete;
-  DenseDMatrixImpl(
-      std::vector<ElementType> data, ElementType missing_value, size_t num_row, size_t num_col);
+  DenseDMatrixImpl(std::vector<ElementType> data, ElementType missing_value, std::size_t num_row,
+      std::size_t num_col);
   ~DenseDMatrixImpl() = default;
   DenseDMatrixImpl(DenseDMatrixImpl const&) = default;
   DenseDMatrixImpl(DenseDMatrixImpl&&) noexcept = default;
   DenseDMatrixImpl& operator=(DenseDMatrixImpl const&) = default;
   DenseDMatrixImpl& operator=(DenseDMatrixImpl&&) noexcept = default;
 
-  size_t GetNumRow() const override;
-  size_t GetNumCol() const override;
-  size_t GetNumElem() const override;
+  std::size_t GetNumRow() const override;
+  std::size_t GetNumCol() const override;
+  std::size_t GetNumElem() const override;
   DMatrixType GetType() const override;
 
   template <typename OutputType>
-  void FillRow(size_t row_id, OutputType* out) const;
+  void FillRow(std::size_t row_id, OutputType* out) const;
   template <typename OutputType>
-  void ClearRow(size_t row_id, OutputType* out) const;
+  void ClearRow(std::size_t row_id, OutputType* out) const;
 
   friend class DenseDMatrix;
 };
@@ -89,15 +91,17 @@ class CSRDMatrix : public DMatrix {
  public:
   template <typename ElementType>
   static std::unique_ptr<CSRDMatrix> Create(std::vector<ElementType> data,
-      std::vector<uint32_t> col_ind, std::vector<size_t> row_ptr, size_t num_row, size_t num_col);
+      std::vector<std::uint32_t> col_ind, std::vector<std::size_t> row_ptr, std::size_t num_row,
+      std::size_t num_col);
   template <typename ElementType>
-  static std::unique_ptr<CSRDMatrix> Create(void const* data, uint32_t const* col_ind,
-      size_t const* row_ptr, size_t num_row, size_t num_col);
+  static std::unique_ptr<CSRDMatrix> Create(void const* data, std::uint32_t const* col_ind,
+      std::size_t const* row_ptr, std::size_t num_row, std::size_t num_col);
   static std::unique_ptr<CSRDMatrix> Create(TypeInfo type, void const* data,
-      uint32_t const* col_ind, size_t const* row_ptr, size_t num_row, size_t num_col);
-  size_t GetNumRow() const override = 0;
-  size_t GetNumCol() const override = 0;
-  size_t GetNumElem() const override = 0;
+      std::uint32_t const* col_ind, std::size_t const* row_ptr, std::size_t num_row,
+      std::size_t num_col);
+  std::size_t GetNumRow() const override = 0;
+  std::size_t GetNumCol() const override = 0;
+  std::size_t GetNumElem() const override = 0;
   DMatrixType GetType() const override = 0;
   TypeInfo GetElementType() const override;
 };
@@ -108,31 +112,31 @@ class CSRDMatrixImpl : public CSRDMatrix {
   /*! \brief feature values */
   std::vector<ElementType> data;
   /*! \brief feature indices. col_ind[i] indicates the feature index associated with data[i]. */
-  std::vector<uint32_t> col_ind;
+  std::vector<std::uint32_t> col_ind;
   /*! \brief pointer to row headers; length is [num_row] + 1. */
-  std::vector<size_t> row_ptr;
+  std::vector<std::size_t> row_ptr;
   /*! \brief number of rows */
-  size_t num_row;
+  std::size_t num_row;
   /*! \brief number of columns (i.e. # of features used) */
-  size_t num_col;
+  std::size_t num_col;
 
   CSRDMatrixImpl() = delete;
-  CSRDMatrixImpl(std::vector<ElementType> data, std::vector<uint32_t> col_ind,
-      std::vector<size_t> row_ptr, size_t num_row, size_t num_col);
+  CSRDMatrixImpl(std::vector<ElementType> data, std::vector<std::uint32_t> col_ind,
+      std::vector<std::size_t> row_ptr, std::size_t num_row, std::size_t num_col);
   CSRDMatrixImpl(CSRDMatrixImpl const&) = default;
   CSRDMatrixImpl(CSRDMatrixImpl&&) noexcept = default;
   CSRDMatrixImpl& operator=(CSRDMatrixImpl const&) = default;
   CSRDMatrixImpl& operator=(CSRDMatrixImpl&&) noexcept = default;
 
-  size_t GetNumRow() const override;
-  size_t GetNumCol() const override;
-  size_t GetNumElem() const override;
+  std::size_t GetNumRow() const override;
+  std::size_t GetNumCol() const override;
+  std::size_t GetNumElem() const override;
   DMatrixType GetType() const override;
 
   template <typename OutputType>
-  void FillRow(size_t row_id, OutputType* out) const;
+  void FillRow(std::size_t row_id, OutputType* out) const;
   template <typename OutputType>
-  void ClearRow(size_t row_id, OutputType* out) const;
+  void ClearRow(std::size_t row_id, OutputType* out) const;
 
   friend class CSRDMatrix;
 };

--- a/include/treelite/logging.h
+++ b/include/treelite/logging.h
@@ -46,15 +46,21 @@ std::unique_ptr<std::string> LogCheckFormat(X const& x, Y const& y) {
     return LogCheck##name<int, int>(x, y);                                                     \
   }
 
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-compare"
+#endif  // __GNUC__
+
 DEFINE_CHECK_FUNC(_LT, <)
 DEFINE_CHECK_FUNC(_GT, >)
 DEFINE_CHECK_FUNC(_LE, <=)
 DEFINE_CHECK_FUNC(_GE, >=)
 DEFINE_CHECK_FUNC(_EQ, ==)
 DEFINE_CHECK_FUNC(_NE, !=)
+
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif  // __GNUC__
 
 #define TREELITE_CHECK_BINARY_OP(name, op, x, y)                    \
   if (auto __treelite__log__err = ::treelite::LogCheck##name(x, y)) \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,9 +5,6 @@ target_link_libraries(objtreelite PRIVATE fmt::fmt-header-only RapidJSON::rapidj
 
 if(USE_OPENMP)
   if(APPLE)
-    # Require CMake 3.16+ on Mac OSX, as previous versions of CMake had trouble locating
-    # OpenMP on Mac. See https://github.com/dmlc/xgboost/pull/5146#issuecomment-568312706
-    cmake_minimum_required(VERSION 3.16)
     find_package(OpenMP)
     if (NOT OpenMP_FOUND)
       # Try again with extra path info; required for libomp 15+ from Homebrew

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -46,7 +46,8 @@ int TreeliteLoadLightGBMModel(char const* filename, ModelHandle* out) {
   return TreeliteLoadLightGBMModelEx(filename, "{}", out);
 }
 
-int TreeliteLoadLightGBMModelEx(char const* filename, char const* config_json, ModelHandle* out) {
+int TreeliteLoadLightGBMModelEx(
+    char const* filename, [[maybe_unused]] char const* config_json, ModelHandle* out) {
   // config_json is unused for now
   API_BEGIN();
   std::unique_ptr<Model> model = frontend::LoadLightGBMModel(filename);
@@ -60,7 +61,8 @@ int TreeliteLoadXGBoostModel(char const* filename, ModelHandle* out) {
   return TreeliteLoadXGBoostModelEx(filename, "{}", out);
 }
 
-int TreeliteLoadXGBoostModelEx(char const* filename, char const* config_json, ModelHandle* out) {
+int TreeliteLoadXGBoostModelEx(
+    char const* filename, [[maybe_unused]] char const* config_json, ModelHandle* out) {
   // config_json is unused for now
   API_BEGIN();
   std::unique_ptr<Model> model = frontend::LoadXGBoostModel(filename);
@@ -103,7 +105,7 @@ int TreeliteLoadXGBoostModelFromMemoryBuffer(void const* buf, size_t len, ModelH
 }
 
 int TreeliteLoadXGBoostModelFromMemoryBufferEx(
-    void const* buf, size_t len, char const* config_json, ModelHandle* out) {
+    void const* buf, size_t len, [[maybe_unused]] char const* config_json, ModelHandle* out) {
   // config_json is unused for now
   API_BEGIN();
   std::unique_ptr<Model> model = frontend::LoadXGBoostModel(buf, len);
@@ -118,7 +120,7 @@ int TreeliteLoadLightGBMModelFromString(char const* model_str, ModelHandle* out)
 }
 
 int TreeliteLoadLightGBMModelFromStringEx(
-    char const* model_str, char const* config_json, ModelHandle* out) {
+    char const* model_str, [[maybe_unused]] char const* config_json, ModelHandle* out) {
   // config_json is unused for now
   API_BEGIN();
   std::unique_ptr<Model> model = frontend::LoadLightGBMModelFromString(model_str);
@@ -127,7 +129,7 @@ int TreeliteLoadLightGBMModelFromStringEx(
 }
 
 int TreeliteBuildModelFromJSONString(
-    char const* json_str, char const* config_json, ModelHandle* out) {
+    char const* json_str, [[maybe_unused]] char const* config_json, ModelHandle* out) {
   API_BEGIN();
   std::unique_ptr<Model> model = frontend::BuildModelFromJSONString(json_str, config_json);
   *out = static_cast<ModelHandle>(model.release());

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -364,8 +364,8 @@ int TreeliteGTILPredictEx(ModelHandle model, float const* input, size_t num_row,
   auto const* config_ = static_cast<gtil::Configuration const*>(config);
   auto& pred_shape = TreeliteAPIThreadLocalStore::Get()->prediction_shape;
   *out_result_size = gtil::Predict(model_, input, num_row, output, *config_, pred_shape);
-  auto prod
-      = std::accumulate<>(std::begin(pred_shape), std::end(pred_shape), 1, std::multiplies<>{});
+  auto prod = std::accumulate<>(
+      std::begin(pred_shape), std::end(pred_shape), std::size_t(1), std::multiplies<>{});
   TREELITE_CHECK_EQ(prod, *out_result_size);
   *out_result_ndim = pred_shape.size();
   *out_result_shape = pred_shape.data();

--- a/src/data.cc
+++ b/src/data.cc
@@ -8,6 +8,7 @@
 #include <treelite/data.h>
 #include <treelite/logging.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <memory>
@@ -15,8 +16,8 @@
 namespace treelite {
 
 template <typename ElementType>
-std::unique_ptr<DenseDMatrix> DenseDMatrix::Create(
-    std::vector<ElementType> data, ElementType missing_value, size_t num_row, size_t num_col) {
+std::unique_ptr<DenseDMatrix> DenseDMatrix::Create(std::vector<ElementType> data,
+    ElementType missing_value, std::size_t num_row, std::size_t num_col) {
   std::unique_ptr<DenseDMatrix> matrix = std::make_unique<DenseDMatrixImpl<ElementType>>(
       std::move(data), missing_value, num_row, num_col);
   matrix->element_type_ = TypeToInfo<ElementType>();
@@ -25,15 +26,15 @@ std::unique_ptr<DenseDMatrix> DenseDMatrix::Create(
 
 template <typename ElementType>
 std::unique_ptr<DenseDMatrix> DenseDMatrix::Create(
-    void const* data, void const* missing_value, size_t num_row, size_t num_col) {
+    void const* data, void const* missing_value, std::size_t num_row, std::size_t num_col) {
   auto* data_ptr = static_cast<ElementType const*>(data);
-  const size_t num_elem = num_row * num_col;
+  const std::size_t num_elem = num_row * num_col;
   return DenseDMatrix::Create(std::vector<ElementType>(data_ptr, data_ptr + num_elem),
       *static_cast<ElementType const*>(missing_value), num_row, num_col);
 }
 
-std::unique_ptr<DenseDMatrix> DenseDMatrix::Create(
-    TypeInfo type, void const* data, void const* missing_value, size_t num_row, size_t num_col) {
+std::unique_ptr<DenseDMatrix> DenseDMatrix::Create(TypeInfo type, void const* data,
+    void const* missing_value, std::size_t num_row, std::size_t num_col) {
   TREELITE_CHECK(type != TypeInfo::kInvalid) << "ElementType cannot be invalid";
   switch (type) {
   case TypeInfo::kFloat32:
@@ -53,8 +54,8 @@ TypeInfo DenseDMatrix::GetElementType() const {
 }
 
 template <typename ElementType>
-DenseDMatrixImpl<ElementType>::DenseDMatrixImpl(
-    std::vector<ElementType> data, ElementType missing_value, size_t num_row, size_t num_col)
+DenseDMatrixImpl<ElementType>::DenseDMatrixImpl(std::vector<ElementType> data,
+    ElementType missing_value, std::size_t num_row, std::size_t num_col)
     : DenseDMatrix(),
       data(std::move(data)),
       missing_value(missing_value),
@@ -62,17 +63,17 @@ DenseDMatrixImpl<ElementType>::DenseDMatrixImpl(
       num_col(num_col) {}
 
 template <typename ElementType>
-size_t DenseDMatrixImpl<ElementType>::GetNumRow() const {
+std::size_t DenseDMatrixImpl<ElementType>::GetNumRow() const {
   return num_row;
 }
 
 template <typename ElementType>
-size_t DenseDMatrixImpl<ElementType>::GetNumCol() const {
+std::size_t DenseDMatrixImpl<ElementType>::GetNumCol() const {
   return num_col;
 }
 
 template <typename ElementType>
-size_t DenseDMatrixImpl<ElementType>::GetNumElem() const {
+std::size_t DenseDMatrixImpl<ElementType>::GetNumElem() const {
   return num_row * num_col;
 }
 
@@ -83,9 +84,9 @@ DMatrixType DenseDMatrixImpl<ElementType>::GetType() const {
 
 template <typename ElementType>
 template <typename OutputType>
-void DenseDMatrixImpl<ElementType>::FillRow(size_t row_id, OutputType* out) const {
-  size_t out_idx = 0;
-  size_t in_idx = row_id * num_col;
+void DenseDMatrixImpl<ElementType>::FillRow(std::size_t row_id, OutputType* out) const {
+  std::size_t out_idx = 0;
+  std::size_t in_idx = row_id * num_col;
   while (out_idx < num_col) {
     out[out_idx] = static_cast<OutputType>(data[in_idx]);
     ++out_idx;
@@ -95,15 +96,16 @@ void DenseDMatrixImpl<ElementType>::FillRow(size_t row_id, OutputType* out) cons
 
 template <typename ElementType>
 template <typename OutputType>
-void DenseDMatrixImpl<ElementType>::ClearRow(size_t row_id, OutputType* out) const {
-  for (size_t i = 0; i < num_col; ++i) {
+void DenseDMatrixImpl<ElementType>::ClearRow(std::size_t row_id, OutputType* out) const {
+  for (std::size_t i = 0; i < num_col; ++i) {
     out[i] = std::numeric_limits<OutputType>::quiet_NaN();
   }
 }
 
 template <typename ElementType>
 std::unique_ptr<CSRDMatrix> CSRDMatrix::Create(std::vector<ElementType> data,
-    std::vector<uint32_t> col_ind, std::vector<size_t> row_ptr, size_t num_row, size_t num_col) {
+    std::vector<std::uint32_t> col_ind, std::vector<std::size_t> row_ptr, std::size_t num_row,
+    std::size_t num_col) {
   std::unique_ptr<CSRDMatrix> matrix = std::make_unique<CSRDMatrixImpl<ElementType>>(
       std::move(data), std::move(col_ind), std::move(row_ptr), num_row, num_col);
   matrix->element_type_ = TypeToInfo<ElementType>();
@@ -111,17 +113,18 @@ std::unique_ptr<CSRDMatrix> CSRDMatrix::Create(std::vector<ElementType> data,
 }
 
 template <typename ElementType>
-std::unique_ptr<CSRDMatrix> CSRDMatrix::Create(void const* data, uint32_t const* col_ind,
-    size_t const* row_ptr, size_t num_row, size_t num_col) {
+std::unique_ptr<CSRDMatrix> CSRDMatrix::Create(void const* data, std::uint32_t const* col_ind,
+    std::size_t const* row_ptr, std::size_t num_row, std::size_t num_col) {
   auto* data_ptr = static_cast<ElementType const*>(data);
-  const size_t num_elem = row_ptr[num_row];
+  const std::size_t num_elem = row_ptr[num_row];
   return CSRDMatrix::Create(std::vector<ElementType>(data_ptr, data_ptr + num_elem),
-      std::vector<uint32_t>(col_ind, col_ind + num_elem),
-      std::vector<size_t>(row_ptr, row_ptr + num_row + 1), num_row, num_col);
+      std::vector<std::uint32_t>(col_ind, col_ind + num_elem),
+      std::vector<std::size_t>(row_ptr, row_ptr + num_row + 1), num_row, num_col);
 }
 
 std::unique_ptr<CSRDMatrix> CSRDMatrix::Create(TypeInfo type, void const* data,
-    uint32_t const* col_ind, size_t const* row_ptr, size_t num_row, size_t num_col) {
+    std::uint32_t const* col_ind, std::size_t const* row_ptr, std::size_t num_row,
+    std::size_t num_col) {
   TREELITE_CHECK(type != TypeInfo::kInvalid) << "ElementType cannot be invalid";
   switch (type) {
   case TypeInfo::kFloat32:
@@ -142,7 +145,8 @@ TypeInfo CSRDMatrix::GetElementType() const {
 
 template <typename ElementType>
 CSRDMatrixImpl<ElementType>::CSRDMatrixImpl(std::vector<ElementType> data,
-    std::vector<uint32_t> col_ind, std::vector<size_t> row_ptr, size_t num_row, size_t num_col)
+    std::vector<std::uint32_t> col_ind, std::vector<std::size_t> row_ptr, std::size_t num_row,
+    std::size_t num_col)
     : CSRDMatrix(),
       data(std::move(data)),
       col_ind(std::move(col_ind)),
@@ -151,17 +155,17 @@ CSRDMatrixImpl<ElementType>::CSRDMatrixImpl(std::vector<ElementType> data,
       num_col(num_col) {}
 
 template <typename ElementType>
-size_t CSRDMatrixImpl<ElementType>::GetNumRow() const {
+std::size_t CSRDMatrixImpl<ElementType>::GetNumRow() const {
   return num_row;
 }
 
 template <typename ElementType>
-size_t CSRDMatrixImpl<ElementType>::GetNumCol() const {
+std::size_t CSRDMatrixImpl<ElementType>::GetNumCol() const {
   return num_col;
 }
 
 template <typename ElementType>
-size_t CSRDMatrixImpl<ElementType>::GetNumElem() const {
+std::size_t CSRDMatrixImpl<ElementType>::GetNumElem() const {
   return row_ptr.at(num_row);
 }
 
@@ -172,16 +176,16 @@ DMatrixType CSRDMatrixImpl<ElementType>::GetType() const {
 
 template <typename ElementType>
 template <typename OutputType>
-void CSRDMatrixImpl<ElementType>::FillRow(size_t row_id, OutputType* out) const {
-  for (size_t i = row_ptr[row_id]; i < row_ptr[row_id + 1]; ++i) {
+void CSRDMatrixImpl<ElementType>::FillRow(std::size_t row_id, OutputType* out) const {
+  for (std::size_t i = row_ptr[row_id]; i < row_ptr[row_id + 1]; ++i) {
     out[col_ind[i]] = static_cast<OutputType>(data[i]);
   }
 }
 
 template <typename ElementType>
 template <typename OutputType>
-void CSRDMatrixImpl<ElementType>::ClearRow(size_t row_id, OutputType* out) const {
-  for (size_t i = row_ptr[row_id]; i < row_ptr[row_id + 1]; ++i) {
+void CSRDMatrixImpl<ElementType>::ClearRow(std::size_t row_id, OutputType* out) const {
+  for (std::size_t i = row_ptr[row_id]; i < row_ptr[row_id + 1]; ++i) {
     out[col_ind[i]] = std::numeric_limits<OutputType>::quiet_NaN();
   }
 }
@@ -191,21 +195,21 @@ template class DenseDMatrixImpl<double>;
 template class CSRDMatrixImpl<float>;
 template class CSRDMatrixImpl<double>;
 
-template void CSRDMatrixImpl<float>::FillRow<float>(size_t, float*) const;
-template void CSRDMatrixImpl<float>::FillRow<double>(size_t, double*) const;
-template void CSRDMatrixImpl<float>::ClearRow<float>(size_t, float*) const;
-template void CSRDMatrixImpl<float>::ClearRow<double>(size_t, double*) const;
-template void CSRDMatrixImpl<double>::FillRow<float>(size_t, float*) const;
-template void CSRDMatrixImpl<double>::FillRow<double>(size_t, double*) const;
-template void CSRDMatrixImpl<double>::ClearRow<float>(size_t, float*) const;
-template void CSRDMatrixImpl<double>::ClearRow<double>(size_t, double*) const;
-template void DenseDMatrixImpl<float>::FillRow<float>(size_t, float*) const;
-template void DenseDMatrixImpl<float>::FillRow<double>(size_t, double*) const;
-template void DenseDMatrixImpl<float>::ClearRow<float>(size_t, float*) const;
-template void DenseDMatrixImpl<float>::ClearRow<double>(size_t, double*) const;
-template void DenseDMatrixImpl<double>::FillRow<float>(size_t, float*) const;
-template void DenseDMatrixImpl<double>::FillRow<double>(size_t, double*) const;
-template void DenseDMatrixImpl<double>::ClearRow<float>(size_t, float*) const;
-template void DenseDMatrixImpl<double>::ClearRow<double>(size_t, double*) const;
+template void CSRDMatrixImpl<float>::FillRow<float>(std::size_t, float*) const;
+template void CSRDMatrixImpl<float>::FillRow<double>(std::size_t, double*) const;
+template void CSRDMatrixImpl<float>::ClearRow<float>(std::size_t, float*) const;
+template void CSRDMatrixImpl<float>::ClearRow<double>(std::size_t, double*) const;
+template void CSRDMatrixImpl<double>::FillRow<float>(std::size_t, float*) const;
+template void CSRDMatrixImpl<double>::FillRow<double>(std::size_t, double*) const;
+template void CSRDMatrixImpl<double>::ClearRow<float>(std::size_t, float*) const;
+template void CSRDMatrixImpl<double>::ClearRow<double>(std::size_t, double*) const;
+template void DenseDMatrixImpl<float>::FillRow<float>(std::size_t, float*) const;
+template void DenseDMatrixImpl<float>::FillRow<double>(std::size_t, double*) const;
+template void DenseDMatrixImpl<float>::ClearRow<float>(std::size_t, float*) const;
+template void DenseDMatrixImpl<float>::ClearRow<double>(std::size_t, double*) const;
+template void DenseDMatrixImpl<double>::FillRow<float>(std::size_t, float*) const;
+template void DenseDMatrixImpl<double>::FillRow<double>(std::size_t, double*) const;
+template void DenseDMatrixImpl<double>::ClearRow<float>(std::size_t, float*) const;
+template void DenseDMatrixImpl<double>::ClearRow<double>(std::size_t, double*) const;
 
 }  // namespace treelite

--- a/src/data.cc
+++ b/src/data.cc
@@ -96,7 +96,8 @@ void DenseDMatrixImpl<ElementType>::FillRow(std::size_t row_id, OutputType* out)
 
 template <typename ElementType>
 template <typename OutputType>
-void DenseDMatrixImpl<ElementType>::ClearRow(std::size_t row_id, OutputType* out) const {
+void DenseDMatrixImpl<ElementType>::ClearRow(
+    [[maybe_unused]] std::size_t row_id, OutputType* out) const {
   for (std::size_t i = 0; i < num_col; ++i) {
     out[i] = std::numeric_limits<OutputType>::quiet_NaN();
   }

--- a/src/frontend/json_importer.cc
+++ b/src/frontend/json_importer.cc
@@ -141,7 +141,6 @@ void ParseTree(rapidjson::Value::ConstObject const& object, treelite::Tree<float
   TREELITE_CHECK_GE(root_id, 0) << "root_id cannot be negative";
   auto const& nodes = ExpectArray(object, "nodes");
   TREELITE_CHECK(!nodes.Empty()) << "The nodes array must not be empty";
-  const std::size_t num_nodes = nodes.Size();
 
   // Scan through nodes and create a lookup table. This is so that users can specify custom
   // node IDs via field "node_id". Note that the constructed Treelite model objects will use
@@ -218,7 +217,7 @@ void ParseTree(rapidjson::Value::ConstObject const& object, treelite::Tree<float
 namespace treelite::frontend {
 
 std::unique_ptr<treelite::Model> BuildModelFromJSONString(
-    char const* json_str, char const* config_json) {
+    char const* json_str, [[maybe_unused]] char const* config_json) {
   // config_json unused for now
 
   rapidjson::Document model_spec;

--- a/src/frontend/sklearn.cc
+++ b/src/frontend/sklearn.cc
@@ -19,7 +19,7 @@ namespace treelite::frontend {
 
 template <typename MetaHandlerFunc, typename LeafHandlerFunc>
 std::unique_ptr<treelite::Model> LoadSKLearnModel(int n_trees, int n_features, int n_classes,
-    std::int64_t const* node_count, std::int64_t const** children_left,
+    [[maybe_unused]] std::int64_t const* node_count, std::int64_t const** children_left,
     std::int64_t const** children_right, std::int64_t const** feature, double const** threshold,
     double const** value, std::int64_t const** n_node_samples,
     double const** weighted_n_node_samples, double const** impurity, MetaHandlerFunc meta_handler,
@@ -79,10 +79,11 @@ std::unique_ptr<treelite::Model> LoadSKLearnModel(int n_trees, int n_features, i
 
 template <typename MetaHandlerFunc, typename LeafHandlerFunc>
 std::unique_ptr<treelite::Model> LoadSKLearnHistGradientBoosting(int n_trees, int n_features,
-    int n_classes, std::int64_t const* node_count, std::int64_t const** children_left,
-    std::int64_t const** children_right, std::int64_t const** feature, double const** threshold,
-    std::int8_t const** default_left, double const** value, std::int64_t const** n_node_samples,
-    double const** gain, MetaHandlerFunc meta_handler, LeafHandlerFunc leaf_handler) {
+    int n_classes, [[maybe_unused]] std::int64_t const* node_count,
+    std::int64_t const** children_left, std::int64_t const** children_right,
+    std::int64_t const** feature, double const** threshold, std::int8_t const** default_left,
+    double const** value, std::int64_t const** n_node_samples, double const** gain,
+    MetaHandlerFunc meta_handler, LeafHandlerFunc leaf_handler) {
   TREELITE_CHECK_GT(n_trees, 0);
   TREELITE_CHECK_GT(n_features, 0);
 
@@ -130,7 +131,7 @@ std::unique_ptr<treelite::Model> LoadSKLearnRandomForestRegressor(int n_estimato
     std::int64_t const** children_right, std::int64_t const** feature, double const** threshold,
     double const** value, std::int64_t const** n_node_samples,
     double const** weighted_n_node_samples, double const** impurity) {
-  auto meta_handler = [](treelite::Model* model, int n_features, int n_classes) {
+  auto meta_handler = [](treelite::Model* model, int n_features, [[maybe_unused]] int n_classes) {
     model->num_feature = n_features;
     model->average_tree_output = true;
     model->task_type = treelite::TaskType::kBinaryClfRegr;
@@ -141,11 +142,12 @@ std::unique_ptr<treelite::Model> LoadSKLearnRandomForestRegressor(int n_estimato
     std::strncpy(model->param.pred_transform, "identity", sizeof(model->param.pred_transform));
     model->param.global_bias = 0.0f;
   };
-  auto leaf_handler = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
-                          int n_classes, treelite::Tree<double, double>& dest_tree) {
-    const double leaf_value = value[tree_id][node_id];
-    dest_tree.SetLeaf(new_node_id, leaf_value);
-  };
+  auto leaf_handler
+      = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
+            [[maybe_unused]] int n_classes, treelite::Tree<double, double>& dest_tree) {
+          const double leaf_value = value[tree_id][node_id];
+          dest_tree.SetLeaf(new_node_id, leaf_value);
+        };
   return LoadSKLearnModel(n_estimators, n_features, 1, node_count, children_left, children_right,
       feature, threshold, value, n_node_samples, weighted_n_node_samples, impurity, meta_handler,
       leaf_handler);
@@ -156,23 +158,25 @@ std::unique_ptr<treelite::Model> LoadSKLearnIsolationForest(int n_estimators, in
     std::int64_t const** children_right, std::int64_t const** feature, double const** threshold,
     double const** value, std::int64_t const** n_node_samples,
     double const** weighted_n_node_samples, double const** impurity, double const ratio_c) {
-  auto meta_handler = [ratio_c](treelite::Model* model, int n_features, int n_classes) {
-    model->num_feature = n_features;
-    model->average_tree_output = true;
-    model->task_type = treelite::TaskType::kBinaryClfRegr;
-    model->task_param.grove_per_class = false;
-    model->task_param.output_type = treelite::TaskParam::OutputType::kFloat;
-    model->task_param.num_class = 1;
-    model->task_param.leaf_vector_size = 1;
-    std::strncpy(model->param.pred_transform, "exponential_standard_ratio",
-        sizeof(model->param.pred_transform));
-    model->param.ratio_c = ratio_c;
-  };
-  auto leaf_handler = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
-                          int n_classes, treelite::Tree<double, double>& dest_tree) {
-    const double leaf_value = value[tree_id][node_id];
-    dest_tree.SetLeaf(new_node_id, leaf_value);
-  };
+  auto meta_handler
+      = [ratio_c](treelite::Model* model, int n_features, [[maybe_unused]] int n_classes) {
+          model->num_feature = n_features;
+          model->average_tree_output = true;
+          model->task_type = treelite::TaskType::kBinaryClfRegr;
+          model->task_param.grove_per_class = false;
+          model->task_param.output_type = treelite::TaskParam::OutputType::kFloat;
+          model->task_param.num_class = 1;
+          model->task_param.leaf_vector_size = 1;
+          std::strncpy(model->param.pred_transform, "exponential_standard_ratio",
+              sizeof(model->param.pred_transform));
+          model->param.ratio_c = ratio_c;
+        };
+  auto leaf_handler
+      = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
+            [[maybe_unused]] int n_classes, treelite::Tree<double, double>& dest_tree) {
+          const double leaf_value = value[tree_id][node_id];
+          dest_tree.SetLeaf(new_node_id, leaf_value);
+        };
   return LoadSKLearnModel(n_estimators, n_features, 1, node_count, children_left, children_right,
       feature, threshold, value, n_node_samples, weighted_n_node_samples, impurity, meta_handler,
       leaf_handler);
@@ -184,7 +188,7 @@ std::unique_ptr<treelite::Model> LoadSKLearnRandomForestClassifierBinary(int n_e
     std::int64_t const** feature, double const** threshold, double const** value,
     std::int64_t const** n_node_samples, double const** weighted_n_node_samples,
     double const** impurity) {
-  auto meta_handler = [](treelite::Model* model, int n_features, int n_classes) {
+  auto meta_handler = [](treelite::Model* model, int n_features, [[maybe_unused]] int n_classes) {
     model->num_feature = n_features;
     model->average_tree_output = true;
     model->task_type = treelite::TaskType::kBinaryClfRegr;
@@ -195,14 +199,15 @@ std::unique_ptr<treelite::Model> LoadSKLearnRandomForestClassifierBinary(int n_e
     std::strncpy(model->param.pred_transform, "identity", sizeof(model->param.pred_transform));
     model->param.global_bias = 0.0f;
   };
-  auto leaf_handler = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
-                          int n_classes, treelite::Tree<double, double>& dest_tree) {
-    // Get counts for each label (+/-) at this leaf node
-    const double* leaf_count = &value[tree_id][node_id * 2];
-    // Compute the fraction of positive data points at this leaf node
-    const double fraction_positive = leaf_count[1] / (leaf_count[0] + leaf_count[1]);
-    dest_tree.SetLeaf(new_node_id, fraction_positive);
-  };
+  auto leaf_handler
+      = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
+            [[maybe_unused]] int n_classes, treelite::Tree<double, double>& dest_tree) {
+          // Get counts for each label (+/-) at this leaf node
+          const double* leaf_count = &value[tree_id][node_id * 2];
+          // Compute the fraction of positive data points at this leaf node
+          const double fraction_positive = leaf_count[1] / (leaf_count[0] + leaf_count[1]);
+          dest_tree.SetLeaf(new_node_id, fraction_positive);
+        };
   return LoadSKLearnModel(n_estimators, n_features, n_classes, node_count, children_left,
       children_right, feature, threshold, value, n_node_samples, weighted_n_node_samples, impurity,
       meta_handler, leaf_handler);
@@ -265,7 +270,7 @@ std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingRegressor(int n_iter
     std::int64_t const** children_right, std::int64_t const** feature, double const** threshold,
     double const** value, std::int64_t const** n_node_samples,
     double const** weighted_n_node_samples, double const** impurity) {
-  auto meta_handler = [](treelite::Model* model, int n_features, int n_classes) {
+  auto meta_handler = [](treelite::Model* model, int n_features, [[maybe_unused]] int n_classes) {
     model->num_feature = n_features;
     model->average_tree_output = false;
     model->task_type = treelite::TaskType::kBinaryClfRegr;
@@ -276,11 +281,12 @@ std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingRegressor(int n_iter
     std::strncpy(model->param.pred_transform, "identity", sizeof(model->param.pred_transform));
     model->param.global_bias = 0.0f;
   };
-  auto leaf_handler = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
-                          int n_classes, treelite::Tree<double, double>& dest_tree) {
-    const double leaf_value = value[tree_id][node_id];
-    dest_tree.SetLeaf(new_node_id, leaf_value);
-  };
+  auto leaf_handler
+      = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
+            [[maybe_unused]] int n_classes, treelite::Tree<double, double>& dest_tree) {
+          const double leaf_value = value[tree_id][node_id];
+          dest_tree.SetLeaf(new_node_id, leaf_value);
+        };
   return LoadSKLearnModel(n_iter, n_features, 1, node_count, children_left, children_right, feature,
       threshold, value, n_node_samples, weighted_n_node_samples, impurity, meta_handler,
       leaf_handler);
@@ -292,7 +298,7 @@ std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingClassifierBinary(int
     std::int64_t const** feature, double const** threshold, double const** value,
     std::int64_t const** n_node_samples, double const** weighted_n_node_samples,
     double const** impurity) {
-  auto meta_handler = [](treelite::Model* model, int n_features, int n_classes) {
+  auto meta_handler = [](treelite::Model* model, int n_features, [[maybe_unused]] int n_classes) {
     model->num_feature = n_features;
     model->average_tree_output = false;
     model->task_type = treelite::TaskType::kBinaryClfRegr;
@@ -303,11 +309,12 @@ std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingClassifierBinary(int
     std::strncpy(model->param.pred_transform, "sigmoid", sizeof(model->param.pred_transform));
     model->param.global_bias = 0.0f;
   };
-  auto leaf_handler = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
-                          int n_classes, treelite::Tree<double, double>& dest_tree) {
-    const double leaf_value = value[tree_id][node_id];
-    dest_tree.SetLeaf(new_node_id, leaf_value);
-  };
+  auto leaf_handler
+      = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
+            [[maybe_unused]] int n_classes, treelite::Tree<double, double>& dest_tree) {
+          const double leaf_value = value[tree_id][node_id];
+          dest_tree.SetLeaf(new_node_id, leaf_value);
+        };
   return LoadSKLearnModel(n_iter, n_features, n_classes, node_count, children_left, children_right,
       feature, threshold, value, n_node_samples, weighted_n_node_samples, impurity, meta_handler,
       leaf_handler);
@@ -330,11 +337,12 @@ std::unique_ptr<treelite::Model> LoadSKLearnGradientBoostingClassifierMulticlass
     std::strncpy(model->param.pred_transform, "softmax", sizeof(model->param.pred_transform));
     model->param.global_bias = 0.0f;
   };
-  auto leaf_handler = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
-                          int n_classes, treelite::Tree<double, double>& dest_tree) {
-    const double leaf_value = value[tree_id][node_id];
-    dest_tree.SetLeaf(new_node_id, leaf_value);
-  };
+  auto leaf_handler
+      = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
+            [[maybe_unused]] int n_classes, treelite::Tree<double, double>& dest_tree) {
+          const double leaf_value = value[tree_id][node_id];
+          dest_tree.SetLeaf(new_node_id, leaf_value);
+        };
   return LoadSKLearnModel(n_iter * n_classes, n_features, n_classes, node_count, children_left,
       children_right, feature, threshold, value, n_node_samples, weighted_n_node_samples, impurity,
       meta_handler, leaf_handler);
@@ -363,7 +371,8 @@ std::unique_ptr<treelite::Model> LoadSKLearnHistGradientBoostingRegressor(int n_
     std::int8_t const** default_left, double const** value, std::int64_t const** n_node_samples,
     double const** gain, double const* baseline_prediction) {
   auto const global_bias = static_cast<float>(baseline_prediction[0]);
-  auto meta_handler = [global_bias](treelite::Model* model, int n_features, int n_classes) {
+  auto meta_handler = [global_bias](
+                          treelite::Model* model, int n_features, [[maybe_unused]] int n_classes) {
     model->num_feature = n_features;
     model->average_tree_output = false;
     model->task_type = treelite::TaskType::kBinaryClfRegr;
@@ -374,11 +383,12 @@ std::unique_ptr<treelite::Model> LoadSKLearnHistGradientBoostingRegressor(int n_
     std::strncpy(model->param.pred_transform, "identity", sizeof(model->param.pred_transform));
     model->param.global_bias = global_bias;
   };
-  auto leaf_handler = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
-                          int n_classes, treelite::Tree<double, double>& dest_tree) {
-    const double leaf_value = value[tree_id][node_id];
-    dest_tree.SetLeaf(new_node_id, leaf_value);
-  };
+  auto leaf_handler
+      = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
+            [[maybe_unused]] int n_classes, treelite::Tree<double, double>& dest_tree) {
+          const double leaf_value = value[tree_id][node_id];
+          dest_tree.SetLeaf(new_node_id, leaf_value);
+        };
   return LoadSKLearnHistGradientBoosting(n_iter, n_features, 1, node_count, children_left,
       children_right, feature, threshold, default_left, value, n_node_samples, gain, meta_handler,
       leaf_handler);
@@ -391,22 +401,24 @@ std::unique_ptr<treelite::Model> LoadSKLearnHistGradientBoostingClassifierBinary
     double const** value, std::int64_t const** n_node_samples, double const** gain,
     double const* baseline_prediction) {
   auto const global_bias = static_cast<float>(baseline_prediction[0]);
-  auto meta_handler = [global_bias](treelite::Model* model, int n_features, int n_classes) {
-    model->num_feature = n_features;
-    model->average_tree_output = false;
-    model->task_type = treelite::TaskType::kBinaryClfRegr;
-    model->task_param.grove_per_class = false;
-    model->task_param.output_type = treelite::TaskParam::OutputType::kFloat;
-    model->task_param.num_class = 1;
-    model->task_param.leaf_vector_size = 1;
-    std::strncpy(model->param.pred_transform, "sigmoid", sizeof(model->param.pred_transform));
-    model->param.global_bias = global_bias;
-  };
-  auto leaf_handler = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
-                          int n_classes, treelite::Tree<double, double>& dest_tree) {
-    const double leaf_value = value[tree_id][node_id];
-    dest_tree.SetLeaf(new_node_id, leaf_value);
-  };
+  auto meta_handler
+      = [global_bias](treelite::Model* model, int n_features, [[maybe_unused]] int n_classes) {
+          model->num_feature = n_features;
+          model->average_tree_output = false;
+          model->task_type = treelite::TaskType::kBinaryClfRegr;
+          model->task_param.grove_per_class = false;
+          model->task_param.output_type = treelite::TaskParam::OutputType::kFloat;
+          model->task_param.num_class = 1;
+          model->task_param.leaf_vector_size = 1;
+          std::strncpy(model->param.pred_transform, "sigmoid", sizeof(model->param.pred_transform));
+          model->param.global_bias = global_bias;
+        };
+  auto leaf_handler
+      = [](int tree_id, std::int64_t node_id, int new_node_id, double const** value,
+            [[maybe_unused]] int n_classes, treelite::Tree<double, double>& dest_tree) {
+          const double leaf_value = value[tree_id][node_id];
+          dest_tree.SetLeaf(new_node_id, leaf_value);
+        };
   return LoadSKLearnHistGradientBoosting(n_iter, n_features, n_classes, node_count, children_left,
       children_right, feature, threshold, default_left, value, n_node_samples, gain, meta_handler,
       leaf_handler);

--- a/src/frontend/xgboost/xgboost_json.h
+++ b/src/frontend/xgboost/xgboost_json.h
@@ -176,7 +176,7 @@ class BaseHandler : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, BaseH
   template <typename ValueType>
   bool assign_value(std::string const& key, ValueType const& value, ValueType& output);
 
-  virtual bool is_recognized_key(std::string const& key) {
+  virtual bool is_recognized_key([[maybe_unused]] std::string const& key) {
     return false;
   }
 

--- a/src/frontend/xgboost_json.cc
+++ b/src/frontend/xgboost_json.cc
@@ -439,7 +439,7 @@ bool GradientBoosterHandler::StartArray() {
   return push_key_handler<ArrayHandler<double>, std::vector<double>>("weight_drop", weight_drop);
 }
 
-bool GradientBoosterHandler::EndObject(std::size_t memberCount) {
+bool GradientBoosterHandler::EndObject([[maybe_unused]] std::size_t memberCount) {
   if (name == "dart" && !weight_drop.empty()) {
     // Fold weight drop into leaf value for dart models.
     auto& trees = std::get<ModelPreset<float, float>>(output.model->variant_).trees;
@@ -595,7 +595,7 @@ bool XGBoostModelHandler::StartObject() {
           || push_key_handler<XGBoostCheckpointHandler, ParsedXGBoostModel>("Model", output));
 }
 
-bool XGBoostModelHandler::EndObject(std::size_t memberCount) {
+bool XGBoostModelHandler::EndObject([[maybe_unused]] std::size_t memberCount) {
   output.model->average_tree_output = false;
   output.model->task_param.output_type = TaskParam::OutputType::kFloat;
   output.model->task_param.leaf_vector_size = 1;

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -240,7 +240,7 @@ void FVecFill(const std::size_t block_size, const std::size_t batch_offset,
 
 template <typename DMatrixType>
 void FVecDrop(const std::size_t block_size, const std::size_t batch_offset,
-    DMatrixType const* input, const std::size_t fvec_offset, int num_feature,
+    DMatrixType const* input, const std::size_t fvec_offset, [[maybe_unused]] int num_feature,
     std::vector<FVec>& feats) {
   for (std::size_t i = 0; i < block_size; ++i) {
     const std::size_t row_id = batch_offset + i;
@@ -654,8 +654,8 @@ inline std::size_t PredTransform(treelite::Model const& model, DMatrixType const
   // Query the size of output per input row.
   output_size_per_row = pred_transform_func(model, &output[0], &temp[0]);
   // Now transform predictions in parallel
-  treelite::threading_utils::ParallelFor(
-      std::size_t(0), num_row, thread_config, sched, [&](std::size_t row_id, int thread_id) {
+  treelite::threading_utils::ParallelFor(std::size_t(0), num_row, thread_config, sched,
+      [&](std::size_t row_id, [[maybe_unused]] int thread_id) {
         pred_transform_func(
             model, &output[row_id * num_class], &temp[row_id * output_size_per_row]);
       });

--- a/src/gtil/predict.cc
+++ b/src/gtil/predict.cc
@@ -11,6 +11,7 @@
 #include <treelite/logging.h>
 #include <treelite/tree.h>
 
+#include <algorithm>
 #include <cfloat>
 #include <cmath>
 #include <cstddef>
@@ -213,7 +214,8 @@ struct PredictScoreByTreeWithVectorLeafOutputLogic {
   inline static void PushOutput(treelite::Tree<ThresholdType, LeafOutputType> const& tree,
       std::size_t, int node_id, float* output, std::size_t) {
     auto leaf_vector = tree.LeafVector(node_id);
-    std::copy(std::begin(leaf_vector), std::end(leaf_vector), output);
+    std::transform(std::begin(leaf_vector), std::end(leaf_vector), output,
+        [](auto e) { return static_cast<float>(e); });
   }
 };
 


### PR DESCRIPTION
* Protect `#pragma GCC` behind `#ifdef`
* Use `std::filesystem` API from C++17 to create temporary files
* Fix various warnings regarding type casts and unused parameters