### PR TITLE
[sklearn] Use more stable interface to get base_scores

### DIFF
--- a/python/treelite/sklearn/importer.py
+++ b/python/treelite/sklearn/importer.py
@@ -295,8 +295,8 @@ def import_model(sklearn_model):
                 raise NotImplementedError("Custom init estimator not supported")
             # pylint: disable=W0212
             base_scores = np.array(
-                sklearn_model._loss.get_init_raw_predictions(
-                    np.zeros((1, sklearn_model.n_features_in_)), sklearn_model.init_
+                sklearn_model._raw_predict_init(
+                    np.zeros((1, sklearn_model.n_features_in_))
                 ),
                 dtype=np.float64,
             )


### PR DESCRIPTION
`_loss.get_init_raw_predictions` is removed in the recent refactoring of `HistGradientBoosting` (https://github.com/scikit-learn/scikit-learn/pull/26278). Replace it with `_raw_predict_init`, which would probably stick around for a while.