### PR TITLE
Support serializing models larger than 2**31 - 1

### DIFF
--- a/python/treelite/model.py
+++ b/python/treelite/model.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from . import compat
 from .core import _LIB, _check_call
-from .util import c_array, c_str, py_str
+from .util import bytes_from_string_and_size, c_array, c_str, py_str
 
 
 class Model:
@@ -345,7 +345,7 @@ class Model:
                 self.handle, ctypes.byref(out_bytes), ctypes.byref(out_bytes_len)
             )
         )
-        return ctypes.string_at(out_bytes, out_bytes_len.value)
+        return bytes_from_string_and_size(out_bytes, out_bytes_len)
 
     @classmethod
     def deserialize(cls, filename: Union[str, pathlib.Path]) -> Model:

--- a/python/treelite/model.py
+++ b/python/treelite/model.py
@@ -345,7 +345,7 @@ class Model:
                 self.handle, ctypes.byref(out_bytes), ctypes.byref(out_bytes_len)
             )
         )
-        return bytes_from_string_and_size(out_bytes, out_bytes_len)
+        return bytes_from_string_and_size(out_bytes, out_bytes_len.value)
 
     @classmethod
     def deserialize(cls, filename: Union[str, pathlib.Path]) -> Model:

--- a/python/treelite/util.py
+++ b/python/treelite/util.py
@@ -20,6 +20,11 @@ _CTYPES_TYPE_TABLE = {
 _NUMPY_TYPE_TABLE = {"uint32": np.uint32, "float32": np.float32, "float64": np.float64}
 
 
+_PyBytes_FromStringAndSize = ctypes.pythonapi.PyBytes_FromStringAndSize
+_PyBytes_FromStringAndSize.argtypes = (ctypes.c_char_p, ctypes.c_ssize_t)
+_PyBytes_FromStringAndSize.restype = ctypes.py_object
+
+
 def typestr_to_ctypes_type(type_info):
     """Obtain ctypes type corresponding to a given Type str"""
     return _CTYPES_TYPE_TABLE[type_info]
@@ -33,6 +38,14 @@ def typestr_to_numpy_type(type_info):
 def c_str(string):
     """Convert a Python string to C string"""
     return ctypes.c_char_p(string.encode("utf-8"))
+
+
+def bytes_from_string_and_size(ptr, size):
+    """Copy `size` bytes from `ptr` to create a new python `bytes` object"""
+    # Theoretically `ctypes.string_at` does this, but the `size` argument
+    # there only takes an `int`, while python bytes object can support up to a
+    # `ssize_t` in size.
+    return _PyBytes_FromStringAndSize(ptr, size)
 
 
 def py_str(string):


### PR DESCRIPTION
Previously `treelite` used `ctypes.string_at` to copy the serialized bytes return value to a new python `bytes` object. This method takes a pointer and a length (expressed as an `int`). Python `bytes` objects have a max capacity of `Py_ssize_t`, not `int`. This meant that serializing very large models could error as the `size` parameter would overflow an `int`.

We now use `PyBytes_FromStringAndSize` directly, avoiding this issue.

It's hard to write a sane test for this that can run on CI, but I've verified that things are working locally.