### PR TITLE
Make the lib compilable for gcc 14

### DIFF
--- a/src/gtil/postprocessor.h
+++ b/src/gtil/postprocessor.h
@@ -8,6 +8,7 @@
 #ifndef SRC_GTIL_POSTPROCESSOR_H_
 #define SRC_GTIL_POSTPROCESSOR_H_
 
+#include <cstdint>
 #include <string>
 
 namespace treelite {

--- a/src/model_loader/detail/xgboost.cc
+++ b/src/model_loader/detail/xgboost.cc
@@ -6,6 +6,7 @@
  */
 #include "./xgboost.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <fstream>
 #include <string>


### PR DESCRIPTION
I'm surprised that gcc11 can compile the lib without proper importing..