### PR TITLE
[backport] Don't fetch GTest if it's found by CMake (#539)

### DIFF
--- a/cmake/ExternalLibs.cmake
+++ b/cmake/ExternalLibs.cmake
@@ -40,7 +40,7 @@ endif()
 # Google C++ tests
 if(BUILD_CPP_TEST)
   find_package(GTest 1.11.0)
-  if(NOT GTEST_FOUND)
+  if(NOT GTest_FOUND)
     message(STATUS "Did not find Google Test in the system root. Fetching Google Test now...")
     FetchContent_Declare(
       googletest


### PR DESCRIPTION
Port #539 to the 4.0 release branch.