### PR TITLE
[4.7.2] Restore support for Python 3.8

### DIFF
--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Build and test wheel
-        uses: pypa/cibuildwheel@v4.1.0
+        uses: pypa/cibuildwheel@v3.4.1
         with:
           package-dir: python
           output-dir: wheelhouse

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Treelite: Universal model exchange format for decision tree forests"
 readme = {file = "README.rst", content-type = "text/x-rst"}
-requires-python = ">=3.11"
+requires-python = ">=3.8"
 license = {text = "Apache-2.0"}
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
@@ -18,6 +18,9 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -56,7 +59,7 @@ version = "CMakeLists.txt"
 build-type = "Release"
 
 [tool.cibuildwheel]
-build = ["cp312-*"]
+build = ["cp38-*"]
 archs = ["auto64"] # so win32 is excluded
 skip = ["*musllinux*"]
 build-verbosity = 3


### PR DESCRIPTION
A patch release should not change the Python version requirement.