### PR TITLE
Clarify output dimensions of GTIL

### DIFF
--- a/.github/workflows/misc-tests.yml
+++ b/.github/workflows/misc-tests.yml
@@ -114,7 +114,7 @@ jobs:
         cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=/opt/treelite
         ninja install -v
         cd ../python
-        pip install -v . --config-settings use_system_libtreelite=True \
+        pip install --force-reinstall -v . --config-settings use_system_libtreelite=True \
           --config-settings system_libtreelite_dir=/opt/treelite/lib
         cd ..
         rm -rf build/

--- a/include/treelite/gtil.h
+++ b/include/treelite/gtil.h
@@ -26,16 +26,12 @@ namespace gtil {
 enum class PredictKind : std::int8_t {
   /*!
    * \brief Usual prediction method: sum over trees and apply post-processing.
-   * Expected output dimensions:
-   * - (num_row, num_class) if num_target == 1
-   * - (num_target, num_row, max_num_class) if num_target > 1
+   * Expected output dimensions: (num_target, num_row, max_num_class)
    */
   kPredictDefault = 0,
   /*!
    * \brief Sum over trees, but don't apply post-processing; get raw margin scores instead.
-   * Expected output dimensions:
-   * - (num_row, num_class) if num_target == 1
-   * - (num_target, num_row, max_num_class) if num_target > 1
+   * Expected output dimensions: (num_target, num_row, max_num_class)
    */
   kPredictRaw = 1,
   /*!

--- a/ops/test-linux-python-wheel.sh
+++ b/ops/test-linux-python-wheel.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 echo "##[section]Installing Treelite into Python environment..."
-pip install wheelhouse/*.whl
+pip install --force-reinstall wheelhouse/*.whl
 
 echo "##[section]Running Python tests..."
 python -m pytest -v -rxXs --fulltrace --durations=0 tests/python/test_sklearn_integration.py

--- a/ops/test-macos-python-wheel.sh
+++ b/ops/test-macos-python-wheel.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 echo "##[section]Installing Treelite into Python environment..."
-pip install wheelhouse/*.whl
+pip install --force-reinstall wheelhouse/*.whl
 
 echo "##[section]Running Python tests..."
 python -m pytest -v -rxXs --fulltrace --durations=0 tests/python/test_sklearn_integration.py

--- a/ops/test-sdist.sh
+++ b/ops/test-sdist.sh
@@ -6,7 +6,7 @@ echo "##[section]Building a source distribution..."
 python -m build --sdist python/ --outdir .
 
 echo "##[section]Testing the source distribution..."
-python -m pip install -v treelite-*.tar.gz
+python -m pip install --force-reinstall -v treelite-*.tar.gz
 python -m pytest -v -rxXs --fulltrace --durations=0 tests/python/test_sklearn_integration.py
 
 # Deploy source distribution to S3

--- a/ops/test-serializer-compatibility.sh
+++ b/ops/test-serializer-compatibility.sh
@@ -12,7 +12,7 @@ cd ..
 CURRENT_VERSION=$(cat python/treelite/VERSION)
 
 echo "##[section]Testing serialization: 3.9 -> ${CURRENT_VERSION}"
-pip install treelite==3.9.0 treelite_runtime==3.9.0
+pip install --force-reinstall treelite==3.9.0 treelite_runtime==3.9.0
 python tests/serializer/compatibility_tester.py --task save --checkpoint-path checkpoint.bin \
   --model-pickle-path model.pkl --expected-treelite-version 3.9.0
 PYTHONPATH=./python/ python tests/serializer/compatibility_tester.py --task load \

--- a/python/treelite/gtil/gtil.py
+++ b/python/treelite/gtil/gtil.py
@@ -74,7 +74,7 @@ def predict(
     Returns
     -------
     prediction : :py:class:`numpy.ndarray` array
-        Prediction output. TODO(hcho3): Add expected dimensions
+        Prediction output. Expected dimensions: (num_target, num_row, max(num_class))
     """
     predict_type = "raw" if pred_margin else "default"
 
@@ -131,11 +131,7 @@ def predict_per_tree(model: Model, data: np.ndarray, *, nthread: int = -1):
     -------
     prediction : :py:class:`numpy.ndarray` array
         Prediction output. Expected output dimensions:
-
-        - (num_row, num_tree) for regressors, binary classifiers,
-          and multi-class classifiers with task_type="MultiClfGrovePerClass"
-        - (num_row, num_tree, num_class) for multi-class classifiers with
-          task_type="kMultiClfProbDistLeaf"
+        (num_row, num_tree, leaf_vector_shape[0] * leaf_vector_shape[1])
     """
 
     config = GTILConfig(nthread=nthread, predict_type="score_per_tree")

--- a/src/gtil/output_shape.cc
+++ b/src/gtil/output_shape.cc
@@ -25,7 +25,7 @@ std::vector<std::uint64_t> GetOutputShape(
     if (model.num_target > 1) {
       return {static_cast<std::uint64_t>(model.num_target), num_row, max_num_class};
     } else {
-      return {num_row, max_num_class};
+      return {1, num_row, max_num_class};
     }
   case PredictKind::kPredictLeafID:
     return {num_row, num_tree};

--- a/tests/cpp/test_gtil.cc
+++ b/tests/cpp/test_gtil.cc
@@ -85,10 +85,10 @@ TEST_P(ParametrizedTestSuite, MulticlassClfGrovePerClass) {
   std::vector<std::uint64_t> expected_output_shape;
   std::vector<std::vector<float>> expected_output;
   if (predict_kind == "raw") {
-    expected_output_shape = {1, 3};
+    expected_output_shape = {1, 1, 3};
     expected_output = {{1.3f, -1.8f, 2.5f}, {-1.7f, 1.2f, 1.5f}};
   } else if (predict_kind == "default") {
-    expected_output_shape = {1, 3};
+    expected_output_shape = {1, 1, 3};
     auto softmax = [](float a, float b, float c) {
       float const max = std::max({a, b, c});
       a -= max;
@@ -156,7 +156,7 @@ TEST_P(ParametrizedTestSuite, LeafVectorRF) {
   std::vector<std::uint64_t> expected_output_shape;
   std::vector<std::vector<float>> expected_output;
   if (predict_kind == "raw" || predict_kind == "default") {
-    expected_output_shape = {1, 3};
+    expected_output_shape = {1, 1, 3};
     expected_output = {{100.0f, 200.5f, 300.5f}, {101.0f, 200.0f, 300.0f}};
   } else if (predict_kind == "leaf_id") {
     expected_output_shape = {1, 2};

--- a/tests/python/test_field_accessor.py
+++ b/tests/python/test_field_accessor.py
@@ -170,7 +170,7 @@ def test_tree_editing():
         treelite.gtil.predict(
             model, np.array([[-1.0, 0.0], [1.0, 0.0]], dtype=np.float32)
         ),
-        np.array([[-1.0], [1.0]], dtype=np.float32),
+        np.array([[[-1.0], [1.0]]], dtype=np.float32),
     )
 
     # Change leaf values
@@ -180,7 +180,7 @@ def test_tree_editing():
         treelite.gtil.predict(
             model, np.array([[-1.0, 0.0], [1.0, 0.0]], dtype=np.float32)
         ),
-        np.array([[-100.0], [100.0]], dtype=np.float32),
+        np.array([[[-100.0], [100.0]]], dtype=np.float32),
     )
 
     # Change numerical test
@@ -190,7 +190,7 @@ def test_tree_editing():
         treelite.gtil.predict(
             model, np.array([[0.0, 0.0], [0.0, 2.0]], dtype=np.float32)
         ),
-        np.array([[-100.0], [100.0]], dtype=np.float32),
+        np.array([[[-100.0], [100.0]]], dtype=np.float32),
     )
 
     # Add a test node
@@ -222,5 +222,5 @@ def test_tree_editing():
                 dtype=np.float32,
             ),
         ),
-        np.array([[1.0], [1.0], [2.0], [3.0]], dtype=np.float32),
+        np.array([[[1.0], [1.0], [2.0], [3.0]]], dtype=np.float32),
     )

--- a/tests/python/test_gtil.py
+++ b/tests/python/test_gtil.py
@@ -47,7 +47,7 @@ def test_predict_special_with_regressor(predict_kind, dataset, num_boost_round):
         dtrain,
         num_boost_round=num_boost_round,
     )
-    model: treelite.Model = treelite.Model.from_xgboost(xgb_model)
+    model: treelite.Model = treelite.frontend.from_xgboost(xgb_model)
     assert model.num_tree == num_boost_round
 
     if predict_kind == "leaf_id":
@@ -87,7 +87,7 @@ def test_predict_special_with_binary_classifier(predict_kind, dataset, num_boost
         dtrain=dtrain,
         num_boost_round=num_boost_round,
     )
-    model: treelite.Model = treelite.Model.from_xgboost(xgb_model)
+    model: treelite.Model = treelite.frontend.from_xgboost(xgb_model)
     assert model.num_tree == num_boost_round
 
     if predict_kind == "leaf_id":
@@ -139,7 +139,7 @@ def test_predict_special_with_multiclass_classifier_grove_per_class(
         dtrain,
         num_boost_round=num_boost_round,
     )
-    model: treelite.Model = treelite.Model.from_xgboost(xgb_model)
+    model: treelite.Model = treelite.frontend.from_xgboost(xgb_model)
     assert model.num_tree == num_boost_round * num_class
 
     X_sample = X[0:sample_size]

--- a/tests/python/test_lightgbm_integration.py
+++ b/tests/python/test_lightgbm_integration.py
@@ -77,7 +77,7 @@ def test_lightgbm_regression(
         valid_sets=[dtrain],
         valid_names=["train"],
     )
-    expected_pred = lgb_model.predict(X_pred).reshape((-1, 1))
+    expected_pred = lgb_model.predict(X_pred).reshape((1, -1, 1))
 
     with TemporaryDirectory() as tmpdir:
         lgb_model_path = pathlib.Path(tmpdir) / "lightgbm_model.txt"
@@ -131,7 +131,7 @@ def test_lightgbm_binary_classification(
         valid_sets=[dtrain],
         valid_names=["train"],
     )
-    expected_prob = lgb_model.predict(X_pred).reshape((-1, 1))
+    expected_prob = lgb_model.predict(X_pred).reshape((1, -1, 1))
 
     with TemporaryDirectory() as tmpdir:
         lgb_model_path = pathlib.Path(tmpdir) / "breast_cancer_lightgbm.txt"
@@ -192,7 +192,7 @@ def test_lightgbm_multiclass_classification(
         valid_sets=[dtrain],
         valid_names=["train"],
     )
-    expected_pred = lgb_model.predict(X_pred)
+    expected_pred = lgb_model.predict(X_pred).reshape((1, -1, num_class))
 
     with TemporaryDirectory() as tmpdir:
         lgb_model_path = pathlib.Path(tmpdir) / "iris_lightgbm.txt"
@@ -210,7 +210,7 @@ def test_lightgbm_categorical_data():
     tl_model = treelite.frontend.load_lightgbm_model(lgb_model_path)
 
     X, _ = load_svmlight_file(dataset_db[dataset].dtest, zero_based=True)
-    expected_pred = load_txt(dataset_db[dataset].expected_margin).reshape((-1, 1))
+    expected_pred = load_txt(dataset_db[dataset].expected_margin).reshape((1, -1, 1))
     out_pred = treelite.gtil.predict(tl_model, X.toarray())
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
@@ -238,7 +238,7 @@ def test_lightgbm_sparse_ranking_model(tmpdir):
 
     dtrain = lgb.Dataset(X, label=y, group=[X.shape[0]])
     lgb_model = lgb.train(params, dtrain, num_boost_round=1)
-    lgb_out = lgb_model.predict(X).reshape((-1, 1))
+    lgb_out = lgb_model.predict(X).reshape((1, -1, 1))
     lgb_model.save_model(lgb_model_path)
 
     tl_model = treelite.frontend.load_lightgbm_model(lgb_model_path)
@@ -260,7 +260,7 @@ def test_lightgbm_sparse_categorical_model():
     X, _ = load_svmlight_file(
         dataset_db[dataset].dtest, zero_based=True, n_features=tl_model.num_feature
     )
-    expected_pred = load_txt(dataset_db[dataset].expected_margin).reshape((-1, 1))
+    expected_pred = load_txt(dataset_db[dataset].expected_margin).reshape((1, -1, 1))
     # GTIL doesn't yet support sparse matrix; so use NaN to represent missing values
     Xa = X.toarray()
     Xa[Xa == 0] = "nan"

--- a/tests/python/test_model_builder.py
+++ b/tests/python/test_model_builder.py
@@ -130,10 +130,10 @@ def test_leaf_vector_rf(predict_kind):
     model = builder.commit()
     dmat = np.array([[1.0], [-1.0]], dtype=np.float32)
     if predict_kind in "default":
-        expected_pred = np.array([[100.0, 200.5, 300.5], [101.0, 200.0, 300.0]])
+        expected_pred = np.array([[[100.0, 200.5, 300.5], [101.0, 200.0, 300.0]]])
         pred = treelite.gtil.predict(model, dmat, pred_margin=False)
     elif predict_kind == "raw":
-        expected_pred = np.array([[100.0, 200.5, 300.5], [101.0, 200.0, 300.0]])
+        expected_pred = np.array([[[100.0, 200.5, 300.5], [101.0, 200.0, 300.0]]])
         pred = treelite.gtil.predict(model, dmat, pred_margin=True)
     else:
         expected_pred = np.array([[2, 2], [1, 1]])

--- a/tests/python/test_serializer.py
+++ b/tests/python/test_serializer.py
@@ -71,12 +71,12 @@ def test_serialize_as_bytes(clazz, dataset, n_estimators, max_depth, callback):
         )
     clf = clazz(**kwargs)
     clf.fit(X, y)
-    expected_prob = clf.predict_proba(X)
+    expected_prob = clf.predict_proba(X)[np.newaxis, :, :]
     if (
         clazz in [GradientBoostingClassifier, HistGradientBoostingClassifier]
         and n_classes == 2
     ):
-        expected_prob = expected_prob[:, 1:]
+        expected_prob = expected_prob[:, :, 1:]
 
     # Prediction should be correct after a round-trip
     tl_model = treelite.sklearn.import_model(clf)
@@ -131,7 +131,7 @@ def test_serialize_as_checkpoint(clazz, n_estimators, max_depth, callback):
     if n_targets > 1:
         expected_pred = np.transpose(clf.predict(X)[:, :, np.newaxis], axes=(1, 0, 2))
     else:
-        expected_pred = clf.predict(X).reshape((X.shape[0], -1))
+        expected_pred = clf.predict(X).reshape((1, X.shape[0], -1))
 
     with TemporaryDirectory() as tmpdir:
         # Prediction should be correct after a round-trip

--- a/tests/python/test_sklearn_integration.py
+++ b/tests/python/test_sklearn_integration.py
@@ -77,7 +77,7 @@ def test_skl_regressor(clazz, n_estimators, callback):
     if n_targets > 1:
         expected_pred = np.transpose(clf.predict(X)[:, :, np.newaxis], axes=(1, 0, 2))
     else:
-        expected_pred = clf.predict(X).reshape((X.shape[0], -1))
+        expected_pred = clf.predict(X).reshape((1, X.shape[0], -1))
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=3)
 
 
@@ -126,12 +126,12 @@ def test_skl_classifier(clazz, dataset, n_estimators, callback):
         np.testing.assert_equal(base_scores, np.zeros(expected_base_scores_shape))
 
     out_prob = treelite.gtil.predict(tl_model, X)
-    expected_prob = clf.predict_proba(X)
+    expected_prob = clf.predict_proba(X)[np.newaxis, :, :]
     if (
         clazz in [GradientBoostingClassifier, HistGradientBoostingClassifier]
         and n_classes == 2
     ):
-        expected_prob = expected_prob[:, 1:]
+        expected_prob = expected_prob[:, :, 1:]
     np.testing.assert_almost_equal(out_prob, expected_prob, decimal=5)
 
 
@@ -148,7 +148,7 @@ def test_skl_converter_iforest(dataset):
     )
     clf.fit(X)
     expected_pred = clf._compute_chunked_score_samples(X)  # pylint: disable=W0212
-    expected_pred = expected_pred.reshape((-1, 1))
+    expected_pred = expected_pred.reshape((1, -1, 1))
 
     tl_model = treelite.sklearn.import_model(clf)
     out_pred = treelite.gtil.predict(tl_model, X)
@@ -194,5 +194,5 @@ def test_skl_hist_gradient_boosting_with_categorical(
 
     tl_model = treelite.sklearn.import_model(clf)
     out_pred = treelite.gtil.predict(tl_model, X_pred)
-    expected_pred = clf.predict_proba(X_pred)[:, 1:]
+    expected_pred = clf.predict_proba(X_pred)[np.newaxis, :, 1:]
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=4)

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -75,10 +75,6 @@ def test_xgb_regressor(
     # pylint: disable=too-many-locals
     """Test XGBoost with regression data"""
 
-    # See https://github.com/dmlc/xgboost/pull/9574
-    if objective == "reg:pseudohubererror":
-        pytest.xfail("XGBoost 2.0 has a bug in the serialization of Pseudo-Huber error")
-
     if objective == "reg:squaredlogerror":
         X, y = generate_data_for_squared_log_error()
         use_categorical = False
@@ -125,7 +121,7 @@ def test_xgb_regressor(
         out_pred = treelite.gtil.predict(tl_model, X_pred, pred_margin=pred_margin)
         expected_pred = xgb_model.predict(
             xgb.DMatrix(X_pred), output_margin=pred_margin, validate_features=False
-        ).reshape((X.shape[0], -1))
+        ).reshape((1, X.shape[0], -1))
         np.testing.assert_almost_equal(out_pred, expected_pred, decimal=3)
 
 
@@ -202,7 +198,7 @@ def test_xgb_multiclass_classifier(
             out_pred = treelite.gtil.predict(tl_model, X_pred, pred_margin=pred_margin)
             expected_pred = xgb_model.predict(
                 xgb.DMatrix(X_pred), output_margin=pred_margin, validate_features=False
-            )
+            ).reshape((1, -1, num_class))
         np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
@@ -282,7 +278,7 @@ def test_xgb_nonlinear_objective(
         out_pred = treelite.gtil.predict(tl_model, X_pred, pred_margin=True)
         expected_pred = xgb_model.predict(
             xgb.DMatrix(X_pred), output_margin=True, validate_features=False
-        ).reshape((X.shape[0], -1))
+        ).reshape((1, X.shape[0], -1))
         np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 
@@ -317,10 +313,10 @@ def test_xgb_dart(dataset, model_format, num_boost_round):
             xgb_model.save_model(model_path)
             tl_model = treelite.frontend.load_xgboost_model(model_path)
         else:
-            tl_model = treelite.Model.from_xgboost(xgb_model)
+            tl_model = treelite.frontend.from_xgboost(xgb_model)
         out_pred = treelite.gtil.predict(tl_model, X, pred_margin=True)
         expected_pred = xgb_model.predict(dtrain, output_margin=True).reshape(
-            (X.shape[0], -1)
+            (1, X.shape[0], -1)
         )
         np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
@@ -508,10 +504,6 @@ def test_xgb_multi_target_regressor(
 ):
     # pylint: disable=too-many-locals
     """Test XGBoost with regression data"""
-
-    # See https://github.com/dmlc/xgboost/pull/9574
-    if objective == "reg:pseudohubererror":
-        pytest.xfail("XGBoost 2.0 has a bug in the serialization of Pseudo-Huber error")
 
     if objective == "reg:squaredlogerror":
         X, y = generate_data_for_squared_log_error(n_targets=n_targets)

--- a/tests/serializer/compatibility_tester.py
+++ b/tests/serializer/compatibility_tester.py
@@ -37,7 +37,7 @@ def load(args):
     with open(args.model_pickle_path, "rb") as f:
         clf = pickle.load(f)
     tl_model = treelite.Model.deserialize(args.checkpoint_path)
-    expected_prob = clf.predict_proba(X)
+    expected_prob = clf.predict_proba(X).reshape((1, X.shape[0], -1))
     out_prob = treelite.gtil.predict(tl_model, X)
     np.testing.assert_almost_equal(out_prob, expected_prob, decimal=5)
     print("Test passed!")

--- a/tests/serializer/test_serializer.py
+++ b/tests/serializer/test_serializer.py
@@ -59,7 +59,7 @@ def test_serialize_as_buffer(clazz):
         params["init"] = "zero"
     clf = clazz(**params)
     clf.fit(X, y)
-    expected_prob = clf.predict_proba(X)
+    expected_prob = clf.predict_proba(X).reshape((1, X.shape[0], -1))
 
     # Prediction should be correct after a round-trip
     tl_model = treelite.sklearn.import_model(clf)


### PR DESCRIPTION
* Document the expected dimensions of the prediction.
* Always use the first dimension to represent output targets, even for single target models.