### PR TITLE
Apply hotfix from 4.1.0 release

### DIFF
--- a/python/treelite/core.py
+++ b/python/treelite/core.py
@@ -36,7 +36,7 @@ def _load_lib():
         os.add_dll_directory(
             os.path.join(os.path.normpath(sys.base_prefix), "Library", "bin")
         )
-    lib = ctypes.CDLL(lib_path[0], mode=ctypes.RTLD_GLOBAL)
+    lib = ctypes.cdll.LoadLibrary(lib_path[0])
     lib.TreeliteGetLastError.restype = ctypes.c_char_p
     lib.log_callback = _log_callback
     lib.warn_callback = _warn_callback


### PR DESCRIPTION
I forgot to apply [this hotfix](https://github.com/dmlc/treelite/commit/454abc4bfe03e6e9d45155c15f74ae36d8c73111) that I made to the 4.1.0 release. My bad.