### PR TITLE
statically link GTest, update to 1.18.0, fetch it with CPM

### DIFF
--- a/cmake/CPMFindGTest.cmake
+++ b/cmake/CPMFindGTest.cmake
@@ -1,0 +1,65 @@
+# Description:
+#
+#   Find / build GTest. Prefers a system install if one is found,
+#   otherwise downloads sources with CPM (https://github.com/cpm-cmake/CPM.cmake)
+#   and builds GTest.
+#
+# Targets:
+#
+#   GTest::gtest
+#   Gtest::mock
+#
+# Usage:
+#
+#   include(CPMFindGTest.cmake)
+#
+
+function(_treelite_find_gtest gtest_version)
+
+  # Prefer a system-installed GTest if one is found
+  find_package(GTest ${gtest_version})
+  if(GTEST_FOUND)
+    return()
+  endif()
+
+  # not found, use CPM to download sources and build it
+  message(STATUS "GTest not found, fetching GTest via CPM.")
+
+  # For MSVC, ensure GTest uses the same C runtime (/MD vs. /MT) as Treelite.
+  #
+  # As of v1.14.0, googletest did literal string replacements on CMAKE_CXX_FLAGS,
+  # and doesn't respect CMAKE_MSVC_RUNTIME_LIBRARY.
+  #
+  # TODO(jameslamb): remove this once this project uses at least GTest v1.18.0
+  # That version has this fix: https://github.com/google/googletest/pull/4877
+  #
+  set(gtest_force_shared_crt ${FORCE_SHARED_CRT} CACHE BOOL "" FORCE)
+
+  # populate local CPM cache with googletest source (if not already populated), build targets
+  include(${treelite_SOURCE_DIR}/cmake/CPMSetup.cmake)
+
+  # prefer statically linking GTest, so test executables are relocatable
+  CPMAddPackage(
+    NAME googletest
+    GITHUB_REPOSITORY google/googletest
+    GIT_TAG v${gtest_version}
+    VERSION ${gtest_version}
+    EXCLUDE_FROM_ALL YES
+    OPTIONS
+      "BUILD_GMOCK ON"
+      "BUILD_SHARED_LIBS OFF"
+      "CMAKE_POSITION_INDEPENDENT_CODE ON"
+      "INSTALL_GTEST OFF"
+  )
+
+  if(MSVC)
+    foreach(target gtest gmock)
+      # For MSVC, ensure GTest targets propagate the same MSVC C Runtime
+      # to anything linking against them.
+      set_target_properties(${target} PROPERTIES
+          MSVC_RUNTIME_LIBRARY "${CMAKE_MSVC_RUNTIME_LIBRARY}")
+    endforeach()
+  endif()
+endfunction()
+
+_treelite_find_gtest(1.14.0)

--- a/cmake/CPMFindGTest.cmake
+++ b/cmake/CPMFindGTest.cmake
@@ -25,16 +25,6 @@ function(_treelite_find_gtest gtest_version)
   # not found, use CPM to download sources and build it
   message(STATUS "GTest not found, fetching GTest via CPM.")
 
-  # For MSVC, ensure GTest uses the same C runtime (/MD vs. /MT) as Treelite.
-  #
-  # As of v1.14.0, googletest did literal string replacements on CMAKE_CXX_FLAGS,
-  # and doesn't respect CMAKE_MSVC_RUNTIME_LIBRARY.
-  #
-  # TODO(jameslamb): remove this once this project uses at least GTest v1.18.0
-  # That version has this fix: https://github.com/google/googletest/pull/4877
-  #
-  set(gtest_force_shared_crt ${FORCE_SHARED_CRT} CACHE BOOL "" FORCE)
-
   # populate local CPM cache with googletest source (if not already populated), build targets
   include(${treelite_SOURCE_DIR}/cmake/CPMSetup.cmake)
 
@@ -51,15 +41,6 @@ function(_treelite_find_gtest gtest_version)
       "CMAKE_POSITION_INDEPENDENT_CODE ON"
       "INSTALL_GTEST OFF"
   )
-
-  if(MSVC)
-    foreach(target gtest gmock)
-      # For MSVC, ensure GTest targets propagate the same MSVC C Runtime
-      # to anything linking against them.
-      set_target_properties(${target} PROPERTIES
-          MSVC_RUNTIME_LIBRARY "${CMAKE_MSVC_RUNTIME_LIBRARY}")
-    endforeach()
-  endif()
 endfunction()
 
-_treelite_find_gtest(1.14.0)
+_treelite_find_gtest(1.18.0)

--- a/cmake/CPMSetup.cmake
+++ b/cmake/CPMSetup.cmake
@@ -1,0 +1,33 @@
+# Ensure CPM ("CMake Package Manager") is available.
+#
+# ref: https://github.com/cpm-cmake/cpm.cmake
+
+function(_setup_cpm cpm_version)
+  # look for already-downloaded CPM source in this order:
+  #
+  #   1. already-defined CMake variable 'CPM_SOURCE_CACHE'
+  #   2. environment variable 'CPM_SOURCE_CACHE'
+  #   3. path relative to the top-level build directory
+  #
+  if(CPM_SOURCE_CACHE)
+    set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${cpm_version}.cmake")
+  elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+    set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${cpm_version}.cmake")
+  else()
+    set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${cpm_version}.cmake")
+  endif()
+
+  # download source if necessary
+  if(NOT EXISTS ${CPM_DOWNLOAD_LOCATION})
+    message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
+    file(DOWNLOAD
+      https://github.com/cpm-cmake/CPM.cmake/releases/download/v${cpm_version}/CPM.cmake
+      ${CPM_DOWNLOAD_LOCATION}
+    )
+  endif()
+
+  set(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} PARENT_SCOPE)
+endfunction()
+
+_setup_cpm(0.43.1)
+include(${CPM_DOWNLOAD_LOCATION})

--- a/cmake/ExternalLibs.cmake
+++ b/cmake/ExternalLibs.cmake
@@ -63,32 +63,8 @@ endif()
 
 # Google C++ tests
 if(BUILD_CPP_TEST)
-  find_package(GTest 1.14.0)
-  if(NOT GTest_FOUND)
-    message(STATUS "Did not find Google Test in the system root. Fetching Google Test now...")
-    FetchContent_Declare(
-      googletest
-      URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
-    )
-    set(gtest_force_shared_crt ${DMLC_FORCE_SHARED_CRT} CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(googletest)
-
-    add_library(GTest::gtest ALIAS gtest)
-    add_library(GTest::gmock ALIAS gmock)
-    target_compile_definitions(gtest PRIVATE ${ENABLE_GNU_EXTENSION_FLAGS})
-    target_compile_definitions(gmock PRIVATE ${ENABLE_GNU_EXTENSION_FLAGS})
-    foreach(target gtest gmock)
-      target_compile_features(${target} PUBLIC cxx_std_14)
-      if(MSVC)
-        set_target_properties(${target} PROPERTIES
-          MSVC_RUNTIME_LIBRARY "${Treelite_MSVC_RUNTIME_LIBRARY}")
-      endif()
-    endforeach()
-    if(IS_DIRECTORY "${googletest_SOURCE_DIR}")
-      # Do not install gtest
-      set_property(DIRECTORY ${googletest_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL YES)
-    endif()
-  endif()
+  # find/build GTest
+  include(${treelite_SOURCE_DIR}/cmake/CPMFindGTest.cmake)
 endif()
 
 # fmtlib


### PR DESCRIPTION
Closes #704 

Proposes:

* statically linking GoogleTest
* getting GoogleTest via CPM for simplicity and cache-friendliness (mostly borrowing the approach I added to XGBoost in https://github.com/dmlc/xgboost/pull/12494)

## Notes for Reviewers

### How I tested this

Using the reproducible example from #704.

```console
# build tests
$ rm -rf ./build
$ cmake -B build -S . -DBUILD_SHARED_LIBS=ON -DBUILD_CPP_TEST=ON
$ cmake --build build -j8

# relocate the test executable
$ TMP_DIR=$(mktemp -d)
$ mv ./build/treelite_cpp_test "${TMP_DIR}/"
$ rm -rf ./build
$ pushd "${TMP_DIR}"

# try testing
$ ./treelite_cpp_test
...
[==========] 29 tests from 9 test suites ran. (11 ms total)
[  PASSED  ] 29 tests.

$ ldd ./treelite_cpp_test
        linux-vdso.so.1 (0x0000766f56a2e000)
        libgomp.so.1 => /lib/x86_64-linux-gnu/libgomp.so.1 (0x0000766f569bd000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x0000766f56200000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x0000766f568d4000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x0000766f568a6000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0000766f55e00000)
        /lib64/ld-linux-x86-64.so.2 (0x0000766f56a30000)
```