### PR TITLE
Use latest pylint + Remove outdated docstring

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -10,7 +10,7 @@ repos:
   - id: check-added-large-files
     args: ["--maxkb=4000"]
 - repo: https://github.com/psf/black
-  rev: 24.2.0
+  rev: 24.8.0
   hooks:
   - id: black
 - repo: https://github.com/pycqa/isort
@@ -19,12 +19,12 @@ repos:
   - id: isort
     args: ["--profile", "black", "--filter-files"]
 - repo: https://github.com/MarcoGorelli/cython-lint
-  rev: v0.16.0
+  rev: v0.16.2
   hooks:
   - id: cython-lint
   - id: double-quote-cython-strings
 - repo: https://github.com/PyCQA/flake8
-  rev: 7.0.0
+  rev: 7.1.1
   hooks:
   - id: flake8
     args: [--config=.flake8]
@@ -60,12 +60,12 @@ repos:
       additional_dependencies: [cpplint]
       types_or: [c++]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.8.0
+  rev: v1.11.2
   hooks:
     - id: mypy
       additional_dependencies: [types-setuptools, numpy]
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.4
+  rev: v0.6.8
   hooks:
     - id: ruff
       args: ["--config", "python/pyproject.toml"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,8 +40,8 @@ repos:
       language: python
       types: [python]
       additional_dependencies: [
-        pylint, hatchling, pytest, scikit-learn, hypothesis, pandas, treelite,
-        lightgbm, xgboost, tqdm
+        pylint>=3.3.1, hatchling, pytest, scikit-learn>=1.5.2, hypothesis, pandas, treelite,
+        lightgbm, xgboost>=2.1.1, tqdm
       ]
 - repo: https://github.com/pocc/pre-commit-hooks
   rev: v1.3.5

--- a/dev/change_version.py
+++ b/dev/change_version.py
@@ -35,7 +35,6 @@ def update_pypkg(
     rc_ver: Optional[int] = None,
 ) -> None:
     """Change version in the Python package"""
-    # pylint: disable=too-many-arguments
     version = f"{major}.{minor}.{patch}"
     if is_rc:
         assert rc_ver

--- a/dev/prepare_pypi_release.py
+++ b/dev/prepare_pypi_release.py
@@ -3,7 +3,7 @@ It fetches Python wheels from the CI pipelines.
 tqdm, sh are required to run this script.
 """
 
-# pylint: disable=W0603,C0103,too-many-arguments
+# pylint: disable=W0603,C0103
 
 import argparse
 import os
@@ -51,6 +51,7 @@ def latest_hash() -> str:
 
 
 def download_wheels(
+    *,
     platforms: List[str],
     url_prefix: str,
     dest_dir: str,
@@ -93,7 +94,11 @@ def download_py_packages(version_str: str, commit_hash: str) -> None:
         src_filename_prefix = f"{pkg}-{version_str}%2B{commit_hash}-py3-none-"
         target_filename_prefix = f"{pkg}-{version_str}-py3-none-"
         filenames = download_wheels(
-            platforms, PREFIX, dest_dir, src_filename_prefix, target_filename_prefix
+            platforms=platforms,
+            url_prefix=PREFIX,
+            dest_dir=dest_dir,
+            src_filename_prefix=src_filename_prefix,
+            target_filename_prefix=target_filename_prefix,
         )
         print(f"List of downloaded wheels: {filenames}\n")
 
@@ -102,12 +107,12 @@ def download_py_packages(version_str: str, commit_hash: str) -> None:
         src_filename_prefix = f"{pkg}-{version_str}%2B{commit_hash}"
         target_filename_prefix = f"{pkg}-{version_str}"
         filenames = download_wheels(
-            [""],
-            PREFIX,
-            dest_dir,
-            src_filename_prefix,
-            target_filename_prefix,
-            "tar.gz",
+            platforms=[""],
+            url_prefix=PREFIX,
+            dest_dir=dest_dir,
+            src_filename_prefix=src_filename_prefix,
+            target_filename_prefix=target_filename_prefix,
+            ext="tar.gz",
         )
         print(f"List of downloaded sdist: {filenames}\n")
     print(

--- a/python/.pylintrc
+++ b/python/.pylintrc
@@ -4,7 +4,7 @@ extension-pkg-whitelist=numpy
 
 load-plugins=pylint.extensions.no_self_use
 
-disable=unexpected-special-method-signature,too-many-nested-blocks,useless-object-inheritance,import-outside-toplevel,unsubscriptable-object,attribute-defined-outside-init,unbalanced-tuple-unpacking,too-many-lines,duplicate-code
+disable=unexpected-special-method-signature,too-many-nested-blocks,useless-object-inheritance,import-outside-toplevel,unsubscriptable-object,attribute-defined-outside-init,unbalanced-tuple-unpacking,too-many-lines,duplicate-code,too-many-arguments
 
 dummy-variables-rgx=(unused|)_.*
 

--- a/python/treelite/model_builder.py
+++ b/python/treelite/model_builder.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from .core import _LIB, _check_call
 from .model import Model
-from .util import c_array, c_str
+from .util import c_array, c_str, deprecate_positional_args
 
 
 @dataclasses.dataclass
@@ -151,7 +151,7 @@ class ModelBuilder:
         postprocessor: PostProcessorFunc,
         base_scores: List[float],
         attributes: Optional[Dict[Any, Any]] = None,
-    ):  # pylint: disable=R0913
+    ):
         self._handle = None
 
         handle = ctypes.c_void_p()
@@ -211,15 +211,17 @@ class ModelBuilder:
         """End the current node"""
         _check_call(_LIB.TreeliteModelBuilderEndNode(self.handle))
 
+    @deprecate_positional_args
     def numerical_test(
         self,
         feature_id: int,
         threshold: float,
+        *,
         default_left: bool,
         opname: str,
         left_child_key: int,
         right_child_key: int,
-    ):  # pylint: disable=R0913
+    ):
         """
         Declare the current node as a numerical test node, where the test is of form
         [feature value] [op] [threshold]. Data points for which the test evaluates to True
@@ -253,15 +255,17 @@ class ModelBuilder:
             )
         )
 
+    @deprecate_positional_args
     def categorical_test(
         self,
         feature_id: int,
+        *,
         default_left: bool,
         category_list: List[int],
         category_list_right_child: bool,
         left_child_key: int,
         right_child_key: int,
-    ):  # pylint: disable=R0913
+    ):
         """
         Declare the current node as a categorical test node, where the test is of form
         [feature value] \\in [category list].

--- a/python/treelite/model_builder_legacy.py
+++ b/python/treelite/model_builder_legacy.py
@@ -13,6 +13,7 @@ from .model import Model
 from .model_builder import Metadata
 from .model_builder import ModelBuilder as ModelBuilderNew
 from .model_builder import PostProcessorFunc, TreeAnnotation
+from .util import deprecate_positional_args
 
 
 @dataclasses.dataclass
@@ -138,12 +139,13 @@ class ModelBuilder:
                 )
             self.node = _LeafNode(leaf_value=leaf_value)
 
-        # pylint: disable=R0913
+        @deprecate_positional_args
         def set_numerical_test_node(
             self,
             feature_id: int,
             opname: str,
             threshold: float,
+            *,
             default_left: bool,
             left_child_key: int,
             right_child_key: int,
@@ -204,11 +206,12 @@ class ModelBuilder:
             )
             self.empty = False
 
-        # pylint: disable=R0913
+        @deprecate_positional_args
         def set_categorical_test_node(
             self,
             feature_id: int,
             left_categories: List[int],
+            *,
             default_left: bool,
             left_child_key: int,
             right_child_key: int,
@@ -332,19 +335,20 @@ class ModelBuilder:
             assert node_key is not None
             self.root_key = node_key
 
+    @deprecate_positional_args
     def __init__(
         self,
+        *,
         num_feature: int,
         num_class: int = 1,
         average_tree_output: bool = False,
         threshold_type: str = "float32",
         leaf_output_type: str = "float32",
-        *,
         pred_transform: str = "identity",
         sigmoid_alpha: float = 1.0,
         ratio_c: float = 1.0,
         global_bias: float = 0.0,
-    ):  # pylint: disable=R0913
+    ):
         warnings.warn(
             "treelite.ModelBuilder is deprecated and will be removed in Treelite 4.1. "
             "Please use treelite.model_builder.ModelBuilder class instead. The new model builder "

--- a/python/treelite/sklearn/importer.py
+++ b/python/treelite/sklearn/importer.py
@@ -111,14 +111,6 @@ def import_model(sklearn_model):
 
       import treelite.sklearn
       model = treelite.sklearn.import_model(clf)
-
-    Note
-    ----
-    This function does not yet support categorical splits in
-    :py:class:`~sklearn.ensemble.HistGradientBoostingRegressor` and
-    :py:class:`~sklearn.ensemble.HistGradientBoostingClassifier`.
-    If you are using either estimator types, make sure that all
-    test nodes have numerical test conditions.
     """
     try:
         from sklearn.dummy import DummyClassifier, DummyRegressor

--- a/python/treelite/util.py
+++ b/python/treelite/util.py
@@ -3,6 +3,10 @@ Miscellaneous utilities
 """
 
 import ctypes
+import warnings
+from functools import wraps
+from inspect import Parameter, signature
+from typing import Any, Callable, TypeVar
 
 import numpy as np
 
@@ -47,3 +51,79 @@ def c_array(ctype, values):
     ndarray.ctypes.data_as(*) to expose underlying buffer as C pointer.
     """
     return (ctype * len(values))(*values)
+
+
+_T = TypeVar("_T")
+
+
+# Notice for `require_keyword_args`
+# Authors: Olivier Grisel
+#          Gael Varoquaux
+#          Andreas Mueller
+#          Lars Buitinck
+#          Alexandre Gramfort
+#          Nicolas Tresegnie
+#          Sylvain Marie
+# License: BSD 3 clause
+def _require_keyword_args(
+    error: bool,
+) -> Callable[[Callable[..., _T]], Callable[..., _T]]:
+    """Decorator for methods that issues warnings for positional arguments
+
+    Using the keyword-only argument syntax in pep 3102, arguments after the
+    * will issue a warning or error when passed as a positional argument.
+
+    Modified from sklearn utils.validation.
+
+    Parameters
+    ----------
+    error :
+        Whether to throw an error or raise a warning.
+    """
+
+    def throw_if(func: Callable[..., _T]) -> Callable[..., _T]:
+        """Throw an error/warning if there are positional arguments after the asterisk.
+
+        Parameters
+        ----------
+        func :
+            function to check arguments on.
+
+        """
+        sig = signature(func)
+        kwonly_args = []
+        all_args = []
+
+        for name, param in sig.parameters.items():
+            if param.kind == Parameter.POSITIONAL_OR_KEYWORD:
+                all_args.append(name)
+            elif param.kind == Parameter.KEYWORD_ONLY:
+                kwonly_args.append(name)
+
+        @wraps(func)
+        def inner_f(*args: Any, **kwargs: Any) -> _T:
+            extra_args = len(args) - len(all_args)
+            if not all_args and extra_args > 0:  # keyword argument only
+                raise TypeError("Keyword argument is required.")
+
+            if extra_args > 0:
+                # ignore first 'self' argument for instance methods
+                args_msg = [
+                    f"{name}"
+                    for name, _ in zip(kwonly_args[:extra_args], args[-extra_args:])
+                ]
+                # pylint: disable=consider-using-f-string
+                msg = "Pass `{}` as keyword args.".format(", ".join(args_msg))
+                if error:
+                    raise TypeError(msg)
+                warnings.warn(msg, FutureWarning)
+            for k, arg in zip(sig.parameters, args):
+                kwargs[k] = arg
+            return func(**kwargs)
+
+        return inner_f
+
+    return throw_if
+
+
+deprecate_positional_args = _require_keyword_args(False)

--- a/tests/python/hypothesis_util.py
+++ b/tests/python/hypothesis_util.py
@@ -49,7 +49,7 @@ def standard_classification_datasets(
     shuffle=just(True),
     random_state=None,
 ):
-    # pylint: disable=too-many-locals, too-many-arguments
+    # pylint: disable=too-many-locals
     """
     Returns a strategy to generate classification problem input datasets.
     Note:
@@ -246,7 +246,6 @@ def standard_regression_datasets(
         A tuple of search strategies for arrays subject to the constraints of
         the provided parameters.
     """
-    # pylint: disable=too-many-arguments
     n_features_ = draw(n_features)
     if n_informative is None:
         n_informative = just(max(min(n_features_, 1), int(0.1 * n_features_)))

--- a/tests/python/test_lightgbm_integration.py
+++ b/tests/python/test_lightgbm_integration.py
@@ -156,6 +156,7 @@ def test_lightgbm_binary_classification(
 )
 @settings(**standard_settings())
 def test_lightgbm_multiclass_classification(
+    *,
     dataset,
     objective,
     boosting_type,
@@ -163,7 +164,7 @@ def test_lightgbm_multiclass_classification(
     use_categorical,
     callback,
 ):
-    # pylint: disable=too-many-locals,too-many-arguments
+    # pylint: disable=too-many-locals
     """Test LightGBM multi-class classifier"""
     X, y = dataset
     num_class = np.max(y) + 1

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -1,6 +1,6 @@
 """Tests for XGBoost integration"""
 
-# pylint: disable=R0201, R0915, R0913, R0914
+# pylint: disable=R0201, R0915, R0914
 import json
 import pathlib
 
@@ -141,6 +141,7 @@ def test_xgb_regressor(
 )
 @settings(**standard_settings())
 def test_xgb_multiclass_classifier(
+    *,
     dataset,
     objective,
     pred_margin,
@@ -335,7 +336,7 @@ def test_xgb_dart(dataset, model_format, num_boost_round):
 )
 @settings(print_blob=True, deadline=None)
 def test_extra_field_in_xgb_json(random_integer_seq, extra_field_type, use_tempfile):
-    # pylint: disable=too-many-locals,too-many-arguments
+    # pylint: disable=too-many-locals
     """
     Test if we can handle extra fields in XGBoost JSON model file
     Insert an extra field at a random place and then load the model into Treelite,
@@ -426,6 +427,7 @@ def test_extra_field_in_xgb_json(random_integer_seq, extra_field_type, use_tempf
 )
 @settings(**standard_settings())
 def test_xgb_multi_target_binary_classifier(
+    *,
     dataset,
     num_boost_round,
     num_parallel_tree,
@@ -502,6 +504,7 @@ def test_xgb_multi_target_binary_classifier(
 )
 @settings(**standard_settings())
 def test_xgb_multi_target_regressor(
+    *,
     n_targets,
     objective,
     num_boost_round,


### PR DESCRIPTION
* Reduce positional arguments to 4 per function.
* Show a deprecation notice whenever the user uses a public function with too many positional arguments.
* Treelite now supports `HistGradientBoostingRegressor` with categorical features. Remove an outdated docstring.