### PR TITLE
tree.h: Fix SetModelPresetVariant variant_index template parameter

### DIFF
--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -429,7 +429,7 @@ class ModelPreset {
 using ModelPresetVariant = std::variant<ModelPreset<float, float>, ModelPreset<double, double>>;
 
 template <std::size_t variant_index>
-ModelPresetVariant SetModelPresetVariant(int target_variant_index) {
+ModelPresetVariant SetModelPresetVariant(std::size_t target_variant_index) {
   ModelPresetVariant result;
   if constexpr (variant_index != std::variant_size_v<ModelPresetVariant>) {
     if (variant_index == target_variant_index) {

--- a/include/treelite/tree.h
+++ b/include/treelite/tree.h
@@ -428,7 +428,7 @@ class ModelPreset {
 
 using ModelPresetVariant = std::variant<ModelPreset<float, float>, ModelPreset<double, double>>;
 
-template <int variant_index>
+template <std::size_t variant_index>
 ModelPresetVariant SetModelPresetVariant(int target_variant_index) {
   ModelPresetVariant result;
   if constexpr (variant_index != std::variant_size_v<ModelPresetVariant>) {


### PR DESCRIPTION
Fixes compiling with -Werror=sign-conversion
Fixes #599