### PR TITLE
Fix undefined behavior in base_score

### DIFF
--- a/src/model_loader/detail/xgboost.cc
+++ b/src/model_loader/detail/xgboost.cc
@@ -73,7 +73,7 @@ std::vector<float> ParseBaseScore(std::string const& str) {
     }
   } else {
     // Scalar base_score (from XGBoost <3.1)
-    parsed_base_score = {std::stof(str)};
+    parsed_base_score = std::vector<float>{std::stof(str)};
   }
   return parsed_base_score;
 }


### PR DESCRIPTION
Latest GCC emits the following warning about undefined behavior:
```
[1/3] Building CXX object src/CMakeFiles/objtreelite.dir/model_loader/detail/xgboost.cc.o
In file included from /usr/include/c++/13/bits/specfun.h:43,
                 from /usr/include/c++/13/cmath:3699,
                 from /home/phcho/Desktop/treelite/src/model_loader/detail/./xgboost.h:10,
                 from /home/phcho/Desktop/treelite/src/model_loader/detail/xgboost.cc:7:
In static member function ‘static _Up* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(_Tp*, _Tp*, _Up*) [with _Tp = const float; _Up = float; bool _IsMove = false]’,
    inlined from ‘_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = false; _II = const float*; _OI = float*]’ at /usr/include/c++/13/bits/stl_algobase.h:506:30,
    inlined from ‘_OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = const float*; _OI = float*]’ at /usr/include/c++/13/bits/stl_algobase.h:533:42,
    inlined from ‘_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = const float*; _OI = float*]’ at /usr/include/c++/13/bits/stl_algobase.h:540:31,
    inlined from ‘_OI std::copy(_II, _II, _OI) [with _II = const float*; _OI = float*]’ at /usr/include/c++/13/bits/stl_algobase.h:633:7,
    inlined from ‘void std::vector<_Tp, _Alloc>::_M_assign_aux(_ForwardIterator, _ForwardIterator, std::forward_iterator_tag) [with _ForwardIterator = const float*; _Tp = float; _Alloc = std::allocator<float>]’ at /usr/include/c++/13/bits/vector.tcc:341:15,
    inlined from ‘std::vector<_Tp, _Alloc>& std::vector<_Tp, _Alloc>::operator=(std::initializer_list<_Tp>) [with _Tp = float; _Alloc = std::allocator<float>]’ at /usr/include/c++/13/bits/stl_vector.h:790:21,
    inlined from ‘std::vector<float> treelite::model_loader::detail::xgboost::ParseBaseScore(const std::string&)’ at /home/phcho/Desktop/treelite/src/model_loader/detail/xgboost.cc:76:40:
/usr/include/c++/13/bits/stl_algobase.h:437:30: warning: ‘void* __builtin_memmove(void*, const void*, long unsigned int)’ reading between 5 and 9223372036854775807 bytes from a region of size 4 [-Wstringop-overread]
  437 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
      |             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/phcho/Desktop/treelite/src/model_loader/detail/xgboost.cc: In function ‘std::vector<float> treelite::model_loader::detail::xgboost::ParseBaseScore(const std::string&)’:
/home/phcho/Desktop/treelite/src/model_loader/detail/xgboost.cc:76:40: note: source object ‘<anonymous>’ of size 4
   76 |     parsed_base_score = {std::stof(str)};
      |                                        ^
[3/3] Linking CXX executable treelite_cpp_test
```

Apparently, `parsed_base_score = {std::stof(str)};` doesn't do what I thought it did.