### PR TITLE
fix: Depth Calculation for iForest importer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
   rev: v1.17.1
   hooks:
     - id: mypy
-      additional_dependencies: [types-setuptools, numpy]
+      additional_dependencies: [types-setuptools]
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.12.8
   hooks:

--- a/python/treelite/sklearn/isolation_forest.py
+++ b/python/treelite/sklearn/isolation_forest.py
@@ -6,7 +6,7 @@ from scipy.special import psi
 
 def harmonic(number):
     """Calculates the n-th harmonic number"""
-    return psi(number + 1) + np.euler_gamma
+    return np.log(number) + np.euler_gamma
 
 
 def expected_depth(n_remainder):
@@ -15,7 +15,7 @@ def expected_depth(n_remainder):
         return 0.0
     if n_remainder == 2:
         return 1.0
-    return float(2 * (harmonic(n_remainder) - 1))
+    return float(2 * harmonic(n_remainder - 1) - 2 * (n_remainder - 1) / n_remainder)
 
 
 def calculate_depths(isolation_depths, tree, curr_node, curr_depth):

--- a/python/treelite/sklearn/isolation_forest.py
+++ b/python/treelite/sklearn/isolation_forest.py
@@ -1,7 +1,6 @@
 """Utility functions for loading IsolationForest models"""
 
 import numpy as np
-from scipy.special import psi
 
 
 def harmonic(number):

--- a/tests/python/test_sklearn_integration.py
+++ b/tests/python/test_sklearn_integration.py
@@ -192,7 +192,7 @@ def test_skl_converter_iforest(dataset):
 
     tl_model = treelite.sklearn.import_model(clf)
     out_pred = treelite.gtil.predict(tl_model, X)
-    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=2)
+    np.testing.assert_almost_equal(out_pred, expected_pred)
 
 
 @given(


### PR DESCRIPTION
Corrected the path depth calculation for `IsolationForest` model conversion to match sklearn's implementation.

In Isolation Forest, the anomaly score is computed as:

    s(x) = 2^(-E[h(x)] / c(n))

Where:
- E[h(x)] is the expected path length for sample x
- c(n) = 2 * H(n - 1) - (2 * (n - 1)) / n
- H(n) is the nth harmonic number

Previously, Treelite used the digamma-based formulation for the harmonic number:

    H(n) = ψ(n + 1) + γ

and computed c(n) as:

    c(n) = float(2 * (harmonic(n) - 1))

While mathematically valid, this differs from sklearn’s implementation and the original paper. sklearn approximates H(n) as:

    H(n) ≈ ln(n) + γ

and computes:

    c(n) = 2 * H(n - 1) - (2 * (n - 1)) / n

This PR changes Treelite’s calculation to match sklearn's implementation, ensuring consistency in path length and anomaly score computations, especially for small n where numerical differences may affect results.


Error Visualization
before:
<img width="833" height="547" alt="old" src="https://github.com/user-attachments/assets/f8826b2f-2fc6-422e-960c-f59e3f9631cf" />

after:
<img width="833" height="547" alt="fixed" src="https://github.com/user-attachments/assets/3b03938a-edfd-44a3-9f77-a390e4edfbc5" />

