### PR TITLE
[CI] Various CI updates for MacOS

### DIFF
--- a/.github/workflows/macos-wheel-builder.yml
+++ b/.github/workflows/macos-wheel-builder.yml
@@ -57,6 +57,5 @@ jobs:
       run: |
         bash ops/build-macos.sh ${{ matrix.platform_id }} ${{ github.sha }}
     - name: Test wheel
-      if: matrix.platform_id == 'macosx_x86_64'
       run: |
         bash ops/test-macos-python-wheel.sh

--- a/.github/workflows/macos-wheel-builder.yml
+++ b/.github/workflows/macos-wheel-builder.yml
@@ -28,11 +28,15 @@ env:
 jobs:
   macos-wheel-builder:
     name: Build and test Python wheels (MacOS)
-    runs-on: macos-13
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        cibw_platform_id: [macosx_x86_64, macosx_arm64]
+        include:
+        - os: macos-15-intel
+          platform_id: macosx_x86_64
+        - os: macos-14
+          platform_id: macosx_arm64
     env:
       CIBW_PLATFORM_ID: ${{ matrix.cibw_platform_id }}
     steps:
@@ -51,8 +55,8 @@ jobs:
         conda list
     - name: Build wheel
       run: |
-        bash ops/build-macos.sh
+        bash ops/build-macos.sh ${{ matrix.platform_id }} ${{ github.sha }}
     - name: Test wheel
-      if: matrix.cibw_platform_id == 'macosx_x86_64'
+      if: matrix.platform_id == 'macosx_x86_64'
       run: |
         bash ops/test-macos-python-wheel.sh

--- a/ops/build-macos.sh
+++ b/ops/build-macos.sh
@@ -2,8 +2,16 @@
 
 set -euo pipefail
 
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 [platform_id] [commit ID]"
+  exit 1
+fi
+
+platform_id=$1
+commit_id=$2
+
 echo "##[section]Building MacOS Python wheels..."
-tests/ci_build/build_macos_python_wheels.sh ${CIBW_PLATFORM_ID} ${COMMIT_ID}
+tests/ci_build/build_macos_python_wheels.sh ${platform_id} ${commit_id}
 
 echo "##[section]Uploading MacOS Python wheels to S3..."
 python -m awscli s3 cp wheelhouse/treelite-*.whl s3://treelite-wheels/ --acl public-read --region us-west-2 || true

--- a/ops/conda_env/dev.yml
+++ b/ops/conda_env/dev.yml
@@ -2,7 +2,7 @@ name: dev
 channels:
 - conda-forge
 dependencies:
-- python=3.10
+- python=3.11
 - numpy
 - scipy
 - pandas

--- a/ops/conda_env/pre-commit.yml
+++ b/ops/conda_env/pre-commit.yml
@@ -2,5 +2,5 @@ name: precommit
 channels:
 - conda-forge
 dependencies:
-- python=3.10
+- python=3.11
 - pre-commit

--- a/python/packager/nativelib.py
+++ b/python/packager/nativelib.py
@@ -49,14 +49,6 @@ def build_libtreelite(
         ]
         cmake_cmd.extend(build_config.get_cmake_args())
 
-        # Flag for cross-compiling for Apple Silicon
-        # We use environment variable because it's the only way to pass down custom flags
-        # through the cibuildwheel package, which calls `pip wheel` command.
-        if "CIBW_TARGET_OSX_ARM64" in os.environ:
-            cmake_cmd.extend(
-                ["-DCMAKE_OSX_ARCHITECTURES=arm64", "-DDETECT_CONDA_ENV=OFF"]
-            )
-
         logger.info("CMake args: %s", str(cmake_cmd))
         subprocess.check_call(cmake_cmd, cwd=build_dir)
 

--- a/tests/ci_build/build_macos_python_wheels.sh
+++ b/tests/ci_build/build_macos_python_wheels.sh
@@ -13,58 +13,35 @@ shift
 commit_id=$1
 shift
 
-# Bundle libomp 11.1.0 when targeting MacOS.
-# This is a workaround in order to prevent segfaults when running inside a Conda environment.
-# See https://github.com/dmlc/xgboost/issues/7039#issuecomment-1025125003 for more context.
-# The workaround is also used by the scikit-learn and XGBoost projects.
 if [[ "$platform_id" == macosx_* ]]; then
-    # Make sure to use a libomp version binary compatible with the oldest
-    # supported version of the macos SDK as libomp will be vendored into the
-    # Treelite wheels for MacOS.
-
     if [[ "$platform_id" == macosx_arm64 ]]; then
         # MacOS, Apple Silicon
-        # arm64 builds must cross compile because CI is on x64
-        # cibuildwheel will take care of cross-compilation.
         wheel_tag=macosx_12_0_arm64
-        cpython_ver=38
-        setup_env_var='CIBW_TARGET_OSX_ARM64=1'  # extra flag to be passed to treelite.packager backend
-        export PYTHON_CROSSENV=1
+        cpython_ver=310
+        cibw_archs=arm64
         export MACOSX_DEPLOYMENT_TARGET=12.0
-        OPENMP_URL="https://anaconda.org/conda-forge/llvm-openmp/11.1.0/download/osx-arm64/llvm-openmp-11.1.0-hf3c4609_1.tar.bz2"
     elif [[ "$platform_id" == macosx_x86_64 ]]; then
         # MacOS, Intel
         wheel_tag=macosx_10_15_x86_64.macosx_11_0_x86_64.macosx_12_0_x86_64
-        cpython_ver=38
+        cpython_ver=310
+        cibw_archs=x86_64
         export MACOSX_DEPLOYMENT_TARGET=10.15
-        OPENMP_URL="https://anaconda.org/conda-forge/llvm-openmp/11.1.0/download/osx-64/llvm-openmp-11.1.0-hda6cdc1_1.tar.bz2"
     else
         echo "Platform not supported: $platform_id"
         exit 3
     fi
     # Set up environment variables to configure cibuildwheel
     export CIBW_BUILD=cp${cpython_ver}-${platform_id}
-    export CIBW_ARCHS=all
-    export CIBW_ENVIRONMENT=${setup_env_var}
+    export CIBW_ARCHS=${cibw_archs}
     export CIBW_TEST_SKIP='*-macosx_arm64'
     export CIBW_BUILD_VERBOSITY=3
-
-    mamba create -n build $OPENMP_URL
-    conda info -e
-    PREFIX="/Users/runner/miniconda3/envs/build"
-
-    # Set up build flags for cibuildwheel
-    # This is needed to bundle libomp lib we downloaded earlier
-    export CC=/usr/bin/clang
-    export CXX=/usr/bin/clang++
-    export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"
-    export CFLAGS="$CFLAGS -I$PREFIX/include"
-    export CXXFLAGS="$CXXFLAGS -I$PREFIX/include"
-    export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib -L$PREFIX/lib -lomp"
 else
     echo "Platform not supported: $platform_id"
     exit 2
 fi
+
+# Tell delocate-wheel to not vendor libomp.dylib into the wheel
+export CIBW_REPAIR_WHEEL_COMMAND_MACOS="delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} --exclude libomp.dylib"
 
 python -m cibuildwheel python --output-dir wheelhouse
 python tests/ci_build/rename_whl.py wheelhouse ${commit_id} ${wheel_tag}


### PR DESCRIPTION
* Use `macos-15-intel` instead of the (deprecated) `macos-13`
* Use native arm64 MacOS worker to build Apple Silicon; remove cross builds
* Stop bundling `libomp.dylib` in the wheel . See https://github.com/dmlc/xgboost/pull/10440 for the rationale.