### PR TITLE
Add ability to export as sklearn RF

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
         "--linelength=100", "--recursive",
         "--filter=-build/c++11,-build/include,-build/namespaces_literals,-runtime/references,-build/include_order,+build/include_what_you_use",
         "--root=include"]
-      additional_dependencies: [cpplint]
+      additional_dependencies: [cpplint==1.6.1]
       types_or: [c++]
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.11.2

--- a/include/treelite/c_api.h
+++ b/include/treelite/c_api.h
@@ -833,6 +833,21 @@ TREELITE_DLL int TreeliteSetTreeField(
 /*! \} */
 
 /*!
+ * \defgroup model_query C API: Model query functions
+ * Query various properties of tree models
+ * \{
+ */
+/*!
+ * \brief Query the depth of each tree.
+ * \param model Treelite Model object
+ * \param out Pointer to array holding depth of each tree
+ * \param out_len Number of trees
+ * \return 0 for success; -1 for failure
+ */
+TREELITE_DLL int TreeliteGetTreeDepth(TreeliteModelHandle model, uint32_t** out, size_t* out_len);
+/*! \} */
+
+/*!
  * \brief Display last error; can be called by multiple threads
  * Note. Each thread will get the last error occured in its own context.
  * \return Error string

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -467,7 +467,6 @@ class Model {
   inline TypeInfo GetLeafOutputType() const {
     return std::visit([](auto&& inner) { return inner.GetLeafOutputType(); }, variant_);
   }
-
   inline std::size_t GetNumTree() const {
     return std::visit([](auto&& inner) { return inner.GetNumTree(); }, variant_);
   }
@@ -513,6 +512,10 @@ class Model {
   void SetHeaderField(std::string const& name, PyBufferFrame frame);
   /*! \brief Set a field in a tree */
   void SetTreeField(std::uint64_t tree_id, std::string const& name, PyBufferFrame frame);
+
+  /* Model query functions */
+  /*! \brief Query the depth of each tree */
+  std::vector<std::uint32_t> GetTreeDepth() const;
 
   /*!
    * \brief Number of features used for the model.

--- a/ops/conda_env/dev.yml
+++ b/ops/conda_env/dev.yml
@@ -18,11 +18,11 @@ dependencies:
 - llvm-openmp
 - cython
 - lightgbm
-- cpplint
+- cpplint==1.6.1
 - pylint
 - awscli
 - python-build
 - pip
 - pip:
   - cibuildwheel
-  - xgboost==2.1.0
+  - xgboost>=2.1.0

--- a/ops/conda_env/dev.yml
+++ b/ops/conda_env/dev.yml
@@ -18,7 +18,7 @@ dependencies:
 - llvm-openmp
 - cython
 - lightgbm
-- cpplint=1.6.1
+- cpplint=1.6.0
 - pylint
 - awscli
 - python-build

--- a/ops/conda_env/dev.yml
+++ b/ops/conda_env/dev.yml
@@ -18,7 +18,7 @@ dependencies:
 - llvm-openmp
 - cython
 - lightgbm
-- cpplint==1.6.1
+- cpplint=1.6.1
 - pylint
 - awscli
 - python-build

--- a/python/treelite/gtil/gtil.py
+++ b/python/treelite/gtil/gtil.py
@@ -11,7 +11,7 @@ import numpy as np
 from scipy.sparse import csr_matrix
 
 from ..core import _LIB, _check_call
-from ..frontend import Model
+from ..model import Model
 from ..util import c_str, typestr_to_ctypes_type, typestr_to_numpy_type
 
 

--- a/python/treelite/model.py
+++ b/python/treelite/model.py
@@ -274,6 +274,21 @@ class Model:
         )
         return py_str(json_str.value)
 
+    def get_tree_depth(self) -> np.ndarray:
+        """
+        Query the depth of each tree.
+        """
+        depth_array_ptr = ctypes.POINTER(ctypes.c_uint32)()
+        depth_array_len = ctypes.c_size_t()
+        _check_call(
+            _LIB.TreeliteGetTreeDepth(
+                self.handle,
+                ctypes.byref(depth_array_ptr),
+                ctypes.byref(depth_array_len),
+            )
+        )
+        return np.ctypeslib.as_array(depth_array_ptr, shape=(depth_array_len.value,))
+
     def get_header_accessor(self) -> HeaderAccessor:
         """
         Obtain accessor for fields in the header.
@@ -331,6 +346,7 @@ class Model:
         n_targets = header_accessor.get_field("num_target").tolist()[0]
         n_classes = header_accessor.get_field("num_class")
         leaf_vector_shape = header_accessor.get_field("leaf_vector_shape")
+        tree_depths = self.get_tree_depth()
 
         assert n_targets == 1
         assert n_classes[0] == 1
@@ -359,13 +375,17 @@ class Model:
             nodes["weighted_n_node_samples"] = np.nan
             nodes["missing_go_to_left"] = tree_accessor.get_field("default_left")
 
+            leaf_value = (
+                tree_accessor.get_field("leaf_value")
+                .astype("float64")
+                .reshape((-1, 1, 1))
+            )
+
             state = {
-                "max_depth": 10,
+                "max_depth": tree_depths[tree_id],
                 "node_count": n_nodes,
                 "nodes": nodes,
-                "values": tree_accessor.get_field("leaf_value")
-                .astype("float64")
-                .reshape((-1, 1, 1)),
+                "values": leaf_value,
             }
             tree.__setstate__(state)
 

--- a/python/treelite/model.py
+++ b/python/treelite/model.py
@@ -11,7 +11,7 @@ from typing import Any, List, Optional, Union
 import numpy as np
 
 from . import compat
-from .core import _LIB, _check_call
+from .core import _LIB, TreeliteError, _check_call
 from .util import c_array, c_str, py_str
 
 
@@ -293,6 +293,104 @@ class Model:
         """
         return TreeAccessor(self, tree_id=tree_id)
 
+    def export_as_sklearn(self):
+        """Export as scikit-learn RandomForest"""
+        # pylint: disable=too-many-locals
+        try:
+            from sklearn import __version__ as sklearn_version
+            from sklearn.ensemble import RandomForestRegressor
+            from sklearn.tree import DecisionTreeRegressor
+            from sklearn.tree._tree import Tree as SKLearnTree
+        except ImportError as e:
+            raise TreeliteError("This function requires scikit-learn package") from e
+
+        node_dtype = np.dtype(
+            {
+                "names": [
+                    "left_child",
+                    "right_child",
+                    "feature",
+                    "threshold",
+                    "impurity",
+                    "n_node_samples",
+                    "weighted_n_node_samples",
+                    "missing_go_to_left",
+                ],
+                "formats": ["<i8", "<i8", "<i8", "<f8", "<f8", "<i8", "<f8", "u1"],
+                "offsets": [0, 8, 16, 24, 32, 40, 48, 56],
+                "itemsize": 64,
+            }
+        )
+
+        header_accessor = self.get_header_accessor()
+        # average_tree_output = (
+        #    header_accessor.get_field("average_tree_output").tolist()[0] == 1
+        # )
+        n_features = header_accessor.get_field("num_feature").tolist()[0]
+        n_trees = header_accessor.get_field("num_tree").tolist()[0]
+        n_targets = header_accessor.get_field("num_target").tolist()[0]
+        n_classes = header_accessor.get_field("num_class")
+        leaf_vector_shape = header_accessor.get_field("leaf_vector_shape")
+
+        assert n_targets == 1
+        assert n_classes[0] == 1
+        assert np.array_equal(leaf_vector_shape, [1, 1])
+
+        estimators = []
+
+        for tree_id in range(n_trees):
+            tree_accessor = self.get_tree_accessor(tree_id)
+            has_categorical_split = tree_accessor.get_field(
+                "has_categorical_split"
+            ).tolist()[0]
+            assert not has_categorical_split
+
+            tree = SKLearnTree(n_features, n_classes, n_targets)
+
+            n_nodes = tree_accessor.get_field("num_nodes").tolist()[0]
+            nodes = np.empty(n_nodes, dtype=node_dtype)
+
+            nodes["left_child"] = tree_accessor.get_field("cleft")
+            nodes["right_child"] = tree_accessor.get_field("cright")
+            nodes["feature"] = tree_accessor.get_field("split_index")
+            nodes["threshold"] = tree_accessor.get_field("threshold")
+            nodes["impurity"] = np.nan
+            nodes["n_node_samples"] = -1
+            nodes["weighted_n_node_samples"] = np.nan
+            nodes["missing_go_to_left"] = tree_accessor.get_field("default_left")
+
+            state = {
+                "max_depth": 10,
+                "node_count": n_nodes,
+                "nodes": nodes,
+                "values": tree_accessor.get_field("leaf_value")
+                .astype("float64")
+                .reshape((-1, 1, 1)),
+            }
+            tree.__setstate__(state)
+
+            reg = DecisionTreeRegressor()
+            reg.__setstate__(
+                {
+                    "tree_": tree,
+                    "n_outputs_": n_targets,
+                    "_sklearn_version": sklearn_version,
+                }
+            )
+
+            estimators.append(reg)
+
+        clf = RandomForestRegressor()
+        clf.__setstate__(
+            {
+                "estimators_": estimators,
+                "n_outputs_": n_targets,
+                "_sklearn_version": sklearn_version,
+            }
+        )
+
+        return clf
+
     def serialize(self, filename: Union[str, pathlib.Path]):
         """
         Serialize (persist) the model to a checkpoint file in the disk, using a fast binary
@@ -483,7 +581,7 @@ def _numpy2pybuffer(array: np.ndarray) -> _TreelitePyBufferFrame:
         ctypes.pythonapi.PyObject_GetBuffer(
             ctypes.py_object(view),
             ctypes.byref(buffer),
-            ctypes.c_int(0),  # PyBUF_SIMPLE
+            ctypes.c_int(28),  # PyBUF_RECORDS_RO
         )
         != 0
     ):

--- a/python/treelite/model.py
+++ b/python/treelite/model.py
@@ -348,9 +348,8 @@ class Model:
         leaf_vector_shape = header_accessor.get_field("leaf_vector_shape")
         tree_depths = self.get_tree_depth()
 
-        assert n_targets == 1
-        assert n_classes[0] == 1
-        assert np.array_equal(leaf_vector_shape, [1, 1])
+        assert np.all(n_classes == 1)
+        assert np.array_equal(leaf_vector_shape, [n_targets, 1])
 
         estimators = []
 
@@ -375,11 +374,26 @@ class Model:
             nodes["weighted_n_node_samples"] = np.nan
             nodes["missing_go_to_left"] = tree_accessor.get_field("default_left")
 
-            leaf_value = (
-                tree_accessor.get_field("leaf_value")
-                .astype("float64")
-                .reshape((-1, 1, 1))
-            )
+            if n_targets == 1:
+                leaf_value = (
+                    tree_accessor.get_field("leaf_value")
+                    .astype("float64")
+                    .reshape((-1, 1, 1))
+                )
+            else:
+                # Need to map leaf values to correct layout
+                leaf_value = np.zeros((n_nodes, n_targets, 1), dtype="float64")
+                leaf_value_raw = tree_accessor.get_field("leaf_vector").astype(
+                    "float64"
+                )
+                leaf_vec_begin = tree_accessor.get_field("leaf_vector_begin")
+                leaf_vec_end = tree_accessor.get_field("leaf_vector_end")
+                for node_id in range(n_nodes):
+                    if leaf_vec_begin[node_id] != leaf_vec_end[node_id]:
+                        # This node is a leaf node and outputs a vector
+                        leaf_value[node_id, :, :] = leaf_value_raw[
+                            leaf_vec_begin[node_id] : leaf_vec_end[node_id]
+                        ].reshape((n_targets, 1))
 
             state = {
                 "max_depth": tree_depths[tree_id],

--- a/python/treelite/model.py
+++ b/python/treelite/model.py
@@ -11,7 +11,7 @@ from typing import Any, List, Optional, Union
 import numpy as np
 
 from . import compat
-from .core import _LIB, TreeliteError, _check_call
+from .core import _LIB, _check_call
 from .util import c_array, c_str, py_str
 
 
@@ -308,123 +308,6 @@ class Model:
         """
         return TreeAccessor(self, tree_id=tree_id)
 
-    def export_as_sklearn(self):
-        """Export as scikit-learn RandomForest"""
-        # pylint: disable=too-many-locals
-        try:
-            from sklearn import __version__ as sklearn_version
-            from sklearn.ensemble import RandomForestRegressor
-            from sklearn.tree import DecisionTreeRegressor
-            from sklearn.tree._tree import Tree as SKLearnTree
-        except ImportError as e:
-            raise TreeliteError("This function requires scikit-learn package") from e
-
-        node_dtype = np.dtype(
-            {
-                "names": [
-                    "left_child",
-                    "right_child",
-                    "feature",
-                    "threshold",
-                    "impurity",
-                    "n_node_samples",
-                    "weighted_n_node_samples",
-                    "missing_go_to_left",
-                ],
-                "formats": ["<i8", "<i8", "<i8", "<f8", "<f8", "<i8", "<f8", "u1"],
-                "offsets": [0, 8, 16, 24, 32, 40, 48, 56],
-                "itemsize": 64,
-            }
-        )
-
-        header_accessor = self.get_header_accessor()
-        # average_tree_output = (
-        #    header_accessor.get_field("average_tree_output").tolist()[0] == 1
-        # )
-        n_features = header_accessor.get_field("num_feature").tolist()[0]
-        n_trees = header_accessor.get_field("num_tree").tolist()[0]
-        n_targets = header_accessor.get_field("num_target").tolist()[0]
-        n_classes = header_accessor.get_field("num_class")
-        leaf_vector_shape = header_accessor.get_field("leaf_vector_shape")
-        tree_depths = self.get_tree_depth()
-
-        assert np.all(n_classes == 1)
-        assert np.array_equal(leaf_vector_shape, [n_targets, 1])
-
-        estimators = []
-
-        for tree_id in range(n_trees):
-            tree_accessor = self.get_tree_accessor(tree_id)
-            has_categorical_split = tree_accessor.get_field(
-                "has_categorical_split"
-            ).tolist()[0]
-            assert not has_categorical_split
-
-            tree = SKLearnTree(n_features, n_classes, n_targets)
-
-            n_nodes = tree_accessor.get_field("num_nodes").tolist()[0]
-            nodes = np.empty(n_nodes, dtype=node_dtype)
-
-            nodes["left_child"] = tree_accessor.get_field("cleft")
-            nodes["right_child"] = tree_accessor.get_field("cright")
-            nodes["feature"] = tree_accessor.get_field("split_index")
-            nodes["threshold"] = tree_accessor.get_field("threshold")
-            nodes["impurity"] = np.nan
-            nodes["n_node_samples"] = -1
-            nodes["weighted_n_node_samples"] = np.nan
-            nodes["missing_go_to_left"] = tree_accessor.get_field("default_left")
-
-            if n_targets == 1:
-                leaf_value = (
-                    tree_accessor.get_field("leaf_value")
-                    .astype("float64")
-                    .reshape((-1, 1, 1))
-                )
-            else:
-                # Need to map leaf values to correct layout
-                leaf_value = np.zeros((n_nodes, n_targets, 1), dtype="float64")
-                leaf_value_raw = tree_accessor.get_field("leaf_vector").astype(
-                    "float64"
-                )
-                leaf_vec_begin = tree_accessor.get_field("leaf_vector_begin")
-                leaf_vec_end = tree_accessor.get_field("leaf_vector_end")
-                for node_id in range(n_nodes):
-                    if leaf_vec_begin[node_id] != leaf_vec_end[node_id]:
-                        # This node is a leaf node and outputs a vector
-                        leaf_value[node_id, :, :] = leaf_value_raw[
-                            leaf_vec_begin[node_id] : leaf_vec_end[node_id]
-                        ].reshape((n_targets, 1))
-
-            state = {
-                "max_depth": tree_depths[tree_id],
-                "node_count": n_nodes,
-                "nodes": nodes,
-                "values": leaf_value,
-            }
-            tree.__setstate__(state)
-
-            reg = DecisionTreeRegressor()
-            reg.__setstate__(
-                {
-                    "tree_": tree,
-                    "n_outputs_": n_targets,
-                    "_sklearn_version": sklearn_version,
-                }
-            )
-
-            estimators.append(reg)
-
-        clf = RandomForestRegressor()
-        clf.__setstate__(
-            {
-                "estimators_": estimators,
-                "n_outputs_": n_targets,
-                "_sklearn_version": sklearn_version,
-            }
-        )
-
-        return clf
-
     def serialize(self, filename: Union[str, pathlib.Path]):
         """
         Serialize (persist) the model to a checkpoint file in the disk, using a fast binary
@@ -672,7 +555,7 @@ class HeaderAccessor:
             return array.tobytes().decode("utf-8")
         return array
 
-    def set_field(self, name: str, value: Union[np.ndarray, str]):
+    def set_field(self, name: str, value: Union[np.ndarray, str]) -> None:
         """
         Set a field
 
@@ -740,7 +623,7 @@ class TreeAccessor:
         )
         return _pybuffer2numpy(obj)
 
-    def set_field(self, name: str, value: np.ndarray):
+    def set_field(self, name: str, value: np.ndarray) -> None:
         """
         Set a field
 

--- a/python/treelite/sklearn/__init__.py
+++ b/python/treelite/sklearn/__init__.py
@@ -1,5 +1,6 @@
 """Model loader ingest scikit-learn models into Treelite"""
 
+from .exporter import export_model
 from .importer import import_model
 
 
@@ -14,4 +15,4 @@ def import_model_with_model_builder(sklearn_model):
     )
 
 
-__all__ = ["import_model", "import_model_with_model_builder"]
+__all__ = ["import_model", "export_model", "import_model_with_model_builder"]

--- a/python/treelite/sklearn/__init__.py
+++ b/python/treelite/sklearn/__init__.py
@@ -1,4 +1,4 @@
-"""Model loader ingest scikit-learn models into Treelite"""
+"""Model loader to ingest scikit-learn models into Treelite"""
 
 from .exporter import export_model
 from .importer import import_model

--- a/python/treelite/sklearn/exporter.py
+++ b/python/treelite/sklearn/exporter.py
@@ -3,6 +3,8 @@
 from typing import Any
 
 import numpy as np
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
 from ..core import TreeliteError
 from ..model import Model
@@ -22,6 +24,96 @@ def _ensure_numpy(x: Any) -> np.ndarray:
     if isinstance(x, np.ndarray):
         return x
     raise ValueError(f"x is not a valid NumPy array. {x.type=}")
+
+
+_node_dtype = np.dtype(
+    {
+        "names": [
+            "left_child",
+            "right_child",
+            "feature",
+            "threshold",
+            "impurity",
+            "n_node_samples",
+            "weighted_n_node_samples",
+            "missing_go_to_left",
+        ],
+        "formats": ["<i8", "<i8", "<i8", "<f8", "<f8", "<i8", "<f8", "u1"],
+        "offsets": [0, 8, 16, 24, 32, 40, 48, 56],
+        "itemsize": 64,
+    }
+)
+
+
+def _export_tree(
+    model, *, tree_id, n_features, n_classes, n_targets, tree_depths, subestimator_class
+):
+    # pylint: disable=too-many-locals
+    try:
+        from sklearn import __version__ as sklearn_version
+        from sklearn.tree._tree import Tree as SKLearnTree
+    except ImportError as e:
+        raise TreeliteError("This function requires scikit-learn package") from e
+
+    tree_accessor = model.get_tree_accessor(tree_id)
+    has_categorical_split = tree_accessor.get_field("has_categorical_split").tolist()[0]
+    if has_categorical_split:
+        raise NotImplementedError(
+            "Trees with categorical splits cannot yet be exported as scikit-learn"
+        )
+
+    tree = SKLearnTree(n_features, n_classes, n_targets)
+
+    n_nodes = tree_accessor.get_field("num_nodes").tolist()[0]
+    nodes = np.empty(n_nodes, dtype=_node_dtype)
+
+    nodes["left_child"] = tree_accessor.get_field("cleft")
+    nodes["right_child"] = tree_accessor.get_field("cright")
+    nodes["feature"] = tree_accessor.get_field("split_index")
+    nodes["threshold"] = tree_accessor.get_field("threshold")
+    nodes["impurity"] = np.nan
+    nodes["n_node_samples"] = -1
+    nodes["weighted_n_node_samples"] = np.nan
+    nodes["missing_go_to_left"] = tree_accessor.get_field("default_left")
+
+    if n_targets == 1 and n_classes[0] == 1:
+        leaf_value = (
+            tree_accessor.get_field("leaf_value").astype("float64").reshape((-1, 1, 1))
+        )
+    else:
+        # Need to map leaf values to correct layout
+        leaf_value = np.zeros((n_nodes, n_targets, n_classes[0]), dtype="float64")
+        leaf_value_raw = tree_accessor.get_field("leaf_vector").astype("float64")
+        leaf_vec_begin = tree_accessor.get_field("leaf_vector_begin")
+        leaf_vec_end = tree_accessor.get_field("leaf_vector_end")
+        for node_id in range(n_nodes):
+            if leaf_vec_begin[node_id] != leaf_vec_end[node_id]:
+                # This node is a leaf node and outputs a vector
+                leaf_value[node_id, :, :] = leaf_value_raw[
+                    leaf_vec_begin[node_id] : leaf_vec_end[node_id]
+                ].reshape((n_targets, n_classes[0]))
+
+    state = {
+        "max_depth": tree_depths[tree_id],
+        "node_count": n_nodes,
+        "nodes": nodes,
+        "values": leaf_value,
+    }
+    tree.__setstate__(state)
+
+    subestimator = subestimator_class()
+    subestimator_state = {
+        "tree_": tree,
+        "n_outputs_": n_targets,
+        "_sklearn_version": sklearn_version,
+    }
+    if subestimator_class is DecisionTreeClassifier:
+        if n_targets == 1:
+            subestimator_state["n_classes_"] = n_classes[0]
+        else:
+            subestimator_state["n_classes_"] = n_classes.tolist()
+    subestimator.__setstate__(subestimator_state)
+    return subestimator
 
 
 def export_model(model: Model):
@@ -46,111 +138,90 @@ def export_model(model: Model):
     try:
         from sklearn import __version__ as sklearn_version
         from sklearn.ensemble import RandomForestRegressor
-        from sklearn.tree import DecisionTreeRegressor
-        from sklearn.tree._tree import Tree as SKLearnTree
     except ImportError as e:
         raise TreeliteError("This function requires scikit-learn package") from e
 
-    node_dtype = np.dtype(
-        {
-            "names": [
-                "left_child",
-                "right_child",
-                "feature",
-                "threshold",
-                "impurity",
-                "n_node_samples",
-                "weighted_n_node_samples",
-                "missing_go_to_left",
-            ],
-            "formats": ["<i8", "<i8", "<i8", "<f8", "<f8", "<i8", "<f8", "u1"],
-            "offsets": [0, 8, 16, 24, 32, 40, 48, 56],
-            "itemsize": 64,
-        }
-    )
-
     header_accessor = model.get_header_accessor()
-    # average_tree_output = (
-    #    header_accessor.get_field("average_tree_output").tolist()[0] == 1
-    # )
+    average_tree_output = (
+        _ensure_scalar_int(header_accessor.get_field("average_tree_output")) == 1
+    )
     n_features = _ensure_scalar_int(header_accessor.get_field("num_feature"))
     n_trees = _ensure_scalar_int(header_accessor.get_field("num_tree"))
     n_targets = _ensure_scalar_int(header_accessor.get_field("num_target"))
     n_classes = _ensure_numpy(header_accessor.get_field("num_class"))
     leaf_vector_shape = _ensure_numpy(header_accessor.get_field("leaf_vector_shape"))
+    target_id = _ensure_numpy(header_accessor.get_field("target_id"))
+    class_id = _ensure_numpy(header_accessor.get_field("class_id"))
     tree_depths = model.get_tree_depth()
 
-    assert np.all(n_classes == 1)
-    assert np.array_equal(leaf_vector_shape, [n_targets, 1])
+    # Heuristics to ensure that the model can be represented as scikit-learn random forest
+    # 1. average_tree_output must be True
+    # 2. n_classes[i] must be identical for all targets
+    # 3. Each leaf must yield an output of shape (n_targets, n_classes)
+    # 4. target_id[i] must be either 0 or -1
+    # 5. class_id[i] must be either 0 or -1
+    def raise_not_rf_error():
+        raise NotImplementedError(
+            "Currently only random forests can be exported as scikit-learn model objects. "
+            "Gradient boosting models and other kinds of decision tree models are not yet "
+            "supported."
+        )
+
+    if not average_tree_output:
+        raise_not_rf_error()
+    if not np.all(n_classes == n_classes[0]):
+        raise_not_rf_error()
+    if not np.array_equal(leaf_vector_shape, [n_targets, n_classes.max()]):
+        raise_not_rf_error()
+    if not np.all((target_id == 0) | (target_id == -1)):
+        raise_not_rf_error()
+    if not np.all((class_id == 0) | (class_id == -1)):
+        raise_not_rf_error()
+
+    # Heuristics for determining whether the model is a regressor or a classifier
+    if n_classes[0] == 1:
+        estimator_class = RandomForestRegressor
+        subestimator_class = DecisionTreeRegressor
+    else:
+        estimator_class = RandomForestClassifier
+        subestimator_class = DecisionTreeClassifier
 
     estimators = []
 
     for tree_id in range(n_trees):
-        tree_accessor = model.get_tree_accessor(tree_id)
-        has_categorical_split = tree_accessor.get_field(
-            "has_categorical_split"
-        ).tolist()[0]
-        assert not has_categorical_split
-
-        tree = SKLearnTree(n_features, n_classes, n_targets)
-
-        n_nodes = tree_accessor.get_field("num_nodes").tolist()[0]
-        nodes = np.empty(n_nodes, dtype=node_dtype)
-
-        nodes["left_child"] = tree_accessor.get_field("cleft")
-        nodes["right_child"] = tree_accessor.get_field("cright")
-        nodes["feature"] = tree_accessor.get_field("split_index")
-        nodes["threshold"] = tree_accessor.get_field("threshold")
-        nodes["impurity"] = np.nan
-        nodes["n_node_samples"] = -1
-        nodes["weighted_n_node_samples"] = np.nan
-        nodes["missing_go_to_left"] = tree_accessor.get_field("default_left")
-
-        if n_targets == 1:
-            leaf_value = (
-                tree_accessor.get_field("leaf_value")
-                .astype("float64")
-                .reshape((-1, 1, 1))
+        estimators.append(
+            _export_tree(
+                model,
+                tree_id=tree_id,
+                n_features=n_features,
+                n_classes=n_classes,
+                n_targets=n_targets,
+                tree_depths=tree_depths,
+                subestimator_class=subestimator_class,
             )
-        else:
-            # Need to map leaf values to correct layout
-            leaf_value = np.zeros((n_nodes, n_targets, 1), dtype="float64")
-            leaf_value_raw = tree_accessor.get_field("leaf_vector").astype("float64")
-            leaf_vec_begin = tree_accessor.get_field("leaf_vector_begin")
-            leaf_vec_end = tree_accessor.get_field("leaf_vector_end")
-            for node_id in range(n_nodes):
-                if leaf_vec_begin[node_id] != leaf_vec_end[node_id]:
-                    # This node is a leaf node and outputs a vector
-                    leaf_value[node_id, :, :] = leaf_value_raw[
-                        leaf_vec_begin[node_id] : leaf_vec_end[node_id]
-                    ].reshape((n_targets, 1))
-
-        state = {
-            "max_depth": tree_depths[tree_id],
-            "node_count": n_nodes,
-            "nodes": nodes,
-            "values": leaf_value,
-        }
-        tree.__setstate__(state)
-
-        reg = DecisionTreeRegressor()
-        reg.__setstate__(
-            {
-                "tree_": tree,
-                "n_outputs_": n_targets,
-                "_sklearn_version": sklearn_version,
-            }
         )
 
-        estimators.append(reg)
-
-    clf = RandomForestRegressor()
-    clf.__setstate__(
-        {
-            "estimators_": estimators,
-            "n_outputs_": n_targets,
-            "_sklearn_version": sklearn_version,
-        }
-    )
+    clf = estimator_class()
+    state = {
+        "estimators_": estimators,
+        "n_outputs_": n_targets,
+        "_sklearn_version": sklearn_version,
+    }
+    if estimator_class is RandomForestClassifier:
+        if n_targets == 1:
+            state.update(
+                {
+                    "n_classes_": n_classes[0],
+                    "classes_": np.arange(n_classes[0]),
+                }
+            )
+        else:
+            state.update(
+                {
+                    "n_classes_": n_classes.tolist(),
+                    "classes_": [np.arange(n_classes[i]) for i in range(n_targets)],
+                }
+            )
+    clf.__setstate__(state)
 
     return clf

--- a/python/treelite/sklearn/exporter.py
+++ b/python/treelite/sklearn/exporter.py
@@ -1,5 +1,6 @@
 """Converter to export Treelite models as scikit-learn models (EXPERIMENTAL)"""
 
+from enum import IntEnum
 from typing import Any
 
 import numpy as np
@@ -43,6 +44,15 @@ _node_dtype = np.dtype(
         "itemsize": 64,
     }
 )
+
+
+class _TaskType(IntEnum):
+    # pylint: disable=invalid-name
+    kBinaryClf = 0
+    kRegressor = 1
+    kMultiClf = 2
+    kLearningToRank = 3
+    kIsolationForest = 4
 
 
 def _export_tree(
@@ -118,7 +128,7 @@ def _export_tree(
 
 def export_model(model: Model):
     """
-    Export as scikit-learn RandomForest or GradientBoosting.
+    Export a model as a scikit-learn RandomForest.
 
     Note
     ----
@@ -151,6 +161,7 @@ def export_model(model: Model):
     average_tree_output = (
         _ensure_scalar_int(header_accessor.get_field("average_tree_output")) == 1
     )
+    task_type = _ensure_scalar_int(header_accessor.get_field("task_type"))
     n_features = _ensure_scalar_int(header_accessor.get_field("num_feature"))
     n_trees = _ensure_scalar_int(header_accessor.get_field("num_tree"))
     n_targets = _ensure_scalar_int(header_accessor.get_field("num_target"))
@@ -166,31 +177,34 @@ def export_model(model: Model):
     # 3. Each leaf must yield an output of shape (n_targets, n_classes)
     # 4. target_id[i] must be either 0 or -1
     # 5. class_id[i] must be either 0 or -1
-    def raise_not_rf_error():
+    def raise_not_rf_error(reason):
         raise NotImplementedError(
-            "Currently only random forests can be exported as scikit-learn model objects. "
-            "Gradient boosting models and other kinds of decision tree models are not yet "
-            "supported."
+            "This Treelite model cannot be represented as scikit-learn random forest. "
+            f"Condition unmet: {reason}"
+            "Other kinds of tree models in scikit-learn are not yet supported."
         )
 
     if not average_tree_output:
-        raise_not_rf_error()
+        raise_not_rf_error(
+            "Outputs of tree outputs must be averaged to produce the final output"
+        )
     if not np.all(n_classes == n_classes[0]):
-        raise_not_rf_error()
+        raise_not_rf_error("n_classes must be identical for all trees")
     if not np.array_equal(leaf_vector_shape, [n_targets, n_classes.max()]):
-        raise_not_rf_error()
+        raise_not_rf_error(
+            "Each tree must produce output of dimensions (n_targets, n_classes)"
+        )
     if not np.all((target_id == 0) | (target_id == -1)):
-        raise_not_rf_error()
+        raise_not_rf_error("target_id field must be either 0 or -1")
     if not np.all((class_id == 0) | (class_id == -1)):
-        raise_not_rf_error()
+        raise_not_rf_error("class_id field must be either 0 or -1")
 
-    # Heuristics for determining whether the model is a regressor or a classifier
-    if n_classes[0] == 1:
-        estimator_class = RandomForestRegressor
-        subestimator_class = DecisionTreeRegressor
-    else:
+    if task_type in [_TaskType.kBinaryClf, _TaskType.kMultiClf]:
         estimator_class = RandomForestClassifier
         subestimator_class = DecisionTreeClassifier
+    else:
+        estimator_class = RandomForestRegressor
+        subestimator_class = DecisionTreeRegressor
 
     estimators = []
 

--- a/python/treelite/sklearn/exporter.py
+++ b/python/treelite/sklearn/exporter.py
@@ -225,6 +225,7 @@ def export_model(model: Model):
     state = {
         "estimators_": estimators,
         "n_outputs_": n_targets,
+        "n_features_in_": n_features,
         "_sklearn_version": sklearn_version,
     }
     if estimator_class is RandomForestClassifier:

--- a/python/treelite/sklearn/exporter.py
+++ b/python/treelite/sklearn/exporter.py
@@ -118,11 +118,17 @@ def _export_tree(
 
 def export_model(model: Model):
     """
-    Export as scikit-learn RandomForest or GradientBoosting
+    Export as scikit-learn RandomForest or GradientBoosting.
+
+    Note
+    ----
+    Currently only random forests can be exported as scikit-learn model objects.
+    Support for gradient boosted trees and other kinds of tree models will be
+    added in the future.
 
     Parameters
     ----------
-    model :py:class:`Model`
+    model : :py:class:`Model`
         Treelite mobel to export
 
     Returns

--- a/python/treelite/sklearn/exporter.py
+++ b/python/treelite/sklearn/exporter.py
@@ -1,0 +1,156 @@
+"""Converter to export Treelite models as scikit-learn models (EXPERIMENTAL)"""
+
+from typing import Any
+
+import numpy as np
+
+from ..core import TreeliteError
+from ..model import Model
+
+
+def _ensure_scalar_int(x: Any) -> int:
+    if isinstance(x, np.ndarray):
+        assert x.shape == (1,)
+        return int(x[0])
+    try:
+        return int(x)
+    except ValueError as e:
+        raise ValueError(f"Cannot interpret x as a scalar integer, {x.type=}") from e
+
+
+def _ensure_numpy(x: Any) -> np.ndarray:
+    if isinstance(x, np.ndarray):
+        return x
+    raise ValueError(f"x is not a valid NumPy array. {x.type=}")
+
+
+def export_model(model: Model):
+    """
+    Export as scikit-learn RandomForest or GradientBoosting
+
+    Parameters
+    ----------
+    model :py:class:`Model`
+        Treelite mobel to export
+
+    Returns
+    -------
+    sklearn_model : object of type \
+                    :py:class:`~sklearn.ensemble.RandomForestRegressor` / \
+                    :py:class:`~sklearn.ensemble.RandomForestClassifier` / \
+                    :py:class:`~sklearn.ensemble.GradientBoostingRegressor` / \
+                    :py:class:`~sklearn.ensemble.GradientBoostingClassifier`
+        Scikit-learn model
+    """
+    # pylint: disable=too-many-locals
+    try:
+        from sklearn import __version__ as sklearn_version
+        from sklearn.ensemble import RandomForestRegressor
+        from sklearn.tree import DecisionTreeRegressor
+        from sklearn.tree._tree import Tree as SKLearnTree
+    except ImportError as e:
+        raise TreeliteError("This function requires scikit-learn package") from e
+
+    node_dtype = np.dtype(
+        {
+            "names": [
+                "left_child",
+                "right_child",
+                "feature",
+                "threshold",
+                "impurity",
+                "n_node_samples",
+                "weighted_n_node_samples",
+                "missing_go_to_left",
+            ],
+            "formats": ["<i8", "<i8", "<i8", "<f8", "<f8", "<i8", "<f8", "u1"],
+            "offsets": [0, 8, 16, 24, 32, 40, 48, 56],
+            "itemsize": 64,
+        }
+    )
+
+    header_accessor = model.get_header_accessor()
+    # average_tree_output = (
+    #    header_accessor.get_field("average_tree_output").tolist()[0] == 1
+    # )
+    n_features = _ensure_scalar_int(header_accessor.get_field("num_feature"))
+    n_trees = _ensure_scalar_int(header_accessor.get_field("num_tree"))
+    n_targets = _ensure_scalar_int(header_accessor.get_field("num_target"))
+    n_classes = _ensure_numpy(header_accessor.get_field("num_class"))
+    leaf_vector_shape = _ensure_numpy(header_accessor.get_field("leaf_vector_shape"))
+    tree_depths = model.get_tree_depth()
+
+    assert np.all(n_classes == 1)
+    assert np.array_equal(leaf_vector_shape, [n_targets, 1])
+
+    estimators = []
+
+    for tree_id in range(n_trees):
+        tree_accessor = model.get_tree_accessor(tree_id)
+        has_categorical_split = tree_accessor.get_field(
+            "has_categorical_split"
+        ).tolist()[0]
+        assert not has_categorical_split
+
+        tree = SKLearnTree(n_features, n_classes, n_targets)
+
+        n_nodes = tree_accessor.get_field("num_nodes").tolist()[0]
+        nodes = np.empty(n_nodes, dtype=node_dtype)
+
+        nodes["left_child"] = tree_accessor.get_field("cleft")
+        nodes["right_child"] = tree_accessor.get_field("cright")
+        nodes["feature"] = tree_accessor.get_field("split_index")
+        nodes["threshold"] = tree_accessor.get_field("threshold")
+        nodes["impurity"] = np.nan
+        nodes["n_node_samples"] = -1
+        nodes["weighted_n_node_samples"] = np.nan
+        nodes["missing_go_to_left"] = tree_accessor.get_field("default_left")
+
+        if n_targets == 1:
+            leaf_value = (
+                tree_accessor.get_field("leaf_value")
+                .astype("float64")
+                .reshape((-1, 1, 1))
+            )
+        else:
+            # Need to map leaf values to correct layout
+            leaf_value = np.zeros((n_nodes, n_targets, 1), dtype="float64")
+            leaf_value_raw = tree_accessor.get_field("leaf_vector").astype("float64")
+            leaf_vec_begin = tree_accessor.get_field("leaf_vector_begin")
+            leaf_vec_end = tree_accessor.get_field("leaf_vector_end")
+            for node_id in range(n_nodes):
+                if leaf_vec_begin[node_id] != leaf_vec_end[node_id]:
+                    # This node is a leaf node and outputs a vector
+                    leaf_value[node_id, :, :] = leaf_value_raw[
+                        leaf_vec_begin[node_id] : leaf_vec_end[node_id]
+                    ].reshape((n_targets, 1))
+
+        state = {
+            "max_depth": tree_depths[tree_id],
+            "node_count": n_nodes,
+            "nodes": nodes,
+            "values": leaf_value,
+        }
+        tree.__setstate__(state)
+
+        reg = DecisionTreeRegressor()
+        reg.__setstate__(
+            {
+                "tree_": tree,
+                "n_outputs_": n_targets,
+                "_sklearn_version": sklearn_version,
+            }
+        )
+
+        estimators.append(reg)
+
+    clf = RandomForestRegressor()
+    clf.__setstate__(
+        {
+            "estimators_": estimators,
+            "n_outputs_": n_targets,
+            "_sklearn_version": sklearn_version,
+        }
+    )
+
+    return clf

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,6 +97,7 @@ target_sources(objtreelite
     json_serializer.cc
     logging.cc
     model_concat.cc
+    model_query.cc
     serializer.cc
     c_api/c_api_error.cc
     c_api/c_api_utils.h

--- a/src/c_api/c_api_utils.h
+++ b/src/c_api/c_api_utils.h
@@ -21,7 +21,8 @@ namespace treelite::c_api {
  *         storage is thread-local static storage. */
 struct ReturnValueEntry {
   std::string ret_str;
-  std::vector<std::uint64_t> ret_shape;
+  std::vector<std::uint32_t> ret_uint32_vec;
+  std::vector<std::uint64_t> ret_uint64_vec;
   std::vector<treelite::PyBufferFrame> ret_frames;
 };
 using ReturnValueStore = ThreadLocalStore<ReturnValueEntry>;

--- a/src/c_api/gtil.cc
+++ b/src/c_api/gtil.cc
@@ -34,7 +34,7 @@ int TreeliteGTILGetOutputShape(TreeliteModelHandle model, std::uint64_t num_row,
   API_BEGIN();
   auto const* model_ = static_cast<treelite::Model const*>(model);
   auto const* config_ = static_cast<treelite::gtil::Configuration const*>(config);
-  auto& shape = treelite::c_api::ReturnValueStore::Get()->ret_shape;
+  auto& shape = treelite::c_api::ReturnValueStore::Get()->ret_uint64_vec;
   shape = treelite::gtil::GetOutputShape(*model_, num_row, *config_);
   *out = shape.data();
   *out_ndim = shape.size();

--- a/src/c_api/model.cc
+++ b/src/c_api/model.cc
@@ -72,3 +72,13 @@ int TreeliteFreeModel(TreeliteModelHandle handle) {
   delete static_cast<treelite::Model*>(handle);
   API_END();
 }
+
+int TreeliteGetTreeDepth(TreeliteModelHandle model, std::uint32_t** out, std::size_t* out_len) {
+  API_BEGIN();
+  auto* model_ = static_cast<treelite::Model*>(model);
+  auto& ret_depth = treelite::c_api::ReturnValueStore::Get()->ret_uint32_vec;
+  ret_depth = model_->GetTreeDepth();
+  *out = ret_depth.data();
+  *out_len = ret_depth.size();
+  API_END();
+}

--- a/src/model_query.cc
+++ b/src/model_query.cc
@@ -1,0 +1,54 @@
+/*!
+ * Copyright (c) 2024 by Contributors
+ * \file model_query.cc
+ * \author Hyunsu Cho
+ * \brief Methods for querying various properties of tree models
+ */
+#include <cstdint>
+#include <queue>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <treelite/tree.h>
+
+namespace {
+
+template <typename ThresholdType, typename LeafOutputType>
+std::uint32_t GetDepth(treelite::Tree<ThresholdType, LeafOutputType> const& tree) {
+  // Visit all trees nodes in breath-first order
+  std::queue<std::pair<int, std::uint32_t>> q;
+  // {current node visiting, depth level of the node}
+  q.emplace(0, 0);
+  std::uint32_t tree_depth = 0;
+  while (!q.empty()) {
+    auto [node_id, level] = q.front();
+    q.pop();
+    if (tree.IsLeaf(node_id)) {
+      tree_depth = std::max(tree_depth, level);
+    } else {
+      q.emplace(tree.LeftChild(node_id), level + 1);
+      q.emplace(tree.RightChild(node_id), level + 1);
+    }
+  }
+  return tree_depth;
+}
+
+}  // anonymous namespace
+
+namespace treelite {
+
+std::vector<std::uint32_t> Model::GetTreeDepth() const {
+  return std::visit(
+      [](auto&& concrete_model) {
+        std::vector<std::uint32_t> depth;
+        depth.reserve(concrete_model.trees.size());
+        for (auto const& tree : concrete_model.trees) {
+          depth.push_back(GetDepth(tree));
+        }
+        return depth;
+      },
+      variant_);
+}
+
+}  // namespace treelite

--- a/src/model_query.cc
+++ b/src/model_query.cc
@@ -5,7 +5,7 @@
  * \brief Methods for querying various properties of tree models
  */
 #include <cstdint>
-#include <queue>
+#include <stack>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -16,22 +16,24 @@ namespace {
 
 template <typename ThresholdType, typename LeafOutputType>
 std::uint32_t GetDepth(treelite::Tree<ThresholdType, LeafOutputType> const& tree) {
-  // Visit all trees nodes in breath-first order
-  std::queue<std::pair<int, std::uint32_t>> q;
-  // {current node visiting, depth level of the node}
-  q.emplace(0, 0);
-  std::uint32_t tree_depth = 0;
-  while (!q.empty()) {
-    auto [node_id, level] = q.front();
-    q.pop();
+  // Visit all trees nodes in depth-first order
+  std::stack<int> st;
+  st.push(0);
+  std::uint32_t max_depth = 0;
+  std::uint32_t depth = 1;
+  while (!st.empty()) {
+    int node_id = st.top();
+    st.pop();
     if (tree.IsLeaf(node_id)) {
-      tree_depth = std::max(tree_depth, level);
+      --depth;
     } else {
-      q.emplace(tree.LeftChild(node_id), level + 1);
-      q.emplace(tree.RightChild(node_id), level + 1);
+      st.push(tree.LeftChild(node_id));
+      st.push(tree.RightChild(node_id));
+      ++depth;
     }
+    max_depth = std::max(max_depth, depth);
   }
-  return tree_depth;
+  return max_depth;
 }
 
 }  // anonymous namespace

--- a/tests/python/test_sklearn_integration.py
+++ b/tests/python/test_sklearn_integration.py
@@ -274,6 +274,6 @@ def test_skl_export_regressor(n_targets, max_depth, n_estimators, callback):
     clf.fit(X, y)
 
     tl_model = treelite.sklearn.import_model(clf)
-    clf2 = tl_model.export_as_sklearn()
+    clf2 = treelite.sklearn.export_model(tl_model)
     assert isinstance(clf2, RandomForestRegressor)
     np.testing.assert_almost_equal(clf2.predict(X), clf.predict(X))

--- a/tests/python/test_sklearn_integration.py
+++ b/tests/python/test_sklearn_integration.py
@@ -259,15 +259,16 @@ def test_skl_hist_gradient_boosting_with_string_categorical():
 
 
 @given(
-    n_targets=integers(min_value=1, max_value=3),
+    dataset=standard_regression_datasets(
+        n_targets=integers(min_value=1, max_value=3),
+    ),
     max_depth=integers(min_value=3, max_value=15),
     n_estimators=integers(min_value=5, max_value=10),
-    callback=hypothesis_callback(),
 )
 @settings(**standard_settings())
-def test_skl_export_regressor(n_targets, max_depth, n_estimators, callback):
-    """Round trip with scikit-learn regressor"""
-    X, y = callback.draw(standard_regression_datasets(n_targets=just(n_targets)))
+def test_skl_export_rf_regressor(dataset, max_depth, n_estimators):
+    """Round trip with scikit-learn RF regressor"""
+    X, y = dataset
     clf = RandomForestRegressor(
         max_depth=max_depth, random_state=0, n_estimators=n_estimators, n_jobs=-1
     )
@@ -277,3 +278,55 @@ def test_skl_export_regressor(n_targets, max_depth, n_estimators, callback):
     clf2 = treelite.sklearn.export_model(tl_model)
     assert isinstance(clf2, RandomForestRegressor)
     np.testing.assert_almost_equal(clf2.predict(X), clf.predict(X))
+
+
+@given(
+    dataset=standard_classification_datasets(
+        n_classes=integers(min_value=2, max_value=4),
+    ),
+    max_depth=integers(min_value=3, max_value=15),
+    n_estimators=integers(min_value=5, max_value=10),
+)
+@settings(**standard_settings())
+def test_skl_export_rf_classifier(dataset, max_depth, n_estimators):
+    """Round trip with scikit-learn RF classifier"""
+    X, y = dataset
+    clf = RandomForestClassifier(
+        max_depth=max_depth, random_state=0, n_estimators=n_estimators, n_jobs=-1
+    )
+    clf.fit(X, y)
+
+    tl_model = treelite.sklearn.import_model(clf)
+    clf2 = treelite.sklearn.export_model(tl_model)
+    assert isinstance(clf2, RandomForestClassifier)
+    np.testing.assert_almost_equal(clf2.predict(X), clf.predict(X))
+
+
+@given(
+    n_classes=integers(min_value=3, max_value=5),
+    n_estimators=integers(min_value=3, max_value=10),
+)
+@settings(**standard_settings())
+def test_skl_export_rf_multitarget_multiclass(n_classes, n_estimators):
+    """Round trip with scikit-learn RF classifier, with multiple outputs and classes"""
+    X, y1 = make_classification(
+        n_samples=1000,
+        n_features=100,
+        n_informative=30,
+        n_classes=n_classes,
+        random_state=0,
+    )
+    y2 = shuffle(y1, random_state=1)
+    y3 = shuffle(y1, random_state=2)
+
+    y = np.vstack((y1, y2, y3)).T
+
+    clf = RandomForestClassifier(
+        max_depth=8, n_estimators=n_estimators, n_jobs=-1, random_state=4
+    )
+    clf.fit(X, y)
+
+    tl_model = treelite.sklearn.import_model(clf)
+    clf2 = treelite.sklearn.export_model(tl_model)
+    assert isinstance(clf2, RandomForestClassifier)
+    np.testing.assert_almost_equal(clf2.predict_proba(X), clf.predict_proba(X))

--- a/tests/python/test_sklearn_integration.py
+++ b/tests/python/test_sklearn_integration.py
@@ -259,14 +259,15 @@ def test_skl_hist_gradient_boosting_with_string_categorical():
 
 
 @given(
+    n_targets=integers(min_value=1, max_value=3),
     max_depth=integers(min_value=3, max_value=15),
     n_estimators=integers(min_value=5, max_value=10),
     callback=hypothesis_callback(),
 )
 @settings(**standard_settings())
-def test_skl_export_regressor(max_depth, n_estimators, callback):
+def test_skl_export_regressor(n_targets, max_depth, n_estimators, callback):
     """Round trip with scikit-learn regressor"""
-    X, y = callback.draw(standard_regression_datasets(n_targets=just(1)))
+    X, y = callback.draw(standard_regression_datasets(n_targets=just(n_targets)))
     clf = RandomForestRegressor(
         max_depth=max_depth, random_state=0, n_estimators=n_estimators, n_jobs=-1
     )

--- a/tests/python/test_sklearn_integration.py
+++ b/tests/python/test_sklearn_integration.py
@@ -259,16 +259,20 @@ def test_skl_hist_gradient_boosting_with_string_categorical():
 
 
 @given(
+    max_depth=integers(min_value=3, max_value=15),
+    n_estimators=integers(min_value=5, max_value=10),
     callback=hypothesis_callback(),
 )
 @settings(**standard_settings())
-def test_skl_export(callback):
-    """Scikit-learn regressor"""
+def test_skl_export_regressor(max_depth, n_estimators, callback):
+    """Round trip with scikit-learn regressor"""
     X, y = callback.draw(standard_regression_datasets(n_targets=just(1)))
-    kwargs = {"max_depth": 8, "random_state": 0, "n_estimators": 10, "n_jobs": -1}
-    clf = RandomForestRegressor(**kwargs)
+    clf = RandomForestRegressor(
+        max_depth=max_depth, random_state=0, n_estimators=n_estimators, n_jobs=-1
+    )
     clf.fit(X, y)
 
     tl_model = treelite.sklearn.import_model(clf)
     clf2 = tl_model.export_as_sklearn()
+    assert isinstance(clf2, RandomForestRegressor)
     np.testing.assert_almost_equal(clf2.predict(X), clf.predict(X))

--- a/tests/python/test_sklearn_integration.py
+++ b/tests/python/test_sklearn_integration.py
@@ -256,3 +256,19 @@ def test_skl_hist_gradient_boosting_with_string_categorical():
         NotImplementedError, match=r"String categories are not supported"
     ):
         _ = treelite.sklearn.import_model(clf)
+
+
+@given(
+    callback=hypothesis_callback(),
+)
+@settings(**standard_settings())
+def test_skl_export(callback):
+    """Scikit-learn regressor"""
+    X, y = callback.draw(standard_regression_datasets(n_targets=just(1)))
+    kwargs = {"max_depth": 8, "random_state": 0, "n_estimators": 10, "n_jobs": -1}
+    clf = RandomForestRegressor(**kwargs)
+    clf.fit(X, y)
+
+    tl_model = treelite.sklearn.import_model(clf)
+    clf2 = tl_model.export_as_sklearn()
+    np.testing.assert_almost_equal(clf2.predict(X), clf.predict(X))


### PR DESCRIPTION
This PR adds a function to export Treelite models as scikit-learn random forests.
It makes use of the [field accessor API](https://treelite.readthedocs.io/en/latest/treelite-api.html#field-accessors).

Usage:
```python
# tl_model is an treelite.Model object

# Returns either RandomForestClassifier / RandomForestRegressor
clf = treelite.sklearn.export_model(tl_model)  
```

Limitations
* Export to GradientBoosting is not yet supported.
* Treelite models with categorical splits are not yet supported.
* Test coverage currently ensures that `predict()` and `predict_proba()` return correct result. Other estimator metadata may be missing or incorrect.
* Most of export logic is written in the Python layer so may be slow for very large models.