### PR TITLE
Run arm64 CI on native runners instead of QEMU

### DIFF
--- a/.github/workflows/linux-wheel-builder.yml
+++ b/.github/workflows/linux-wheel-builder.yml
@@ -24,54 +24,42 @@ env:
 
 jobs:
   linux-wheel-builder:
-    name: Build and test Python wheels (Linux amd64)
-    runs-on: ubuntu-latest
+    name: Build and test Python wheels (Linux)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            build-script: ops/build-linux.sh
+          - os: ubuntu-22.04-arm
+            build-script: ops/build-linux-aarch64.sh
+
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: 'true'
-    - uses: conda-incubator/setup-miniconda@v3
-      with:
-        miniforge-variant: Miniforge3
-        miniforge-version: latest
-        activate-environment: dev
-        environment-file: ops/conda_env/dev.yml
-        use-mamba: true
-    - name: Display Conda env
-      run: |
-        conda info
-        conda list
-    - name: Build wheel
-      run: |
-        bash ops/build-linux.sh
-    - name: Test wheel
-      run: |
-        bash ops/test-linux-python-wheel.sh
-  linux-wheel-builder-aarch64:
-    name: Build and test Python wheels (Linux aarch64)
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: 'true'
-    - uses: conda-incubator/setup-miniconda@v3
-      with:
-        miniforge-variant: Miniforge3
-        miniforge-version: latest
-        activate-environment: dev
-        environment-file: ops/conda_env/dev.yml
-        use-mamba: true
-    - name: Display Conda env
-      run: |
-        conda info
-        conda list
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: all
-    - name: Build wheel
-      run: |
-        bash ops/build-linux-aarch64.sh
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-variant: Miniforge3
+          miniforge-version: latest
+          activate-environment: dev
+          environment-file: ops/conda_env/dev.yml
+          use-mamba: true
+
+      - name: Display Conda env
+        run: |
+          conda info
+          conda list
+
+      - name: Build wheel
+        run: |
+          bash ${{ matrix.build-script }}
+
+      - name: Test wheel
+        run: |
+          bash ops/test-linux-python-wheel.sh
+
   cpack-builder:
     name: Build CPack
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use Github-hosted Arm runners instead of QEMU to run Arm64 CI