### PR TITLE
fix: iForest feature mapping

### DIFF
--- a/python/treelite/sklearn/importer.py
+++ b/python/treelite/sklearn/importer.py
@@ -204,11 +204,16 @@ def import_model(sklearn_model) -> Model:
                     expected_shape=leaf_value_expected_shape(tree.node_count),
                 )
                 # Note: for isolation forest, if max_features != 1.0
-            	# the feature index will be subsampled
+                # the feature index will be subsampled
                 feature_subsample = np.full(tree.feature.shape, -2, dtype=np.int64)
                 mask = tree.feature != -2
-                feature_subsample[mask] = np.array(sklearn_model.estimators_features_[tree_idx])[tree.feature[mask]]
-                feature.add(feature_subsample.astype(np.int64), expected_shape=(tree.node_count,))
+                feature_subsample[mask] = np.array(
+                    sklearn_model.estimators_features_[tree_idx]
+                )[tree.feature[mask]]
+                feature.add(
+                    feature_subsample.astype(np.int64),
+                    expected_shape=(tree.node_count,),
+                )
             else:
                 # Note: for gradient boosted trees, we shrink each leaf output by the
                 # learning rate

--- a/python/treelite/sklearn/importer.py
+++ b/python/treelite/sklearn/importer.py
@@ -180,7 +180,7 @@ def import_model(sklearn_model) -> Model:
     n_node_samples = ArrayOfArrays(dtype=np.int64)
     weighted_n_node_samples = ArrayOfArrays(dtype=np.float64)
     impurity = ArrayOfArrays(dtype=np.float64)
-    for estimator in sklearn_model.estimators_:
+    for tree_idx, estimator in enumerate(sklearn_model.estimators_):
         if isinstance(sklearn_model, (GradientBoostingR, GradientBoostingC)):
             estimator_range = estimator
             learning_rate = sklearn_model.learning_rate
@@ -197,13 +197,18 @@ def import_model(sklearn_model) -> Model:
             node_count.append(tree.node_count)
             children_left.add(tree.children_left, expected_shape=(tree.node_count,))
             children_right.add(tree.children_right, expected_shape=(tree.node_count,))
-            feature.add(tree.feature, expected_shape=(tree.node_count,))
             threshold.add(tree.threshold, expected_shape=(tree.node_count,))
             if isinstance(sklearn_model, IsolationForest):
                 value.add(
                     isolation_depths.reshape((-1, 1, 1)),
                     expected_shape=leaf_value_expected_shape(tree.node_count),
                 )
+                # Note: for isolation forest, if max_features != 1.0
+            	# the feature index will be subsampled
+                feature_subsample = np.full(tree.feature.shape, -2, dtype=np.int64)
+                mask = tree.feature != -2
+                feature_subsample[mask] = np.array(sklearn_model.estimators_features_[tree_idx])[tree.feature[mask]]
+                feature.add(feature_subsample.astype(np.int64), expected_shape=(tree.node_count,))
             else:
                 # Note: for gradient boosted trees, we shrink each leaf output by the
                 # learning rate
@@ -211,6 +216,7 @@ def import_model(sklearn_model) -> Model:
                     tree.value * learning_rate,
                     expected_shape=leaf_value_expected_shape(tree.node_count),
                 )
+                feature.add(tree.feature, expected_shape=(tree.node_count,))
             n_node_samples.add(tree.n_node_samples, expected_shape=(tree.node_count,))
             weighted_n_node_samples.add(
                 tree.weighted_n_node_samples, expected_shape=(tree.node_count,)

--- a/tests/python/test_sklearn_integration.py
+++ b/tests/python/test_sklearn_integration.py
@@ -194,9 +194,10 @@ def test_skl_converter_iforest(dataset):
     out_pred = treelite.gtil.predict(tl_model, X)
     np.testing.assert_almost_equal(out_pred, expected_pred)
 
+
 @given(
     dataset=standard_regression_datasets(),
-    max_feat=floats(min_value=0.2, max_value=0.8)
+    max_feat=floats(min_value=0.2, max_value=0.8),
 )
 @settings(**standard_settings())
 def test_skl_converter_iforest_feature_subsampling(dataset, max_feat):
@@ -216,6 +217,7 @@ def test_skl_converter_iforest_feature_subsampling(dataset, max_feat):
     out_pred = treelite.gtil.predict(tl_model, X)
 
     np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
+
 
 @given(
     dataset=standard_classification_datasets(

--- a/tests/python/test_sklearn_integration.py
+++ b/tests/python/test_sklearn_integration.py
@@ -194,6 +194,28 @@ def test_skl_converter_iforest(dataset):
     out_pred = treelite.gtil.predict(tl_model, X)
     np.testing.assert_almost_equal(out_pred, expected_pred)
 
+@given(
+    dataset=standard_regression_datasets(),
+    max_feat=floats(min_value=0.2, max_value=0.8)
+)
+@settings(**standard_settings())
+def test_skl_converter_iforest_feature_subsampling(dataset, max_feat):
+    """Scikit-learn isolation forest with feature subsampling"""
+    X, _ = dataset
+    clf = IsolationForest(
+        max_samples=64,
+        max_features=max_feat,
+        n_estimators=10,
+        n_jobs=-1,
+        random_state=0,
+    )
+    clf.fit(X)
+    expected_pred = -clf.score_samples(X).reshape((-1, 1, 1))
+
+    tl_model = treelite.sklearn.import_model(clf)
+    out_pred = treelite.gtil.predict(tl_model, X)
+
+    np.testing.assert_almost_equal(out_pred, expected_pred, decimal=5)
 
 @given(
     dataset=standard_classification_datasets(


### PR DESCRIPTION
This PR fixes the feature mapping logic when importing Isolation Forest models.

### Bug Description
The issue occurs when max_features is not equal to the number of input features, e.g.:
```
clf = IsolationForest(max_features=0.5)
clf = IsolationForest(max_features=10)
```

### Changes:
- Use `enumerate` to track tree index in `estimators_`.
- For Isolation Forest:
  - Handle feature subsampling when `max_features != 1.0` using
    `estimators_features_[tree_idx]`.
  - Add proper feature indices instead of raw `tree.feature`.
- For Other Trees:
  - Move `feature.add` to else section.
- Updated comments for clarity.

This ensures feature indices are correctly aligned with the training subsample,
avoiding incorrect feature mappings in downstream usage.
