### PR TITLE
Support XGBoost 3.1

### DIFF
--- a/src/model_loader/detail/xgboost.cc
+++ b/src/model_loader/detail/xgboost.cc
@@ -16,6 +16,10 @@
 #include <treelite/logging.h>
 #include <treelite/model_loader.h>
 
+#include <rapidjson/document.h>
+
+#include "./string_utils.h"
+
 namespace treelite::model_loader {
 
 namespace detail::xgboost {
@@ -53,6 +57,25 @@ double TransformBaseScoreToMargin(std::string const& postprocessor, double base_
   } else {
     return base_score;
   }
+}
+
+std::vector<float> ParseBaseScore(std::string const& str) {
+  std::vector<float> parsed_base_score;
+  if (StringStartsWith(str, "[")) {
+    // Vector base_score (from XGBoost 3.1+)
+    rapidjson::Document doc;
+    doc.Parse<rapidjson::ParseFlag::kParseNanAndInfFlag>(str);
+    TREELITE_CHECK(doc.IsArray()) << "Expected an array for base_score";
+    parsed_base_score.clear();
+    for (auto const& e : doc.GetArray()) {
+      TREELITE_CHECK(e.IsFloat()) << "Expected a float array for base_score";
+      parsed_base_score.push_back(e.GetFloat());
+    }
+  } else {
+    // Scalar base_score (from XGBoost <3.1)
+    parsed_base_score = {std::stof(str)};
+  }
+  return parsed_base_score;
 }
 
 }  // namespace detail::xgboost

--- a/src/model_loader/detail/xgboost.h
+++ b/src/model_loader/detail/xgboost.h
@@ -28,6 +28,9 @@ std::string GetPostProcessor(std::string const& objective_name);
 // Transform base score from probability into margin score
 double TransformBaseScoreToMargin(std::string const& postprocessor, double base_score);
 
+// Parse base score
+std::vector<float> ParseBaseScore(std::string const& str);
+
 enum FeatureType { kNumerical = 0, kCategorical = 1 };
 
 }  // namespace treelite::model_loader::detail::xgboost

--- a/src/model_loader/detail/xgboost_json/delegated_handler.cc
+++ b/src/model_loader/detail/xgboost_json/delegated_handler.cc
@@ -8,6 +8,7 @@
 
 #include "./delegated_handler.h"
 
+#include <algorithm>
 #include <string>
 
 #include <treelite/logging.h>
@@ -647,14 +648,17 @@ bool LearnerParamHandler::String(std::string const& str) {
   if (this->should_ignore_upcoming_value()) {
     return true;
   }
-  // For now, XGBoost always outputs a scalar base_score
-  return (
-      assign_value("base_score", static_cast<float>(std::stof(str)), output.base_score)
-      || assign_value("num_class", std::max(std::stoi(str), 1), output.num_class)
-      || assign_value("num_target", static_cast<std::int32_t>(std::stoi(str)), output.num_target)
-      || assign_value("num_feature", std::stoi(str), output.num_feature)
-      || assign_value(
-          "boost_from_average", static_cast<bool>(std::stoi(str)), output.boost_from_average));
+
+  // Special handling logic for base_score
+  bool got_base_score = check_cur_key("base_score");
+  if (got_base_score) {
+    output.base_score = ParseBaseScore(str);
+  }
+  return got_base_score || assign_value("num_class", std::max(std::stoi(str), 1), output.num_class)
+         || assign_value("num_target", static_cast<std::int32_t>(std::stoi(str)), output.num_target)
+         || assign_value("num_feature", std::stoi(str), output.num_feature)
+         || assign_value(
+             "boost_from_average", static_cast<bool>(std::stoi(str)), output.boost_from_average);
 }
 
 bool LearnerParamHandler::is_recognized_key(std::string const& key) {
@@ -743,18 +747,30 @@ bool LearnerHandler::EndObject() {
       leaf_vector_shape[1] = 1;
     }
   }
-  // Set base scores. For now, XGBoost only supports a scalar base score for all targets / classes.
-  auto base_score = static_cast<double>(learner_params.base_score);
+  // Set base scores
+  // Assume: Either num_target or num_class must be 1
+  TREELITE_CHECK(learner_params.num_target == 1 || learner_params.num_class == 1);
+  std::vector<double> base_scores(learner_params.num_target * learner_params.num_class);
+  if (learner_params.base_score.size() == 1) {
+    // Scalar base_score (XGBoost <3.1)
+    // Starting from 3.1, the base score is a vector.
+    std::fill(base_scores.begin(), base_scores.end(),
+        static_cast<double>(learner_params.base_score.at(0)));
+  } else {
+    // Vector base_score (XGBoost 3.1+)
+    // Assume: If base_score is a vector, then its length should be num_target * num_class.
+    TREELITE_CHECK(base_scores.size() == learner_params.base_score.size());
+    std::transform(learner_params.base_score.begin(), learner_params.base_score.end(),
+        base_scores.begin(), [](float e) { return static_cast<double>(e); });
+  }
+
   // Before XGBoost 1.0.0, the base score saved in model is a transformed value.  After
   // 1.0 it's the original value provided by user.
   bool const need_transform_to_margin = output.version.empty() || output.version[0] >= 1;
   if (need_transform_to_margin) {
-    base_score = xgboost::TransformBaseScoreToMargin(postprocessor.name, base_score);
+    std::for_each(base_scores.begin(), base_scores.end(),
+        [&](auto& e) { e = xgboost::TransformBaseScoreToMargin(postprocessor.name, e); });
   }
-  // For now, XGBoost produces a scalar base_score
-  // Assume: Either num_target or num_class must be 1
-  TREELITE_CHECK(learner_params.num_target == 1 || learner_params.num_class == 1);
-  std::vector<double> base_scores(learner_params.num_target * learner_params.num_class, base_score);
 
   model_builder::Metadata metadata{
       num_feature, task_type, average_tree_output, num_target, num_class, leaf_vector_shape};

--- a/src/model_loader/detail/xgboost_json/delegated_handler.cc
+++ b/src/model_loader/detail/xgboost_json/delegated_handler.cc
@@ -500,11 +500,10 @@ RegTreeArrayHandler::RegTreeArrayHandler(std::weak_ptr<Delegator> parent_delegat
 
 bool RegTreeArrayHandler::StartObject() {
   if (this->should_ignore_upcoming_value()) {
-    return this->template push_handler<IgnoreHandler>();
+    return push_handler<IgnoreHandler>();
   }
-  this->output.emplace_back();
-  return this->template push_handler<RegTreeHandler, ParsedRegTreeParams>(
-      this->output.back(), model_builder);
+  output.emplace_back();
+  return push_handler<RegTreeHandler, ParsedRegTreeParams>(output.back(), model_builder);
 }
 
 /******************************************************************************
@@ -526,7 +525,9 @@ bool GBTreeModelHandler::StartObject() {
   if (this->should_ignore_upcoming_value()) {
     return push_handler<IgnoreHandler>();
   }
-  return push_key_handler<IgnoreHandler>("gbtree_model_param");
+  return push_key_handler<IgnoreHandler>("gbtree_model_param")
+         || push_key_handler<CategoryContainerHandler, ParsedCategoryContainer>(
+             "cats", output.category_container);
 }
 
 bool GBTreeModelHandler::EndObject() {
@@ -545,8 +546,124 @@ bool GBTreeModelHandler::EndObject() {
 }
 
 bool GBTreeModelHandler::is_recognized_key(std::string const& key) {
-  return (key == "trees" || key == "tree_info" || key == "gbtree_model_param"
-          || key == "iteration_indptr");
+  return key == "trees" || key == "tree_info" || key == "gbtree_model_param"
+         || key == "iteration_indptr" || key == "cats";
+}
+
+/******************************************************************************
+ * CategoryContainerHandler
+ * ***************************************************************************/
+
+bool CategoryContainerHandler::StartArray() {
+  if (this->should_ignore_upcoming_value()) {
+    return push_handler<IgnoreHandler>();
+  }
+  return push_key_handler<CategoryInfoArrayHandler>("enc", output.enc)
+         || push_key_handler<ArrayHandler<std::int32_t>, std::vector<std::int32_t>>(
+             "feature_segments", output.feature_segments)
+         || push_key_handler<ArrayHandler<std::int32_t>, std::vector<std::int32_t>>(
+             "sorted_idx", output.sorted_idx);
+}
+
+bool CategoryContainerHandler::is_recognized_key(std::string const& key) {
+  return key == "enc" || key == "feature_segments" || key == "sorted_idx";
+}
+
+/******************************************************************************
+ * CategoryInfoArrayHandler
+ * ***************************************************************************/
+bool CategoryInfoArrayHandler::StartObject() {
+  if (this->should_ignore_upcoming_value()) {
+    return push_handler<IgnoreHandler>();
+  }
+  output.emplace_back();
+  return push_handler<CategoryInfoHandler, ParsedCategoryInfo>(output.back());
+}
+
+/******************************************************************************
+ * CategoryInfoHandler
+ * ***************************************************************************/
+bool CategoryInfoHandler::Int64(std::int64_t i) {
+  if (this->should_ignore_upcoming_value()) {
+    return push_handler<IgnoreHandler>();
+  }
+  bool got_type = check_cur_key("type");
+  if (got_type) {
+    output.type = i;
+  }
+  return got_type;
+}
+
+bool CategoryInfoHandler::Uint64(std::uint64_t u) {
+  // The "type" field can be int64 or uint64
+  // Just defer to the int64 handler
+  return Int64(static_cast<std::int64_t>(u));
+}
+
+bool CategoryInfoHandler::StartArray() {
+  if (this->should_ignore_upcoming_value()) {
+    return push_handler<IgnoreHandler>();
+  }
+
+  bool got_offsets = check_cur_key("offsets");
+  if (got_offsets) {
+    output.offsets = std::vector<std::int32_t>{};
+    push_handler<ArrayHandler<std::int32_t>, std::vector<std::int32_t>>(output.offsets.value());
+  }
+
+  // Assumption: Either "offsets" or "type" fields have been given before "values" field.
+  // Only with this assumption can we infer the type of the "values" field.
+  bool got_values = check_cur_key("values");
+  if (got_values) {
+    if (output.offsets.has_value()) {
+      // String categories
+      output.values = std::vector<std::int8_t>{};
+      push_handler<ArrayHandler<std::int8_t>, std::vector<std::int8_t>>(
+          std::get<std::vector<std::int8_t>>(output.values));
+    } else if (output.type.has_value()) {
+      // Numerical categories
+      switch (static_cast<ValueKind>(output.type.value())) {
+      case ValueKind::kU8Array:
+      case ValueKind::kU16Array:
+      case ValueKind::kU32Array:
+      case ValueKind::kU64Array: {
+        output.values = std::vector<std::uint64_t>{};
+        push_handler<ArrayHandler<std::uint64_t>, std::vector<std::uint64_t>>(
+            std::get<std::vector<std::uint64_t>>(output.values));
+        break;
+      }
+      case ValueKind::kI8Array:
+      case ValueKind::kI16Array:
+      case ValueKind::kI32Array:
+      case ValueKind::kI64Array: {
+        output.values = std::vector<std::int64_t>{};
+        push_handler<ArrayHandler<std::int64_t>, std::vector<std::int64_t>>(
+            std::get<std::vector<std::int64_t>>(output.values));
+        break;
+      }
+      case ValueKind::kF32Array:
+      case ValueKind::kF64Array: {
+        output.values = std::vector<double>{};
+        push_handler<ArrayHandler<double>, std::vector<double>>(
+            std::get<std::vector<double>>(output.values));
+        break;
+      }
+      default:
+        TREELITE_LOG(ERROR) << "Got invalid type for `values` array";
+        return false;
+      }
+    } else {
+      TREELITE_LOG(ERROR) << "Cannot determine the type of `values` array, since neither"
+                          << "`type` or `offsets` fields are present";
+      return false;
+    }
+  }
+
+  return got_values || got_offsets;
+}
+
+bool CategoryInfoHandler::is_recognized_key(std::string const& key) {
+  return key == "type" || key == "offsets" || key == "values";
 }
 
 /******************************************************************************
@@ -684,6 +801,13 @@ bool LearnerHandler::StartObject() {
 }
 
 bool LearnerHandler::EndObject() {
+  /* Throw an exception if category encoding is required.
+   * TODO(hcho3): Implement categorical encoding */
+  TREELITE_CHECK(output.category_container.enc.empty()
+                 && output.category_container.feature_segments.empty()
+                 && output.category_container.sorted_idx.empty())
+      << "Treelite does not yet support XGBoost models with categorical encoder";
+
   /* Set metadata */
   auto const num_tree = output.num_tree;
   auto const num_feature = learner_params.num_feature;

--- a/src/model_loader/detail/xgboost_json/delegated_handler.h
+++ b/src/model_loader/detail/xgboost_json/delegated_handler.h
@@ -42,7 +42,7 @@ struct ParsedRegTreeParams {
 };
 
 struct ParsedLearnerParams {
-  float base_score{0.0};
+  std::vector<float> base_score;
   std::int32_t num_class{1};
   std::int32_t num_feature{0};
   std::int32_t num_target{1};

--- a/src/model_loader/detail/xgboost_json/delegated_handler.h
+++ b/src/model_loader/detail/xgboost_json/delegated_handler.h
@@ -12,18 +12,60 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <stack>
 #include <string>
 #include <type_traits>
+#include <variant>
 #include <vector>
 
 #include <treelite/model_builder.h>
 
 namespace treelite::model_loader::detail::xgboost {
 
+enum class ValueKind : std::int64_t {
+  kString = 0,
+  kNumber = 1,
+  kInteger = 2,
+  kObject = 3,
+  kArray = 4,
+  kBoolean = 5,
+  kNull = 6,
+  kF32Array = 7,
+  kF64Array = 8,
+  kI8Array = 9,
+  kU8Array = 10,
+  kI16Array = 11,
+  kU16Array = 12,
+  kI32Array = 13,
+  kU32Array = 14,
+  kI64Array = 15,
+  kU64Array = 16,
+};
+
 class HandlerConfig {
  public:
   bool allow_unknown_field{false};
+};
+
+struct ParsedStringCategorical {
+  std::vector<std::int32_t> offsets;
+  std::vector<std::int8_t> values;
+};
+
+using ParsedCategoryValuesArray = std::variant<std::monostate, std::vector<std::int8_t>,
+    std::vector<std::int64_t>, std::vector<std::uint64_t>, std::vector<double>>;
+
+struct ParsedCategoryInfo {
+  std::optional<std::int64_t> type{};
+  std::optional<std::vector<std::int32_t>> offsets{};
+  ParsedCategoryValuesArray values{std::monostate{}};
+};
+
+struct ParsedCategoryContainer {
+  std::vector<ParsedCategoryInfo> enc;
+  std::vector<std::int32_t> feature_segments;
+  std::vector<std::int32_t> sorted_idx;
 };
 
 struct ParsedXGBoostModel {
@@ -34,6 +76,7 @@ struct ParsedXGBoostModel {
   std::string objective_name{};
   std::int32_t size_leaf_vector{0};
   std::vector<float> weight_drop{};
+  ParsedCategoryContainer category_container;
 };
 
 struct ParsedRegTreeParams {
@@ -413,6 +456,35 @@ class GBTreeModelHandler : public OutputHandler<ParsedXGBoostModel> {
 
  private:
   std::vector<ParsedRegTreeParams> reg_tree_params;
+};
+
+/*! \brief Handler for CategoryContainer objects from XGBoost schema */
+class CategoryContainerHandler : public OutputHandler<ParsedCategoryContainer> {
+ public:
+  using OutputHandler::OutputHandler;
+  bool StartArray() override;
+
+ protected:
+  bool is_recognized_key(std::string const& key) override;
+};
+
+/*! \brief Handler for array of objects of CategoryInfo type */
+class CategoryInfoArrayHandler : public OutputHandler<std::vector<ParsedCategoryInfo>> {
+ public:
+  using OutputHandler::OutputHandler;
+  bool StartObject() override;
+};
+
+/*! \brief Handler for CategoryInfo objects */
+class CategoryInfoHandler : public OutputHandler<ParsedCategoryInfo> {
+ public:
+  using OutputHandler::OutputHandler;
+  bool Int64(std::int64_t i) override;
+  bool Uint64(std::uint64_t u) override;
+  bool StartArray() override;
+
+ protected:
+  bool is_recognized_key(std::string const& key) override;
 };
 
 /*! \brief Handler for GradientBoosterHandler objects from XGBoost schema */

--- a/tests/cpp/test_model_loader.cc
+++ b/tests/cpp/test_model_loader.cc
@@ -5,11 +5,14 @@
  * \brief C++ tests for model loader
  */
 
+#include <memory>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 
 #include "model_loader/detail/string_utils.h"
+#include "model_loader/detail/xgboost.h"
 
 TEST(ModelLoader, StringTrim) {
   std::string s{"foobar\r\n"};
@@ -20,4 +23,20 @@ TEST(ModelLoader, StringTrim) {
 TEST(ModelLoader, StringStartsWith) {
   std::string s{"foobar"};
   EXPECT_TRUE(treelite::model_loader::detail::StringStartsWith(s, "foo"));
+}
+
+TEST(ModelLoader, XGBoostBaseScore) {
+  {
+    std::string s{"[5.2008224E-1,4.665861E-1]"};
+    std::vector<float> parsed = treelite::model_loader::detail::xgboost::ParseBaseScore(s);
+    std::vector<float> expected{5.2008224E-1, 4.665861E-1};
+    EXPECT_EQ(parsed, expected);
+  }
+
+  {
+    std::string s{"4.9333417E-1"};
+    std::vector<float> parsed = treelite::model_loader::detail::xgboost::ParseBaseScore(s);
+    std::vector<float> expected{4.9333417E-1};
+    EXPECT_EQ(parsed, expected);
+  }
 }

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -84,6 +84,8 @@ def test_xgb_regressor(
     else:
         X, y = callback.draw(standard_regression_datasets())
         use_categorical = callback.draw(sampled_from([True, False]))
+    # TODO(hcho3): Remove this once Treelite supports categorical encoding
+    use_categorical = False
     if use_categorical:
         n_categorical = callback.draw(integers(min_value=1, max_value=X.shape[1]))
         df, X_pred = to_categorical(X, n_categorical=n_categorical, invalid_frac=0.1)
@@ -148,6 +150,8 @@ def test_xgb_multiclass_classifier(
     # pylint: disable=too-many-locals
     """Test XGBoost with multi-class classification problem"""
     X, y = dataset
+    # TODO(hcho3): Remove this once Treelite supports categorical encoding
+    use_categorical = False
     if use_categorical:
         n_categorical = callback.draw(integers(min_value=1, max_value=X.shape[1]))
         df, X_pred = to_categorical(X, n_categorical=n_categorical, invalid_frac=0.1)
@@ -229,6 +233,8 @@ def test_xgb_nonlinear_objective(
             n_classes=just(num_class), n_informative=just(5)
         )
     )
+    # TODO(hcho3): Remove this once Treelite supports categorical encoding
+    use_categorical = False
     if use_categorical:
         n_categorical = callback.draw(integers(min_value=1, max_value=X.shape[1]))
         df, X_pred = to_categorical(X, n_categorical=n_categorical, invalid_frac=0.1)
@@ -426,6 +432,8 @@ def test_xgb_multi_target_binary_classifier(
 ):
     """Test XGBoost with multi-target binary classification problem"""
     X, y = dataset
+    # TODO(hcho3): Remove this once Treelite supports categorical encoding
+    use_categorical = False
     if use_categorical:
         n_categorical = callback.draw(integers(min_value=1, max_value=X.shape[1]))
         df, X_pred = to_categorical(X, n_categorical=n_categorical, invalid_frac=0.1)
@@ -499,6 +507,8 @@ def test_xgb_multi_target_regressor(
         X, y = callback.draw(standard_regression_datasets(n_targets=just(n_targets)))
         use_categorical = callback.draw(sampled_from([True, False]))
     model_format = callback.draw(sampled_from(["ubjson", "json"]))
+    # TODO(hcho3): Remove this once Treelite supports categorical encoding
+    use_categorical = False
 
     if use_categorical:
         n_categorical = callback.draw(integers(min_value=1, max_value=X.shape[1]))

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -27,7 +27,7 @@ from .hypothesis_util import (
     standard_regression_datasets,
     standard_settings,
 )
-from .util import TemporaryDirectory, to_categorical
+from .util import TemporaryDirectory, has_pandas, to_categorical
 
 
 def generate_data_for_squared_log_error(n_targets: int = 1):
@@ -599,3 +599,22 @@ def test_load_old_xgboost_model():
         / "mushroom.model"
     )
     _ = treelite.frontend.load_xgboost_model_legacy_binary(path)  # should not crash
+
+
+# TODO(hcho3): Remove this unit test once categorical encoding is added
+@pytest.mark.skipif(not has_pandas(), reason="Pandas is not installed")
+def test_categorical_encoding():
+    """Treelite should throw an exception when XGBoost model uses categorical encoding"""
+    import pandas as pd
+
+    df = pd.DataFrame({"c": ["a", "b", "c"], "a": [-1, 1, 2]}, dtype="category")
+    y = np.array([0, 0, 1])
+
+    Xy = xgb.DMatrix(df, y, enable_categorical=True)
+    bst = xgb.train({"max_depth": 1, "base_score": 0}, Xy, num_boost_round=1)
+
+    with pytest.raises(
+        treelite.TreeliteError,
+        match=r".*Treelite does not yet support XGBoost models with categorical encoder.*",
+    ):
+        _ = treelite.frontend.from_xgboost(bst)

--- a/tests/python/test_xgboost_integration.py
+++ b/tests/python/test_xgboost_integration.py
@@ -92,7 +92,7 @@ def test_xgb_regressor(
     else:
         dtrain = xgb.DMatrix(X, label=y)
         X_pred = X.copy()
-        model_format = callback.draw(sampled_from(["json", "ubjson", "legacy_binary"]))
+        model_format = callback.draw(sampled_from(["json", "ubjson"]))
     param = {
         "max_depth": 8,
         "eta": 0.1,
@@ -106,16 +106,11 @@ def test_xgb_regressor(
         num_boost_round=num_boost_round,
     )
     with TemporaryDirectory() as tmpdir:
-        if model_format in ["json", "ubjson"]:
-            model_path = pathlib.Path(tmpdir) / f"model.{model_format}"
-            xgb_model.save_model(model_path)
-            tl_model = treelite.frontend.load_xgboost_model(
-                model_path, format_choice=model_format
-            )
-        else:
-            model_path = pathlib.Path(tmpdir) / "model.deprecated"
-            xgb_model.save_model(model_path)
-            tl_model = treelite.frontend.load_xgboost_model_legacy_binary(model_path)
+        model_path = pathlib.Path(tmpdir) / f"model.{model_format}"
+        xgb_model.save_model(model_path)
+        tl_model = treelite.frontend.load_xgboost_model(
+            model_path, format_choice=model_format
+        )
         assert (
             len(json.loads(tl_model.dump_as_json())["trees"])
             == num_boost_round * num_parallel_tree
@@ -161,7 +156,7 @@ def test_xgb_multiclass_classifier(
     else:
         dtrain = xgb.DMatrix(X, label=y)
         X_pred = X.copy()
-        model_format = callback.draw(sampled_from(["json", "ubjson", "legacy_binary"]))
+        model_format = callback.draw(sampled_from(["json", "ubjson"]))
 
     num_class = np.max(y) + 1
     param = {
@@ -180,16 +175,11 @@ def test_xgb_multiclass_classifier(
     )
 
     with TemporaryDirectory() as tmpdir:
-        if model_format in ["json", "ubjson"]:
-            model_path = pathlib.Path(tmpdir) / f"iris.{model_format}"
-            xgb_model.save_model(model_path)
-            tl_model = treelite.frontend.load_xgboost_model(
-                model_path, format_choice=model_format
-            )
-        else:
-            model_path = pathlib.Path(tmpdir) / "iris.deprecated"
-            xgb_model.save_model(model_path)
-            tl_model = treelite.frontend.load_xgboost_model_legacy_binary(model_path)
+        model_path = pathlib.Path(tmpdir) / f"iris.{model_format}"
+        xgb_model.save_model(model_path)
+        tl_model = treelite.frontend.load_xgboost_model(
+            model_path, format_choice=model_format
+        )
         expected_num_tree = num_class * num_boost_round * num_parallel_tree
         assert len(json.loads(tl_model.dump_as_json())["trees"]) == expected_num_tree
 
@@ -247,7 +237,7 @@ def test_xgb_nonlinear_objective(
     else:
         dtrain = xgb.DMatrix(X, label=y)
         X_pred = X.copy()
-        model_format = callback.draw(sampled_from(["json", "ubjson", "legacy_binary"]))
+        model_format = callback.draw(sampled_from(["json", "ubjson"]))
 
     assert np.min(y) == 0
     assert np.max(y) == num_class - 1
@@ -274,12 +264,9 @@ def test_xgb_nonlinear_objective(
         model_path = pathlib.Path(tmpdir) / model_name
         xgb_model.save_model(model_path)
 
-        if model_format in ["json", "ubjson"]:
-            tl_model = treelite.frontend.load_xgboost_model(
-                model_path, format_choice=model_format
-            )
-        else:
-            tl_model = treelite.frontend.load_xgboost_model_legacy_binary(model_path)
+        tl_model = treelite.frontend.load_xgboost_model(
+            model_path, format_choice=model_format
+        )
 
         out_pred = treelite.gtil.predict(tl_model, X_pred, pred_margin=True)
         expected_pred = xgb_model.predict(
@@ -447,10 +434,7 @@ def test_xgb_multi_target_binary_classifier(
         dtrain = xgb.DMatrix(X, label=y)
         X_pred = X.copy()
 
-    if use_categorical or multi_strategy == "multi_output_tree" or in_memory:
-        model_format = callback.draw(sampled_from(["ubjson", "json"]))
-    else:
-        model_format = callback.draw(sampled_from(["legacy_binary", "ubjson", "json"]))
+    model_format = callback.draw(sampled_from(["ubjson", "json"]))
 
     params = {
         "tree_method": "hist",
@@ -466,18 +450,11 @@ def test_xgb_multi_target_binary_classifier(
         tl_model = treelite.frontend.from_xgboost(bst)
     else:
         with TemporaryDirectory() as tmpdir:
-            if model_format in ["json", "ubjson"]:
-                model_path = pathlib.Path(tmpdir) / f"multi_target.{model_format}"
-                bst.save_model(model_path)
-                tl_model = treelite.frontend.load_xgboost_model(
-                    model_path, format_choice=model_format
-                )
-            else:
-                model_path = pathlib.Path(tmpdir) / "multi_target.deprecated"
-                bst.save_model(model_path)
-                tl_model = treelite.frontend.load_xgboost_model_legacy_binary(
-                    model_path
-                )
+            model_path = pathlib.Path(tmpdir) / f"multi_target.{model_format}"
+            bst.save_model(model_path)
+            tl_model = treelite.frontend.load_xgboost_model(
+                model_path, format_choice=model_format
+            )
 
     out_pred = treelite.gtil.predict(tl_model, X_pred, pred_margin=pred_margin)
     expected_pred = bst.predict(
@@ -521,10 +498,7 @@ def test_xgb_multi_target_regressor(
     else:
         X, y = callback.draw(standard_regression_datasets(n_targets=just(n_targets)))
         use_categorical = callback.draw(sampled_from([True, False]))
-    if multi_strategy == "multi_output_tree" or use_categorical:
-        model_format = callback.draw(sampled_from(["ubjson", "json"]))
-    else:
-        model_format = callback.draw(sampled_from(["legacy_binary", "ubjson", "json"]))
+    model_format = callback.draw(sampled_from(["ubjson", "json"]))
 
     if use_categorical:
         n_categorical = callback.draw(integers(min_value=1, max_value=X.shape[1]))
@@ -549,16 +523,11 @@ def test_xgb_multi_target_regressor(
     )
 
     with TemporaryDirectory() as tmpdir:
-        if model_format in ["json", "ubjson"]:
-            model_path = pathlib.Path(tmpdir) / f"model.{model_format}"
-            xgb_model.save_model(model_path)
-            tl_model = treelite.frontend.load_xgboost_model(
-                model_path, format_choice=model_format
-            )
-        else:
-            model_path = pathlib.Path(tmpdir) / "model.deprecated"
-            xgb_model.save_model(model_path)
-            tl_model = treelite.frontend.load_xgboost_model_legacy_binary(model_path)
+        model_path = pathlib.Path(tmpdir) / f"model.{model_format}"
+        xgb_model.save_model(model_path)
+        tl_model = treelite.frontend.load_xgboost_model(
+            model_path, format_choice=model_format
+        )
         expected_n_trees = num_boost_round * num_parallel_tree
         if multi_strategy == "one_output_per_tree":
             expected_n_trees *= n_targets


### PR DESCRIPTION
Closes #635
Closes #633 

TODOs
- [x] Support vector `base_score` field (multiple outputs)
- [x] Parse `cats` field. Note that we will parse the field but will not store them in the Treelite model. See #639.
- [x] Update XGBoost integration tests to remove the use of legacy binary format, which was removed from XGBoost 3.1.
- [x] Add test coverage, to ensure that exceptions are thrown for XGBoost models with categorical encoding.
