### PR TITLE
Improve performance of creating categorical splits

### DIFF
--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -269,7 +269,14 @@ class Tree {
   ContiguousArray<std::size_t> leaf_vector_end_;
   ContiguousArray<std::uint32_t> matching_categories_;
   ContiguousArray<std::size_t> matching_categories_offset_;
+  ContiguousArray<std::size_t> matching_categories_size_;
   bool has_categorical_split_{false};
+
+  // Ensure category offsets are all correct, updating nodes where the offset and size are zero
+  inline void ComputeCategoryOffsets();
+
+  // Compute category sizes based on the offsets
+  inline void ComputeCategorySizes();
 
   /* Note: the following member fields shall be re-computed at serialization time */
   // Whether to use optional fields
@@ -399,7 +406,7 @@ class Tree {
    */
   inline std::vector<std::uint32_t> MatchingCategories(int nid) const {
     const std::size_t offset_begin = matching_categories_offset_[nid];
-    const std::size_t offset_end = matching_categories_offset_[nid + 1];
+    const std::size_t offset_end = offset_begin + matching_categories_size_[nid];
     if (offset_begin >= matching_categories_.Size() || offset_end > matching_categories_.Size()) {
       // Return empty vector, to indicate the lack of any matching categories
       // The node might be a numerical split

--- a/src/json_serializer.cc
+++ b/src/json_serializer.cc
@@ -154,7 +154,6 @@ void DumpTreeAsJSON(WriterType& writer, Tree<ThresholdType, LeafOutputType> cons
   // Basic checks
   TREELITE_CHECK_EQ(tree.nodes_.Size(), tree.num_nodes);
   TREELITE_CHECK_EQ(tree.nodes_.Size() + 1, tree.matching_categories_offset_.Size());
-  TREELITE_CHECK_EQ(tree.matching_categories_offset_.Back(), tree.matching_categories_.Size());
 }
 
 template <typename WriterType>

--- a/src/serializer.cc
+++ b/src/serializer.cc
@@ -68,6 +68,7 @@ class Serializer {
   template <typename ThresholdType, typename LeafOutputType>
   void SerializeTree(Tree<ThresholdType, LeafOutputType>& tree) {
     TREELITE_CHECK_EQ(tree.num_nodes, tree.nodes_.Size()) << "Incorrect number of nodes";
+    tree.ComputeCategoryOffsets();  // Ensure offsets are correct before serialization
     mixin_->SerializePrimitiveField(&tree.num_nodes);
     mixin_->SerializePrimitiveField(&tree.has_categorical_split_);
     mixin_->SerializeCompositeArray(&tree.nodes_, tree.GetFormatStringForNode());
@@ -175,6 +176,8 @@ class Deserializer {
     mixin_->DeserializePrimitiveArray(&tree.leaf_vector_end_);
     mixin_->DeserializePrimitiveArray(&tree.matching_categories_);
     mixin_->DeserializePrimitiveArray(&tree.matching_categories_offset_);
+
+    tree.ComputeCategorySizes();  // Compute sizes from offsets
 
     /* Extension slot 2: Per-tree optional fields -- to be added later */
     mixin_->DeserializePrimitiveField(&tree.num_opt_field_per_tree_);


### PR DESCRIPTION
Creating deep trees with categorical splits can be very slow due to checking and updating the `matching_categories_offset_` values for all nodes after the node being split. This change introduces a separate `matching_categories_size_` array to store the array sizes, and computes any unset offsets in one pass before serialization to keep backwards compatibility of the serialization format, and similarly computes sizes after deserialization.

In a test with some synthetic trees with depth 18, this takes the time to create a tree with the C++ API from 12.8 s to 0.18 s