### PR TITLE
Don't fetch GTest if it's found by CMake

### DIFF
--- a/cmake/ExternalLibs.cmake
+++ b/cmake/ExternalLibs.cmake
@@ -40,7 +40,7 @@ endif()
 # Google C++ tests
 if(BUILD_CPP_TEST)
   find_package(GTest 1.11.0)
-  if(NOT GTEST_FOUND)
+  if(NOT GTest_FOUND)
     message(STATUS "Did not find Google Test in the system root. Fetching Google Test now...")
     FetchContent_Declare(
       googletest


### PR DESCRIPTION
The CMake variable is `GTest_FOUND` not `GTEST_FOUND`.