### PR TITLE
[CI] Fix S3 upload

### DIFF
--- a/ops/build-cpack.sh
+++ b/ops/build-cpack.sh
@@ -13,7 +13,7 @@ do
 done
 
 echo "##[section]Uploading CPack for amd64..."
-python -m awscli s3 cp build/*.tar.gz s3://treelite-cpack/ --acl public-read || true
+python -m awscli s3 cp build/*.tar.gz s3://treelite-cpack/ --acl public-read --region us-west-2 || true
 
 rm -rf build/
 
@@ -30,4 +30,4 @@ do
 done
 
 echo "##[section]Uploading CPack for aarch64..."
-python -m awscli s3 cp build/*.tar.gz s3://treelite-cpack/ --acl public-read || true
+python -m awscli s3 cp build/*.tar.gz s3://treelite-cpack/ --acl public-read --region us-west-2 || true

--- a/ops/build-macos.sh
+++ b/ops/build-macos.sh
@@ -6,4 +6,4 @@ echo "##[section]Building MacOS Python wheels..."
 tests/ci_build/build_macos_python_wheels.sh ${CIBW_PLATFORM_ID} ${COMMIT_ID}
 
 echo "##[section]Uploading MacOS Python wheels to S3..."
-python -m awscli s3 cp wheelhouse/treelite-*.whl s3://treelite-wheels/ --acl public-read || true
+python -m awscli s3 cp wheelhouse/treelite-*.whl s3://treelite-wheels/ --acl public-read --region us-west-2 || true

--- a/ops/test-linux-python-wheel.sh
+++ b/ops/test-linux-python-wheel.sh
@@ -9,4 +9,4 @@ echo "##[section]Running Python tests..."
 python -m pytest -v -rxXs --fulltrace --durations=0 tests/python/test_sklearn_integration.py
 
 echo "##[section]Uploading Python wheels..."
-python -m awscli s3 cp python/dist/*.whl s3://treelite-wheels/ --acl public-read || true
+python -m awscli s3 cp python/dist/*.whl s3://treelite-wheels/ --acl public-read --region us-west-2 || true

--- a/ops/test-sdist.sh
+++ b/ops/test-sdist.sh
@@ -14,4 +14,4 @@ for file in ./treelite-*.tar.gz
 do
   mv "${file}" "${file%.tar.gz}+${COMMIT_ID}.tar.gz"
 done
-python -m awscli s3 cp treelite-*.tar.gz s3://treelite-wheels/ --acl public-read || true
+python -m awscli s3 cp treelite-*.tar.gz s3://treelite-wheels/ --acl public-read --region us-west-2 || true

--- a/ops/test-win-python-wheel.bat
+++ b/ops/test-win-python-wheel.bat
@@ -17,5 +17,5 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo ##[section]Uploading Python wheels...
 for /R %%i in (python\\dist\\*.whl) DO (
-  python -m awscli s3 cp "%%i" s3://treelite-wheels/ --acl public-read || cd .
+  python -m awscli s3 cp "%%i" s3://treelite-wheels/ --acl public-read --region us-west-2 || cd .
 )


### PR DESCRIPTION
Recently, the S3 upload was breaking silently with cryptic error like
```
<botocore.awsrequest.AWSRequest object at 0x7f44ac9b2eb8>
```
According to https://florian.ec/blog/github-actions-awscli-errors/, it is necessary to specify the AWS region when invoking the AWS CLI.